### PR TITLE
Pin System.Text.Json to 8.0.5

### DIFF
--- a/SAM/SAM.Core/SAM.Core.csproj
+++ b/SAM/SAM.Core/SAM.Core.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Pin `System.Text.Json` to 8.0.5 in `SAM.Core.csproj` (the only project in this repo referencing it), replacing 10.0.8.
- Part of a workspace-wide alignment across SAM-BIM repos to the LTS-aligned 8.x line (10.x is .NET-10 preview track and inappropriate for libraries still targeting netstandard2.0 / net8.0-windows).
- Cherry-picked from `feature/sam-performance-improvements` so the STJ pin lands on `sow/2026-Q2` independently of the in-progress performance work.

## Test plan
- [x] CI restore + build green on this branch
- [x] No NU1605 (package downgrade) errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)