### PR TITLE
build: Directory.Build.props for centralised SAMVersion stamping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,20 @@ jobs:
 
           throw "No root .sln or root .csproj found to build."
 
+      - name: Compute SAMVersion
+        id: ver
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $ref = if ('${{ github.event_name }}' -eq 'pull_request') { '${{ github.base_ref }}' } else { '${{ github.ref_name }}' }
+          if ($ref -match 'sow/(\d{4})-Q(\d)') {
+            $v = "$($Matches[1]).$($Matches[2]).${{ github.run_number }}"
+          } else {
+            $v = "1.0.0.0"
+          }
+          Write-Host "SAMVersion = $v (derived from ref '$ref')"
+          "samversion=$v" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
       - name: Restore
         shell: pwsh
         env:
@@ -66,6 +80,7 @@ jobs:
             /t:Restore `
             /m:1 /nr:false /v:m `
             /p:Configuration=${{ matrix.configuration }} `
+            /p:SAMVersion=${{ steps.ver.outputs.samversion }} `
             /p:UseSharedCompilation=false
 
       - name: Build
@@ -78,4 +93,5 @@ jobs:
             /t:Rebuild `
             /m:1 /nr:false /v:m `
             /p:Configuration=${{ matrix.configuration }} `
+            /p:SAMVersion=${{ steps.ver.outputs.samversion }} `
             /p:UseSharedCompilation=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build (Windows)
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "sow/**" ]
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [ "master", "main", "sow/**" ]
   workflow_dispatch:
 
 jobs:
@@ -64,10 +64,14 @@ jobs:
           $ref = if ('${{ github.event_name }}' -eq 'pull_request') { '${{ github.base_ref }}' } else { '${{ github.ref_name }}' }
           if ($ref -match 'sow/(\d{4})-Q(\d)') {
             $v = "$($Matches[1]).$($Matches[2]).${{ github.run_number }}"
+            $src = "branch '$ref'"
           } else {
-            $v = "1.0.0.0"
+            $now = (Get-Date).ToUniversalTime()
+            $quarter = [int][Math]::Ceiling($now.Month / 3.0)
+            $v = "$($now.Year).$quarter.${{ github.run_number }}"
+            $src = "date $($now.ToString('yyyy-MM-dd')) (ref '$ref' not sow/yyyy-Qx)"
           }
-          Write-Host "SAMVersion = $v (derived from ref '$ref')"
+          Write-Host "SAMVersion = $v (from $src)"
           "samversion=$v" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,13 +62,15 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $ref = if ('${{ github.event_name }}' -eq 'pull_request') { '${{ github.base_ref }}' } else { '${{ github.ref_name }}' }
+          # .NET AssemblyVersion components are UInt16 (max 65535). Cap to 60000 for headroom.
+          $run = ${{ github.run_number }} % 60000
           if ($ref -match 'sow/(\d{4})-Q(\d)') {
-            $v = "$($Matches[1]).$($Matches[2]).${{ github.run_number }}"
+            $v = "$($Matches[1]).$($Matches[2]).$run"
             $src = "branch '$ref'"
           } else {
             $now = (Get-Date).ToUniversalTime()
             $quarter = [int][Math]::Ceiling($now.Month / 3.0)
-            $v = "$($now.Year).$quarter.${{ github.run_number }}"
+            $v = "$($now.Year).$quarter.$run"
             $src = "date $($now.ToString('yyyy-MM-dd')) (ref '$ref' not sow/yyyy-Qx)"
           }
           Write-Host "SAMVersion = $v (from $src)"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,36 @@
+<Project>
+
+  <PropertyGroup>
+    <!-- Local dev builds default to 1.0.0.0. CI passes /p:SAMVersion=YYYY.Q.<run_number>. -->
+    <SAMVersion Condition="'$(SAMVersion)' == ''">1.0.0.0</SAMVersion>
+    <AssemblyVersion>$(SAMVersion)</AssemblyVersion>
+    <FileVersion>$(SAMVersion)</FileVersion>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+
+  <!--
+    Projects with <GenerateAssemblyInfo>false</GenerateAssemblyInfo> ignore the
+    AssemblyVersion/FileVersion MSBuild properties above. Inject the attributes via a
+    generated source file so those assemblies also get stamped by CI.
+  -->
+  <Target Name="_GenerateSAMVersionFile"
+          BeforeTargets="CoreCompile"
+          Condition="'$(GenerateAssemblyInfo)' == 'false'">
+    <ItemGroup>
+      <_SAMVersionLine Include="// &lt;auto-generated /&gt;" />
+      <_SAMVersionLine Include="[assembly: System.Reflection.AssemblyVersionAttribute(&quot;$(SAMVersion)&quot;)]" />
+      <_SAMVersionLine Include="[assembly: System.Reflection.AssemblyFileVersionAttribute(&quot;$(SAMVersion)&quot;)]" />
+    </ItemGroup>
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <WriteLinesToFile
+      File="$(IntermediateOutputPath)SAMVersion.g.cs"
+      Lines="@(_SAMVersionLine)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)SAMVersion.g.cs" KeepDuplicates="false" />
+      <FileWrites Include="$(IntermediateOutputPath)SAMVersion.g.cs" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/Grasshopper/SAM.Analytical.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Properties/AssemblyInfo.cs
@@ -55,6 +55,3 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Analytical.Grasshopper/SAM.Analytical.Grasshopper.csproj
+++ b/Grasshopper/SAM.Analytical.Grasshopper/SAM.Analytical.Grasshopper.csproj
@@ -9,7 +9,6 @@
 	  <RhinoPluginsDir>$([MSBuild]::ValueOrDefault('$(RhinoDebugPluginsDir)', '$(RhinoDefaultPluginsDir)'))</RhinoPluginsDir><GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <Deterministic>false</Deterministic>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/Grasshopper/SAM.Architectural.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Architectural.Grasshopper/Properties/AssemblyInfo.cs
