### PR TITLE
fix: Query.Decompress under-reads large gzip streams

### DIFF
--- a/SAM/SAM.Core/Query/Decompress.cs
+++ b/SAM/SAM.Core/Query/Decompress.cs
@@ -34,7 +34,16 @@ namespace SAM.Core
                 memoryStream.Position = 0;
                 using (var gZipStream = new GZipStream(memoryStream, CompressionMode.Decompress))
                 {
-                    gZipStream.Read(buffer, 0, buffer.Length);
+                    // GZipStream.Read is not guaranteed to fill the buffer in a single call - for large
+                    // payloads (e.g. a whole model) it returns only part of the data, leaving the rest of
+                    // the buffer as zero bytes and so producing a truncated/corrupt result. Loop until the
+                    // expected dataLength bytes have been read (or the stream ends).
+                    int offset = 0;
+                    int read;
+                    while (offset < buffer.Length && (read = gZipStream.Read(buffer, offset, buffer.Length - offset)) > 0)
+                    {
+                        offset += read;
+                    }
                 }
 
                 return Encoding.UTF8.GetString(buffer);


### PR DESCRIPTION
﻿Fixes `Query.Decompress(string)` truncating large payloads.

`GZipStream.Read(buffer, 0, buffer.Length)` is not guaranteed to fill the buffer in a single call - for large compressed data it returns only the first chunk, leaving the remainder of the buffer zero-filled, so the decompressed string is truncated and unparseable. The read is now looped until `dataLength` bytes have been read (or the stream ends).

**How it surfaced:** SAM_UI undo/redo stores model snapshots via `Query.Compress`/`Decompress`. Restoring a multi-MB model returned `null` (truncated JSON failed to parse), so undo silently did nothing; small objects happened to fit a single `Read` and worked, which is why this stayed latent.

Same-class code in `Query/Copy.cs` already loops its reads; this brings `Decompress` in line. The on-disk/base64 format is unchanged, so it is fully backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
