### PR TITLE
feat(grasshopper): add IGooSAMGeometry interface in SAM.Core.Grasshopper

### DIFF
--- a/Grasshopper/SAM.Core.Grasshopper/Classes/GooObject.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Classes/GooObject.cs
@@ -114,6 +114,38 @@ namespace SAM.Core.Grasshopper
             if (Value == null)
                 return false;
 
+            bool isSAMGeometry = false;
+            System.Type valueType = Value.GetType();
+            if (valueType.FullName == "SAM.Geometry.ISAMGeometry")
+            {
+                isSAMGeometry = true;
+            }
+            else
+            {
+                System.Type[] interfaces = valueType.GetInterfaces();
+                for (int i = 0; i < interfaces.Length; i++)
+                {
+                    if (interfaces[i].FullName == "SAM.Geometry.ISAMGeometry")
+                    {
+                        isSAMGeometry = true;
+                        break;
+                    }
+                }
+            }
+
+            if (isSAMGeometry)
+            {
+                System.Type gooSAMGeometryType = System.Type.GetType("SAM.Geometry.Grasshopper.GooSAMGeometry, SAM.Geometry.Grasshopper");
+                if (gooSAMGeometryType != null)
+                {
+                    IGooSAMGeometry gooSAMGeometryInstance = (IGooSAMGeometry)System.Activator.CreateInstance(gooSAMGeometryType, Value);
+                    if (gooSAMGeometryInstance.CastTo<Y>(out target))
+                    {
+                        return true;
+                    }
+                }
+            }
+
             if (Value is Y)
             {
                 target = (Y)Value;

--- a/Grasshopper/SAM.Core.Grasshopper/Interfaces/IGooSAMGeometry.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Interfaces/IGooSAMGeometry.cs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel.Types;
+
+namespace SAM.Core.Grasshopper
+{
+    public interface IGooSAMGeometry : IGH_Goo
+    {
+    }
+}

--- a/Grasshopper/SAM.Geometry.Grasshopper/Classes/GooSAMGeometry.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Classes/GooSAMGeometry.cs
@@ -16,10 +16,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using SAM.Core.Grasshopper;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GooSAMGeometry : GH_Goo<ISAMGeometry>, IGH_PreviewData, IGH_BakeAwareData
+    public class GooSAMGeometry : GH_Goo<ISAMGeometry>, IGooSAMGeometry, IGH_PreviewData, IGH_BakeAwareData
     {
         public GooSAMGeometry()
             : base()
@@ -448,6 +449,12 @@ namespace SAM.Geometry.Grasshopper
             if (typeof(Y).IsAssignableFrom(Value.GetType()))
             {
                 target = (Y)(object)Value;
+                return true;
+            }
+
+            if(typeof(Y).IsAssignableFrom(typeof(IGH_GeometricGoo)) && Value.ToGrasshopper() is Y y)
+            {
+                target = y;
                 return true;
             }
 


### PR DESCRIPTION
Introduces the `IGooSAMGeometry` interface in `SAM.Core.Grasshopper` and wires it into `GooObject` / `GooSAMGeometry`.

## Changes
- New `SAM.Core.Grasshopper/Interfaces/IGooSAMGeometry.cs`
- `SAM.Core.Grasshopper/Classes/GooObject.cs` — implement/support the interface
- `SAM.Geometry.Grasshopper/Classes/GooSAMGeometry.cs` — implement `IGooSAMGeometry`

This work was on the standalone `feature/grasshopper-geometry-conversion` branch and is not covered by the recently merged #22/#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)