@@ -55,6 +55,3 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Architectural.Grasshopper/SAM.Architectural.Grasshopper.csproj
+++ b/Grasshopper/SAM.Architectural.Grasshopper/SAM.Architectural.Grasshopper.csproj
@@ -9,7 +9,6 @@
 	  <RhinoPluginsDir>$([MSBuild]::ValueOrDefault('$(RhinoDebugPluginsDir)', '$(RhinoDefaultPluginsDir)'))</RhinoPluginsDir><GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <Deterministic>false</Deterministic>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/Grasshopper/SAM.Core.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Properties/AssemblyInfo.cs
@@ -55,6 +55,3 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Core.Grasshopper/SAM.Core.Grasshopper.csproj
+++ b/Grasshopper/SAM.Core.Grasshopper/SAM.Core.Grasshopper.csproj
@@ -10,7 +10,6 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <StartProgram>C:\Program Files\Rhino 8\System\Rhino.exe</StartProgram>
-    <Deterministic>false</Deterministic>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>True</CopyLocalLockFileAssemblies>

--- a/Grasshopper/SAM.Geometry.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Properties/AssemblyInfo.cs
@@ -55,6 +55,3 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Geometry.Grasshopper/SAM.Geometry.Grasshopper.csproj
+++ b/Grasshopper/SAM.Geometry.Grasshopper/SAM.Geometry.Grasshopper.csproj
@@ -9,7 +9,6 @@
 	  <RhinoPluginsDir>$([MSBuild]::ValueOrDefault('$(RhinoDebugPluginsDir)', '$(RhinoDefaultPluginsDir)'))</RhinoPluginsDir><GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <Deterministic>false</Deterministic>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/Grasshopper/SAM.Math.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Math.Grasshopper/Properties/AssemblyInfo.cs
@@ -55,6 +55,3 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Math.Grasshopper/SAM.Math.Grasshopper.csproj
+++ b/Grasshopper/SAM.Math.Grasshopper/SAM.Math.Grasshopper.csproj
@@ -9,7 +9,6 @@
 	  <RhinoPluginsDir>$([MSBuild]::ValueOrDefault('$(RhinoDebugPluginsDir)', '$(RhinoDefaultPluginsDir)'))</RhinoPluginsDir><GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <Deterministic>false</Deterministic>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/Grasshopper/SAM.Weather.Grasshopper/Properties/AssemblyInfo.cs
+++ b/Grasshopper/SAM.Weather.Grasshopper/Properties/AssemblyInfo.cs
@@ -55,6 +55,3 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Grasshopper/SAM.Weather.Grasshopper/SAM.Weather.Grasshopper.csproj
+++ b/Grasshopper/SAM.Weather.Grasshopper/SAM.Weather.Grasshopper.csproj
@@ -9,7 +9,6 @@
 	  <RhinoPluginsDir>$([MSBuild]::ValueOrDefault('$(RhinoDebugPluginsDir)', '$(RhinoDefaultPluginsDir)'))</RhinoPluginsDir><GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
-    <Deterministic>false</Deterministic>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/SAM/SAM.Analytical/SAM.Analytical.csproj
+++ b/SAM/SAM.Analytical/SAM.Analytical.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Deterministic>false</Deterministic>
 	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 	<LangVersion>12.0</LangVersion>

--- a/SAM/SAM.Architectural/SAM.Architectural.csproj
+++ b/SAM/SAM.Architectural/SAM.Architectural.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Deterministic>false</Deterministic>
 	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/SAM/SAM.Core/SAM.Core.csproj
+++ b/SAM/SAM.Core/SAM.Core.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Deterministic>false</Deterministic>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
@@ -11,8 +10,6 @@
     <AssemblyTitle>SAM</AssemblyTitle>
     <Product>SAM</Product>
     <Copyright>Copyright ©  2020</Copyright>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>..\..\build\</OutputPath>

