### PR TITLE
fix: netstandard2.0-safe finite check in WeatherHour

### DIFF
--- a/SAM/SAM.Weather/Classes/WeatherHour.cs
+++ b/SAM/SAM.Weather/Classes/WeatherHour.cs
@@ -208,7 +208,7 @@ namespace SAM.Weather
                 JsonArray dataArray = new JsonArray();
                 foreach (KeyValuePair<string, double> keyValuePair in dictionary)
                 {
-                    if (!double.IsFinite(keyValuePair.Value))
+                    if (double.IsNaN(keyValuePair.Value) || double.IsInfinity(keyValuePair.Value))
                         continue;
 
                     JsonObject dataObject = new JsonObject


### PR DESCRIPTION
## Summary
- `5f0f0a0d` introduced `double.IsFinite(...)` in `SAM.Weather/Classes/WeatherHour.cs`, but `SAM.Weather` targets **netstandard2.0** where `double.IsFinite` does not exist (added in netstandard2.1 / .NET Core 3.0). This breaks the Release build on `sow/2026-Q2` and every PR built against it.
- Replaced with the semantically identical netstandard2.0-safe guard: `double.IsNaN(x) || double.IsInfinity(x)`.

## Test plan
- [x] `dotnet build SAM/SAM.Weather/SAM.Weather.csproj -c Release` succeeds (netstandard2.0)
- [x] CI `build (Release)` + `spdx` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)