### PR TITLE
fix(grasshopper): correct geometry → ISAMGeometry cast (GooObject + GooSAMGeometry)

### DIFF
--- a/Grasshopper/SAM.Core.Grasshopper/Classes/GooObject.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Classes/GooObject.cs
@@ -139,6 +139,11 @@ namespace SAM.Core.Grasshopper
                 if (gooSAMGeometryType != null)
                 {
                     IGooSAMGeometry gooSAMGeometryInstance = (IGooSAMGeometry)System.Activator.CreateInstance(gooSAMGeometryType, Value);
+                    if (gooSAMGeometryInstance is Y geoGoo)
+                    {
+                        target = geoGoo;
+                        return true;
+                    }
                     if (gooSAMGeometryInstance.CastTo<Y>(out target))
                     {
                         return true;

--- a/Grasshopper/SAM.Geometry.Grasshopper/Classes/GooSAMGeometry.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Classes/GooSAMGeometry.cs
@@ -356,10 +356,13 @@ namespace SAM.Geometry.Grasshopper
 
         public override bool CastTo<Y>(ref Y target)
         {
-            if (typeof(Y) is ISAMGeometry)
+            if (typeof(ISAMGeometry).IsAssignableFrom(typeof(Y)))
             {
-                target = (Y)(object)Value;
-                return true;
+                if (Value is Y val)
+                {
+                    target = val;
+                    return true;
+                }
             }
 
             if (typeof(Y) == typeof(Polyline))


### PR DESCRIPTION
Fixes two bugs introduced by the recent Grasshopper geometry cast PRs (#22, #24) that broke connecting SAM geometry wires to `ISAMGeometry` / `GooSAMGeometry` parameters.

## Root causes

**Bug 1 — `GooSAMGeometry.CastTo<Y>` (`GooSAMGeometry.cs:358`)**
```csharp
// Before (always false — typeof(Y) is a System.Type object, not ISAMGeometry)
if (typeof(Y) is ISAMGeometry)

// After
if (typeof(ISAMGeometry).IsAssignableFrom(typeof(Y)))
{
    if (Value is Y val) { target = val; return true; }
}
```

**Bug 2 — `GooObject.CastTo<Y>` (`GooObject.cs:138-146`)**
When `Y` is `GooSAMGeometry` or `IGooSAMGeometry`, the code created a `GooSAMGeometry` wrapper then called `CastTo<Y>` on it — but no check inside `GooSAMGeometry.CastTo` matches the wrapper type itself, so it always returned `false`. Added an `is Y` early-return before the `CastTo` call.

## What this fixes
- Connecting a SAM geometry output to a `GooSAMGeometry` parameter
- Connecting a `GooObject` wrapping an `ISAMGeometry` to any geometry-typed input

🤖 Generated with [Claude Code](https://claude.com/claude-code)