### PR TITLE
fix: pin AssemblyVersion/FileVersion to 1.0.0.0

### DIFF
--- a/Grasshopper/SAM.Analytical.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Properties/AssemblyInfo.cs
@@ -56,5 +56,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Architectural.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Architectural.Grasshopper/Properties/AssemblyInfo.cs
@@ -56,5 +56,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Core.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Properties/AssemblyInfo.cs
@@ -56,5 +56,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Geometry.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Properties/AssemblyInfo.cs
@@ -56,5 +56,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Math.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Math.Grasshopper/Properties/AssemblyInfo.cs
@@ -56,5 +56,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Weather.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Weather.Grasshopper/Properties/AssemblyInfo.cs
@@ -56,5 +56,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyFileVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SAM/SAM.Core/SAM.Core.csproj
+++ b/SAM/SAM.Core/SAM.Core.csproj
@@ -11,8 +11,8 @@
     <AssemblyTitle>SAM</AssemblyTitle>
     <Product>SAM</Product>
     <Copyright>Copyright ©  2020</Copyright>
-    <AssemblyVersion>1.0.%2a</AssemblyVersion>
-    <FileVersion>1.0.%2a</FileVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\build\</OutputPath>

--- a/SAM/SAM.Units/SAM.Units.csproj
+++ b/SAM/SAM.Units/SAM.Units.csproj
@@ -7,8 +7,8 @@
     <AssemblyTitle>SAM</AssemblyTitle>
     <Product>SAM</Product>
     <Copyright>Copyright ©  2020</Copyright>
-    <AssemblyVersion>1.0.%2a</AssemblyVersion>
-    <FileVersion>1.0.%2a</FileVersion>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Pins `AssemblyVersion` and `FileVersion` to `1.0.0.0`, replacing the legacy `1.0.*` wildcard (URL-encoded as `1.0.%2a` in `.csproj`).

## Why

- Eliminates CS1607 warnings emitted on every build.
- Restores deterministic builds; wildcard versions are timestamp-derived and break reproducibility and SourceLink.
- Aligns with the 51 files already using the `1.0.0.0` literal across the SAM-BIM workspace.
- No CI version-injection exists, so a fixed literal is the correct end state.

## Scope

- `AssemblyInfo.cs` and `.csproj` version attributes only.
- The `// [assembly: AssemblyVersion(\"1.0.*\")]` template-comment lines in some `AssemblyInfo.cs` files are intentionally left untouched (they document the wildcard syntax).
- `<Deterministic>false</Deterministic>` cleanup and `<GenerateAssemblyInfo>` migration are out of scope (separate follow-up PRs).

## Test plan

- [x] No active wildcards remain — verified via `git grep -nE '^\s*(\[assembly:|<(Assembly|File)Version>).*(1\.0\.\*|1\.0\.%2a)'` returning zero matches
- [x] Diff limited to `AssemblyInfo.cs` + `.csproj` (8 files, 16 ins / 16 del)
- [x] UTF-8 BOM and CRLF line endings preserved (binary-safe replace)
- [x] CI build passes
- [ ] Merge first across SAM-BIM (downstream CI dep-clones SAM by branch)

No behavioural change.