### PR TITLE
Add AddResult<T>(IResult, T) overload for nested objects (apertures)

### DIFF
--- a/SAM/SAM.Analytical/Classes/AnalyticalModel.cs
+++ b/SAM/SAM.Analytical/Classes/AnalyticalModel.cs
@@ -372,6 +372,41 @@ namespace SAM.Analytical
             return true;
         }
 
+        /// <summary>
+        /// Attaches <paramref name="result"/> and relates it to <paramref name="object"/>, registering
+        /// the object in the cluster first if needed. Unlike the Guid overload — which only relates when
+        /// the object is ALREADY a top-level cluster object — this works for nested objects such as
+        /// <see cref="Aperture"/> (which live inside Panels and are not registered by default), so their
+        /// results become readable back via <see cref="GetResults{T}(IJSAMObject)"/>. Mirrors the
+        /// register-then-relate pattern used by the TAS import (SAM.Analytical.Tas.Modify.CopyResults).
+        /// </summary>
+        public bool AddResult<T>(IResult result, T @object) where T : IJSAMObject
+        {
+            IResult result_Temp = result?.Clone();
+            if (result_Temp == null)
+            {
+                return false;
+            }
+
+            if (adjacencyCluster == null)
+            {
+                adjacencyCluster = new AdjacencyCluster();
+            }
+
+            if (!adjacencyCluster.AddObject(result_Temp))
+            {
+                return false;
+            }
+
+            if (@object != null)
+            {
+                adjacencyCluster.AddObject(@object);
+                adjacencyCluster.AddRelation(result_Temp, @object);
+            }
+
+            return true;
+        }
+
         public bool AddResult(AnalyticalModelSimulationResult analyticalModelSimulationResult)
         {
             AnalyticalModelSimulationResult analyticalModelSimulationResult_Temp = analyticalModelSimulationResult?.Clone();


### PR DESCRIPTION
## What

Adds an in-place `AddResult<T>(IResult result, T @object)` overload to `AnalyticalModel`.

## Why

The existing `AddResult<T>(IResult, Guid)` overload creates the result→object relation only when `adjacencyCluster.GetObject<T>(guid)` is non-null. Apertures live **nested inside Panels** and are **not** top-level cluster objects, so `GetObject<Aperture>(guid)` returns null and the relation is silently skipped — aperture results end up orphaned.

This overload registers the related object (`AddObject`) before relating it, mirroring the proven register-then-relate pattern already used by the TAS import (`SAM.Analytical.Tas.Modify.CopyResults`), but in place. It enables the companion SAM_SolarCalculator change to attach per-window pane/frame solar-coverage results back to `Aperture` objects.

## Companion PR

Consumed by **SAM_SolarCalculator** `feature/aperture-solar-coverage` (same branch name so dep-clone CI pins to this branch). Merge **this** PR first.

## Risk

Additive (new overload, no signature change → no binary break). Registering apertures as top-level cluster objects is already an accepted side effect of the shipped TAS import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)