### PR TITLE
perf(Solver2D): drop per-query allocations in label placement (#58)

### DIFF
--- a/SAM/SAM.Geometry/Geometry/Planar/Classes/Solver2D/Solver2D.cs
+++ b/SAM/SAM.Geometry/Geometry/Planar/Classes/Solver2D/Solver2D.cs
@@ -83,6 +83,9 @@ namespace SAM.Geometry.Planar
             const double budgetMilliseconds = 10000;
             System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
+            // The 8 search directions are identical for every label, so build them once rather than per label.
+            List<Vector2D> offsets = generateOffsets();
+
             foreach (Solver2DData solver2DData in solver2DDatas)
             {
                 Rectangle2D rectangle2D = solver2DData.Closed2D<Rectangle2D>();
@@ -116,7 +119,6 @@ namespace SAM.Geometry.Planar
                 {
                     Point2D point2D = (Point2D)sAMGeometry2D;
                     Rectangle2D rectangle2DWithGivenPointInCenter = rectangle2D.GetMoved(new Vector2D(rectangle2D.GetCentroid(), point2D));
-                    List<Vector2D> offsets = generateOffsets();
 
                     if (overBudget)
                     {
@@ -328,6 +330,11 @@ namespace SAM.Geometry.Planar
             private readonly double cellSize;
             private readonly Dictionary<long, List<Rectangle2D>> cells = new Dictionary<long, List<Rectangle2D>>();
 
+            // Reused across Query calls to de-duplicate the rectangles a query box's cells share, without
+            // allocating a HashSet on every call. Query is enumerated fully and sequentially by the solver
+            // (one query finishes before the next starts), so a single shared scratch set is safe here.
+            private readonly HashSet<Rectangle2D> querySeen = new HashSet<Rectangle2D>();
+
             private RectangleGrid(double cellSize)
             {
                 this.cellSize = cellSize;
@@ -382,7 +389,7 @@ namespace SAM.Geometry.Planar
                     yield break;
                 }
 
-                HashSet<Rectangle2D> seen = new HashSet<Rectangle2D>();
+                querySeen.Clear();
 
                 // One-cell halo: absorbs the InRange tolerance and any box that straddles a cell border.
                 for (long x = minX - 1; x <= maxX + 1; x++)
@@ -393,7 +400,7 @@ namespace SAM.Geometry.Planar
                         {
                             foreach (Rectangle2D placed in list)
                             {
-                                if (seen.Add(placed))
+                                if (querySeen.Add(placed))
                                 {
                                     yield return placed;
                                 }


### PR DESCRIPTION
Toward [SAM_UI #58](https://github.com/SAM-BIM/SAM_UI/issues/58) (floor-plan label solver O(N²) on clustered anchors). This is the **safe, constant-factor** portion — **placement results are unchanged** (all 110 `SAM.Tests` pass); it does **not** yet remove the O(N²) asymptotics, so it's opened for real-model (10k) profiling **before merge**, not auto-merged.

## Changes (both pure allocation reductions, identical behaviour)
1. **`RectangleGrid.Query` no longer allocates a `HashSet` per call.** It de-dups the rectangles a query box's cells share; previously that was a fresh `HashSet` on every candidate evaluation (~1M allocations on a clustered solve). Now a single scratch set is reused and cleared per call. `Query` is enumerated fully and sequentially by the solver (one query completes before the next), so one shared set is safe. Same de-dup → same results, far less GC.
2. **`generateOffsets()` hoisted out of the per-label loop.** The 8 search directions are identical for every label; build them once instead of ~1703×.

## Why not the full fix here
The core of #58 is the O(N²) scan when section anchors cluster into the same grid cells. That needs an algorithmic change (finer/adaptive cell size, or up-front clustered-anchor detection) and **real-model profiling to validate it actually helps and doesn't regress normal plans** — which can't be done from CI. These two allocation wins are unambiguously safe to land regardless; the asymptotic work stays tracked in #58.

## Test
`dotnet build` green; 110/110 `SAM.Tests` pass. **Before merge:** rebuild + open the `Level 0 [20.1m]`-style view on the 10k model with `SAM_UI_PERFORMANCE_LOG` and compare `FloorPlan.LabelSolver` vs the current ~10s cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)