### PR TITLE
fix(geometry): Mesh3D Transform + Extrusion → ISAMGeometry cast

### DIFF
--- a/Grasshopper/SAM.Core.Grasshopper/Classes/GooObject.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Classes/GooObject.cs
@@ -139,7 +139,7 @@ namespace SAM.Core.Grasshopper
                 if (gooSAMGeometryType != null)
                 {
                     IGooSAMGeometry gooSAMGeometryInstance = (IGooSAMGeometry)System.Activator.CreateInstance(gooSAMGeometryType, Value);
-                    if (gooSAMGeometryInstance is Y geoGoo)
+                    if (typeof(IGH_Goo).IsAssignableFrom(typeof(Y)) && gooSAMGeometryInstance is Y geoGoo)
                     {
                         target = geoGoo;
                         return true;

--- a/Grasshopper/SAM.Geometry.Grasshopper/Classes/GooSAMGeometry.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Classes/GooSAMGeometry.cs
@@ -351,6 +351,34 @@ namespace SAM.Geometry.Grasshopper
                 }
             }
 
+            if (source is global::Rhino.Geometry.Extrusion)
+            {
+                Brep brep = ((global::Rhino.Geometry.Extrusion)source).ToBrep(true);
+                if (brep != null)
+                {
+                    List<ISAMGeometry3D> sAMGeometry3Ds = Rhino.Convert.ToSAM(brep);
+                    if (sAMGeometry3Ds != null && sAMGeometry3Ds.Count != 0)
+                    {
+                        Value = sAMGeometry3Ds[0];
+                        return true;
+                    }
+                }
+            }
+
+            if (source is GH_Extrusion)
+            {
+                Brep brep = ((GH_Extrusion)source).Value?.ToBrep(true);
+                if (brep != null)
+                {
+                    List<ISAMGeometry3D> sAMGeometry3Ds = Rhino.Convert.ToSAM(brep);
+                    if (sAMGeometry3Ds != null && sAMGeometry3Ds.Count != 0)
+                    {
+                        Value = sAMGeometry3Ds[0];
+                        return true;
+                    }
+                }
+            }
+
             return base.CastFrom(source);
         }
 

--- a/Grasshopper/SAM.Geometry.Grasshopper/Classes/GooSAMGeometry.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Classes/GooSAMGeometry.cs
@@ -709,7 +709,7 @@ namespace SAM.Geometry.Grasshopper
                 return true;
             }
 
-            if(typeof(Y).IsAssignableFrom(typeof(IGH_GeometricGoo)) && Value.ToGrasshopper() is Y y)
+            if(typeof(IGH_GeometricGoo).IsAssignableFrom(typeof(Y)) && Value.ToGrasshopper() is Y y)
             {
                 target = y;
                 return true;

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Transform.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Transform.cs
@@ -88,6 +88,11 @@ namespace SAM.Geometry.Spatial
             return Transform(coordinateSystem3D, transform3D?.Matrix4D);
         }
 
+        public static Mesh3D Transform(this Mesh3D mesh3D, Transform3D transform3D)
+        {
+            return Transform(mesh3D, transform3D?.Matrix4D);
+        }
+
         public static Circle3D Transform(this Circle3D circle3D, Matrix4D matrix4D)
         {
             if (matrix4D == null)
@@ -323,6 +328,20 @@ namespace SAM.Geometry.Spatial
             Vector3D axisZ = coordinateSystem3D.AxisZ.Transform(matrix4D);
 
             return new CoordinateSystem3D(origin, axisX, axisY, axisZ);
+        }
+
+        public static Mesh3D Transform(this Mesh3D mesh3D, Matrix4D matrix4D)
+        {
+            if (mesh3D == null || matrix4D == null)
+                return null;
+
+            List<Point3D> points = mesh3D.GetPoints()?.ConvertAll(x => x.Transform(matrix4D));
+
+            List<System.Tuple<int, int, int>> indexes = new List<System.Tuple<int, int, int>>();
+            for (int i = 0; i < mesh3D.TrianglesCount; i++)
+                indexes.Add(mesh3D.GetTriangleIndexes(i));
+
+            return new Mesh3D(points, indexes);
         }
     }
 }


### PR DESCRIPTION
Fixes two runtime errors reported when using SAM geometry Grasshopper components.

## Issue 1 — `Data conversion failed from Extrusion to ISAMGeometry`

`GooSAMGeometry.CastFrom` had no handler for `Rhino.Geometry.Extrusion` or `GH_Extrusion`. Both now convert via `extrusion.ToBrep(cap: true)` and flow through the existing Brep→SAM path.

## Issue 2 — Transform exception on Referenced Mesh

```
Solution exception: The best overloaded method match for
'SAM.Geometry.Spatial.Query.Transform(Point3D, Transform3D)'
has some invalid arguments
```

`SAMGeometryTransform.cs` uses `geometry as dynamic` dispatch — when the geometry is a `Mesh3D`, no `Transform(Mesh3D, …)` overload existed, so the runtime resolved to `Transform(Point3D, …)` (closest match) and threw. Added:

- `Transform(this Mesh3D, Transform3D)` — delegates to Matrix4D overload
- `Transform(this Mesh3D, Matrix4D)` — transforms all vertices via `GetPoints()` + `GetTriangleIndexes()` loop, reconstructs with original connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)