### PR TITLE
Register missing _saveWeatherData_ input on CreateAnalyticalModelByAdjacencyCluster

### DIFF
--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateAnalyticalModelByAdjacencyCluster.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateAnalyticalModelByAdjacencyCluster.cs
@@ -22,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.9";
+        public override string LatestComponentVersion => "1.0.10";
 
         /// <summary>
         /// Provides an Icon for the component.

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateAnalyticalModelByAdjacencyCluster.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateAnalyticalModelByAdjacencyCluster.cs
@@ -67,6 +67,7 @@ namespace SAM.Analytical.Grasshopper
 
                 param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_saveWeatherData_", NickName = "_saveWeatherData_", Description = "Save WeatherData, Design Days for Cooling and Design Days for Heating", Access = GH_ParamAccess.item, Optional = true };
                 param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
 
                 result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Adjacency Cluster", Access = GH_ParamAccess.item, Optional = false }, ParamVisibility.Binding));
 


### PR DESCRIPTION
## Problem

In `SAMAnalyticalCreateAnalyticalModelByAdjacencyCluster`, the `_saveWeatherData_` boolean input was created and configured (`SetPersistentData(false)`) but the `result.Add(...)` that registers it in the inputs list was missing. As a result:

- the input never appeared on the component, and
- `SolveInstance`'s `Params.IndexOfInputParam("_saveWeatherData_")` always returned `-1`, so the save-weather-data option was effectively dead.

## Fix

Add the missing `result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding))` so the input is registered between the design-day inputs and `_adjacencyCluster`, matching the order `SolveInstance` expects.

One-line change; no behaviour change for the other inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)