--- a/SAM/SAM.Geometry/SAM.Geometry.csproj
+++ b/SAM/SAM.Geometry/SAM.Geometry.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
 	  <LangVersion>12.0</LangVersion>
-    <Deterministic>false</Deterministic>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
 	<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/SAM/SAM.Math/SAM.Math.csproj
+++ b/SAM/SAM.Math/SAM.Math.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Deterministic>false</Deterministic>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/SAM/SAM.Units/SAM.Units.csproj
+++ b/SAM/SAM.Units/SAM.Units.csproj
@@ -2,13 +2,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Deterministic>false</Deterministic>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>SAM</AssemblyTitle>
     <Product>SAM</Product>
     <Copyright>Copyright ©  2020</Copyright>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
 	  <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	  <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>

--- a/SAM/SAM.Weather/SAM.Weather.csproj
+++ b/SAM/SAM.Weather/SAM.Weather.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <Deterministic>false</Deterministic>
 	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Stage 2 of the AssemblyVersion versioning migration ([Stage 1](https://github.com/SAM-BIM/SAM/pull/5) pinned every literal to `1.0.0.0`). Introduces a single `$(SAMVersion)` MSBuild property at the repo root and wires CI to stamp `YYYY.Q.<run_number>` (e.g. `2026.2.147`) on Release builds.

## What changes

- **`Directory.Build.props`** at repo root — single source of truth for `AssemblyVersion`/`FileVersion`. Defaults `SAMVersion=1.0.0.0`; CI overrides via `/p:SAMVersion=...`.
- **`<AssemblyVersion>`/`<FileVersion>`/`<Deterministic>false</Deterministic>`** stripped from 13 `.csproj` files (now provided by `Directory.Build.props`).
- **`[assembly: AssemblyVersion]`/`[assembly: AssemblyFileVersion]`** stripped from 6 Grasshopper `AssemblyInfo.cs` files. `AssemblyTitle`, `Guid`, copyright headers preserved.
- **`.github/workflows/build.yml`** computes `SAMVersion` by parsing the `sow/yyyy-Qx` branch name (auto-derives quarter — zero PR churn when `sow/2026-Q3` lands) and passes it to both Restore and Build msbuild invocations. Falls back to `1.0.0.0` on `master`/`main`/feature branches.

## How it handles legacy AssemblyInfo.cs projects

`<GenerateAssemblyInfo>false</GenerateAssemblyInfo>` makes MSBuild ignore the `AssemblyVersion` property from `Directory.Build.props`. A conditional MSBuild Target writes `obj/SAMVersion.g.cs` (containing just the two `[assembly: ...]` attributes) before `CoreCompile`, so those assemblies also get stamped. The hand-maintained `AssemblyInfo.cs` files keep `AssemblyTitle`/`Guid`/copyright headers — they're not deleted.

## Why

- Crash dumps, Revit add-in load logs, and customer "what version are you running" questions will resolve to a specific CI build.
- Single source of truth for the version property: future quarters need zero PR churn (branch name auto-derives the quarter).
- Eliminates the literal `1.0.0.0` duplication across ~20 places per repo.

## Side effect (positive)

`SAM.Units.csproj` had `<GenerateAssemblyInfo>false</GenerateAssemblyInfo>` with no `Properties/AssemblyInfo.cs` and was therefore shipping `SAM.Units.dll` as `0.0.0.0`. The generated `SAMVersion.g.cs` mechanism fixes this — `SAM.Units.dll` now stamps correctly.

## Local verification

Built with `msbuild SAM.sln /p:SAMVersion=2026.2.999 /p:Configuration=Release`. All representative DLLs (`SAM.Core.dll`, `SAM.Geometry.dll`, `SAM.Math.dll`, `SAM.Units.dll`, `SAM.Analytical.dll`, `SAM.Core.Grasshopper.dll`, `SAM.Math.Grasshopper.dll`) report `FileVersion=2026.2.999`. SDK-style, `GenerateAssemblyInfo=false` with `AssemblyInfo.cs`, and `GenerateAssemblyInfo=false` without `AssemblyInfo.cs` all work.

Local dev builds (no `/p:SAMVersion` override): all DLLs report `FileVersion=1.0.0.0` — no behaviour change for developers.

## Test plan

- [ ] CI build.yml green on Release
- [ ] CI build logs show `SAMVersion = 2026.2.<run_number> (derived from ref 'sow/2026-Q2')`
- [ ] CI artifacts (if any) report the stamped version
- [ ] spdx-check.yml green (no `.cs` files added; existing SPDX headers preserved)

## Follow-up

Once this merges, the same transform cascades to ~29 remaining repos (SAM_Tas + SAM_SolarCalculator first per dep-clone ordering, then the rest, then SAM_Deploy submodule bump).