### PR TITLE
Fix Mesh3D -> Rhino Mesh dropping faces on bake/preview

### DIFF
--- a/Rhino/SAM.Geometry.Rhino/Convert/ToRhino/Mesh.cs
+++ b/Rhino/SAM.Geometry.Rhino/Convert/ToRhino/Mesh.cs
@@ -17,27 +17,42 @@ namespace SAM.Geometry.Rhino
 
             Mesh result = new Mesh();
 
-            List<Spatial.Triangle3D> triangle3Ds = mesh3D.GetTriangles();
-            if (triangle3Ds != null)
+            // Build the Rhino mesh directly from the SAM mesh's shared vertices and face
+            // indices. The previous approach rebuilt each triangle from its three edge lines
+            // with Mesh.CreateFromLines at a distance tolerance and silently dropped any
+            // triangle it could not reconstruct (slivers, near-coincident edges), which lost
+            // faces on bake/preview. Indexing the stored topology directly is exact - every
+            // triangle becomes one face and no face is dropped.
+            List<Spatial.Point3D> point3Ds = mesh3D.GetPoints();
+            if (point3Ds == null || point3Ds.Count == 0)
             {
-                foreach (Spatial.Triangle3D triangle in triangle3Ds)
-                {
-                    if (triangle == null)
-                    {
-                        continue;
-                    }
-
-                    List<Curve> lines = triangle.GetSegments().ConvertAll(x => (Curve)x.ToRhino_LineCurve());
-
-                    Mesh mesh = Mesh.CreateFromLines(lines.ToArray(), 3, Core.Tolerance.Distance);
-                    if (mesh == null)
-                    {
-                        continue;
-                    }
-
-                    result.Append(mesh);
-                }
+                return result;
             }
+
+            foreach (Spatial.Point3D point3D in point3Ds)
+            {
+                if (point3D == null)
+                {
+                    return result;
+                }
+
+                result.Vertices.Add(point3D.X, point3D.Y, point3D.Z);
+            }
+
+            int trianglesCount = mesh3D.TrianglesCount;
+            for (int i = 0; i < trianglesCount; i++)
+            {
+                System.Tuple<int, int, int> indexes = mesh3D.GetTriangleIndexes(i);
+                if (indexes == null)
+                {
+                    continue;
+                }
+
+                result.Faces.AddFace(indexes.Item1, indexes.Item2, indexes.Item3);
+            }
+
+            result.Normals.ComputeNormals();
+            result.Compact();
 
             return result;
         }


### PR DESCRIPTION
## Problem

Baking (or previewing) a SAM `Mesh3D` in Grasshopper showed **missing faces**, even though the `Mesh3D` itself stored every triangle. Reproduced with a closed Rhino mesh imported to SAM: the `.sam` Mesh3D had **1594 points and 1405 triangles** — an exact match for the source OBJ — so nothing was lost on import. The loss was on the way **back out** to Rhino.

## Cause

`Convert.ToRhino(this Mesh3D)` rebuilt each triangle from its three edge **lines** via `Mesh.CreateFromLines(lines, 3, Tolerance.Distance)` and silently skipped (`continue`) any triangle it couldn't reconstruct. That reconstruction welds endpoints at a distance tolerance, so on meshes with coincident / unwelded duplicate vertices (this mesh: 1594 vertices but only **499 unique coordinates**) some triangles failed to form a face and were dropped — holes on bake/preview.

Both the bake path (`GH_Mesh.ToGrasshopper`) and the viewport-preview path (`DrawViewportMeshes` → `Brep.CreateFromMesh`) go through this converter, so both showed the holes.

## Fix

Build the Rhino mesh **directly** from the mesh's shared vertices (`GetPoints`) and face indices (`TrianglesCount` / `GetTriangleIndexes`): every triangle maps to exactly one face, with no tolerance-dependent reconstruction and no dropped faces. Normals are computed and the mesh compacted.

## Testing

- `SAM.Geometry.Rhino` builds with 0 errors.
- The SAM test project (`SAM.Tests`, net8.0) does not reference the Windows/RhinoCommon `SAM.Geometry.Rhino` assembly, so this converter can't be unit-tested headless; verified by analysis (1405 stored triangles → 1405 faces, 1:1) and by baking the real mesh in Rhino.

Generated by Michal Dengusiak & Claude Code