### PR TITLE
perf(Analytical): AddAperturesByAperture 6.1min -> ~2.4s on 1758-space model

### DIFF
--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByAperture.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByAperture.cs
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.6";
+        public override string LatestComponentVersion => "1.0.7";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -139,40 +139,7 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            List<Tuple<Panel, Aperture>> tuples_Result = null;
-
-            List<Panel> panels = adjacencyCluster.GetPanels();
-            if (panels != null && panels.Count != 0)
-            {
-                tuples_Result = new List<Tuple<Panel, Aperture>>();
-
-                foreach (Panel panel in panels)
-                {
-                    Panel panel_New = Create.Panel(panel);
-
-                    bool updated = false;
-                    foreach (Aperture aperture in apertures)
-                    {
-                        if (aperture == null)
-                        {
-                            continue;
-                        }
-
-                        List<Aperture> apertures_New = Analytical.Modify.AddApertures(panel_New, aperture.ApertureConstruction, aperture.GetFace3D(), trimApertures, Tolerance.MacroDistance, maxDistance);
-                        if (apertures_New != null && apertures_New.Count > 0)
-                        {
-                            updated = true;
-                            foreach (Aperture aperture_New in apertures_New)
-                            {
-                                tuples_Result.Add(new Tuple<Panel, Aperture>(panel_New, aperture_New));
-                            }
-                        }
-                    }
-
-                    if (updated)
-                        adjacencyCluster.AddObject(panel_New);
-                }
-            }
+            List<Aperture> apertures_Result_Cluster = Analytical.Modify.AddAperturesByApertures(adjacencyCluster, apertures, trimApertures, Tolerance.MacroDistance, maxDistance);
 
             if (analyticalModel != null)
             {
@@ -184,8 +151,8 @@ namespace SAM.Analytical.Grasshopper
                 dataAccess.SetData(0, adjacencyCluster);
             }
 
-            dataAccess.SetDataList(1, tuples_Result?.ConvertAll(x => new GooAperture(x.Item2)));
-            dataAccess.SetData(2, tuples_Result != null && tuples_Result.Count != 0);
+            dataAccess.SetDataList(1, apertures_Result_Cluster?.ConvertAll(x => new GooAperture(x)));
+            dataAccess.SetData(2, apertures_Result_Cluster != null && apertures_Result_Cluster.Count != 0);
         }
     }
 }

--- a/SAM/SAM.Analytical/Modify/AddApertures.cs
+++ b/SAM/SAM.Analytical/Modify/AddApertures.cs
@@ -223,6 +223,88 @@ namespace SAM.Analytical
             //return result;
         }
 
+        public static List<Aperture> AddAperturesByApertures(this AdjacencyCluster adjacencyCluster, IEnumerable<Aperture> apertures, bool trimGeometry = true, double minArea = Core.Tolerance.MacroDistance, double maxDistance = Core.Tolerance.MacroDistance, double tolerance = Core.Tolerance.Distance)
+        {
+            if (adjacencyCluster == null || apertures == null)
+                return null;
+
+            List<Panel> panels = adjacencyCluster.GetPanels();
+            if (panels == null || panels.Count == 0)
+                return null;
+
+            double max = System.Math.Max(maxDistance, tolerance);
+
+            List<Tuple<ApertureConstruction, Face3D, double[]>> tuples_Aperture = new List<Tuple<ApertureConstruction, Face3D, double[]>>();
+            foreach (Aperture aperture in apertures)
+            {
+                if (aperture == null)
+                    continue;
+
+                ApertureConstruction apertureConstruction = aperture.ApertureConstruction;
+                Face3D face3D = aperture.GetFace3D();
+                if (apertureConstruction == null || face3D == null)
+                    continue;
+
+                BoundingBox3D boundingBox3D = face3D.GetBoundingBox(max);
+                if (boundingBox3D == null)
+                    continue;
+
+                Point3D point3D_Min = boundingBox3D.Min;
+                Point3D point3D_Max = boundingBox3D.Max;
+                tuples_Aperture.Add(new Tuple<ApertureConstruction, Face3D, double[]>(apertureConstruction, face3D, new double[] { point3D_Min.X, point3D_Min.Y, point3D_Min.Z, point3D_Max.X, point3D_Max.Y, point3D_Max.Z }));
+            }
+
+            List<Aperture> result = new List<Aperture>();
+            if (tuples_Aperture.Count == 0)
+                return result;
+
+            foreach (Panel panel in panels)
+            {
+                if (panel == null || panel.PanelType == PanelType.Air)
+                    continue;
+
+                BoundingBox3D boundingBox3D_Panel = panel.GetBoundingBox(max);
+                if (boundingBox3D_Panel == null)
+                    continue;
+
+                Point3D point3D_Min = boundingBox3D_Panel.Min;
+                Point3D point3D_Max = boundingBox3D_Panel.Max;
+                double min_X = point3D_Min.X;
+                double min_Y = point3D_Min.Y;
+                double min_Z = point3D_Min.Z;
+                double max_X = point3D_Max.X;
+                double max_Y = point3D_Max.Y;
+                double max_Z = point3D_Max.Z;
+
+                Panel panel_New = null;
+                bool updated = false;
+                foreach (Tuple<ApertureConstruction, Face3D, double[]> tuple_Aperture in tuples_Aperture)
+                {
+                    double[] values = tuple_Aperture.Item3;
+
+                    if (values[3] + Core.Tolerance.Distance < min_X || values[0] - Core.Tolerance.Distance > max_X ||
+                        values[4] + Core.Tolerance.Distance < min_Y || values[1] - Core.Tolerance.Distance > max_Y ||
+                        values[5] + Core.Tolerance.Distance < min_Z || values[2] - Core.Tolerance.Distance > max_Z)
+                        continue;
+
+                    if (panel_New == null)
+                        panel_New = Create.Panel(panel);
+
+                    List<Aperture> apertures_New = AddApertures(panel_New, tuple_Aperture.Item1, tuple_Aperture.Item2, trimGeometry, minArea, maxDistance, tolerance);
+                    if (apertures_New != null && apertures_New.Count > 0)
+                    {
+                        updated = true;
+                        result.AddRange(apertures_New);
+                    }
+                }
+
+                if (updated)
+                    adjacencyCluster.AddObject(panel_New);
+            }
+
+            return result;
+        }
+
         public static List<Aperture> AddApertures(this IEnumerable<Panel> panels, ApertureConstruction apertureConstruction, double ratio, double azimuth_Start, double azimuth_End, double tolerance_Area = Core.Tolerance.MacroDistance, double tolerance = Core.Tolerance.Distance)
         {
             if (panels == null || apertureConstruction == null)

--- a/SAM/SAM.Analytical/Modify/AddApertures.cs
+++ b/SAM/SAM.Analytical/Modify/AddApertures.cs
@@ -258,6 +258,8 @@ namespace SAM.Analytical
             if (tuples_Aperture.Count == 0)
                 return result;
 
+            //Phase 1 (sequential): cheap zero-alloc AABB pre-filter -> candidate panels + their surviving aperture indexes
+            List<Tuple<Panel, List<int>>> candidates = new List<Tuple<Panel, List<int>>>();
             foreach (Panel panel in panels)
             {
                 if (panel == null || panel.PanelType == PanelType.Air)
@@ -276,30 +278,79 @@ namespace SAM.Analytical
                 double max_Y = point3D_Max.Y;
                 double max_Z = point3D_Max.Z;
 
-                Panel panel_New = null;
-                bool updated = false;
-                foreach (Tuple<ApertureConstruction, Face3D, double[]> tuple_Aperture in tuples_Aperture)
+                List<int> indexes = null;
+                for (int i = 0; i < tuples_Aperture.Count; i++)
                 {
-                    double[] values = tuple_Aperture.Item3;
+                    double[] values = tuples_Aperture[i].Item3;
 
                     if (values[3] + Core.Tolerance.Distance < min_X || values[0] - Core.Tolerance.Distance > max_X ||
                         values[4] + Core.Tolerance.Distance < min_Y || values[1] - Core.Tolerance.Distance > max_Y ||
                         values[5] + Core.Tolerance.Distance < min_Z || values[2] - Core.Tolerance.Distance > max_Z)
                         continue;
 
-                    if (panel_New == null)
-                        panel_New = Create.Panel(panel);
+                    if (indexes == null)
+                        indexes = new List<int>();
+
+                    indexes.Add(i);
+                }
+
+                if (indexes != null)
+                    candidates.Add(new Tuple<Panel, List<int>>(panel, indexes));
+            }
+
+            if (candidates.Count == 0)
+                return result;
+
+            //Phase 2: process each candidate panel (its own clone, apertures tried in input order) -
+            //parallel across panels once the candidate count justifies it (repo convention: > 30, cf. NormalDictionary.cs),
+            //otherwise sequential. Each task only reads shared state (panel, precomputed aperture Face3D/ApertureConstruction)
+            //and writes into its own pre-sized slot - no shared mutation during the parallel region.
+            Panel[] panels_New = new Panel[candidates.Count];
+            List<Aperture>[] apertures_New_ByPanel = new List<Aperture>[candidates.Count];
+
+            void ProcessCandidate(int i)
+            {
+                Tuple<Panel, List<int>> candidate = candidates[i];
+                Panel panel_New = Create.Panel(candidate.Item1);
+
+                List<Aperture> apertures_New_Panel = null;
+                foreach (int j in candidate.Item2)
+                {
+                    Tuple<ApertureConstruction, Face3D, double[]> tuple_Aperture = tuples_Aperture[j];
 
                     List<Aperture> apertures_New = AddApertures(panel_New, tuple_Aperture.Item1, tuple_Aperture.Item2, trimGeometry, minArea, maxDistance, tolerance);
                     if (apertures_New != null && apertures_New.Count > 0)
                     {
-                        updated = true;
-                        result.AddRange(apertures_New);
+                        if (apertures_New_Panel == null)
+                            apertures_New_Panel = new List<Aperture>();
+
+                        apertures_New_Panel.AddRange(apertures_New);
                     }
                 }
 
-                if (updated)
-                    adjacencyCluster.AddObject(panel_New);
+                panels_New[i] = panel_New;
+                apertures_New_ByPanel[i] = apertures_New_Panel;
+            }
+
+            if (candidates.Count > 30)
+            {
+                System.Threading.Tasks.Parallel.For(0, candidates.Count, ProcessCandidate);
+            }
+            else
+            {
+                for (int i = 0; i < candidates.Count; i++)
+                    ProcessCandidate(i);
+            }
+
+            //Phase 3 (sequential): assemble in original panel order and mutate the cluster
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                List<Aperture> apertures_New_Panel = apertures_New_ByPanel[i];
+                if (apertures_New_Panel == null || apertures_New_Panel.Count == 0)
+                    continue;
+
+                result.AddRange(apertures_New_Panel);
+                adjacencyCluster.AddObject(panels_New[i]);
             }
 
             return result;

--- a/SAM/SAM.Analytical/Modify/AddApertures.cs
+++ b/SAM/SAM.Analytical/Modify/AddApertures.cs
@@ -749,15 +749,20 @@ namespace SAM.Analytical
             if (apertureConstruction == null || closedPlanar3D == null || panel == null)
                 return null;
 
-            if (!Query.ApertureHost(panel, closedPlanar3D, minArea, maxDistance, tolerance))
-                return null;
-
             Face3D face3D = panel.GetFace3D();
             if (face3D == null)
                 return null;
 
             Plane plane = face3D.GetPlane();
             if (plane == null)
+                return null;
+
+            BoundingBox3D boundingBox3D_Panel = face3D.GetBoundingBox(System.Math.Max(maxDistance, tolerance));
+            if (boundingBox3D_Panel == null)
+                return null;
+
+            //NOTE: must be called with the UNFLIPPED plane (below) - ApertureHost expects the panel's own plane orientation
+            if (!Query.ApertureHost(panel, closedPlanar3D, plane, boundingBox3D_Panel, minArea, maxDistance, tolerance))
                 return null;
 
             Plane plane_Aperture = closedPlanar3D.GetPlane();
@@ -802,9 +807,9 @@ namespace SAM.Analytical
                 Point3D point3D_Location = Query.OpeningLocation(face3D_Aperture_New, tolerance);
 
                 Aperture aperture = new Aperture(apertureConstruction, face3D_Aperture_New, point3D_Location);
-                if (!Query.IsValid(panel, aperture))
-                    continue;
 
+                //NOTE: Query.IsValid is not called here - panel.AddAperture performs the identical
+                //check (same default tolerances) and returns false on failure, so the result is unchanged.
                 if (panel.AddAperture(aperture))
                     result.Add(aperture);
             }

--- a/SAM/SAM.Analytical/Query/ApertureHost.cs
+++ b/SAM/SAM.Analytical/Query/ApertureHost.cs
@@ -10,13 +10,34 @@ namespace SAM.Analytical
     {
         public static bool ApertureHost(this Panel panel, IClosedPlanar3D closedPlanar3D, double minArea = Core.Tolerance.MacroDistance, double maxDistance = Core.Tolerance.MacroDistance, double tolerance = Core.Tolerance.Distance)
         {
-            if (closedPlanar3D == null)
+            if (panel == null || closedPlanar3D == null)
             {
                 return false;
             }
 
-            Plane plane = panel?.PlanarBoundary3D?.Plane;
+            Plane plane = panel.Plane;
             if (plane == null)
+            {
+                return false;
+            }
+
+            BoundingBox3D boundingBox3D_Panel = panel.GetBoundingBox(System.Math.Max(maxDistance, tolerance));
+            if (boundingBox3D_Panel == null)
+            {
+                return false;
+            }
+
+            return ApertureHost(panel, closedPlanar3D, plane, boundingBox3D_Panel, minArea, maxDistance, tolerance);
+        }
+
+        /// <summary>
+        /// ApertureHost overload accepting a precomputed, UNFLIPPED panel Plane and panel BoundingBox3D
+        /// (already inflated by Math.Max(maxDistance, tolerance)) to avoid recomputing them per aperture
+        /// when testing many apertures against the same panel.
+        /// </summary>
+        public static bool ApertureHost(this Panel panel, IClosedPlanar3D closedPlanar3D, Plane plane, BoundingBox3D boundingBox3D_Panel, double minArea = Core.Tolerance.MacroDistance, double maxDistance = Core.Tolerance.MacroDistance, double tolerance = Core.Tolerance.Distance)
+        {
+            if (panel == null || closedPlanar3D == null || plane == null || boundingBox3D_Panel == null)
             {
                 return false;
             }
@@ -46,12 +67,6 @@ namespace SAM.Analytical
             }
 
             double max = System.Math.Max(maxDistance, tolerance);
-
-            BoundingBox3D boundingBox3D_Panel = panel.GetBoundingBox(max);
-            if (boundingBox3D_Panel == null)
-            {
-                return false;
-            }
 
             BoundingBox3D boundingBox3D_ClosedPlanar3D = closedPlanar3D.GetBoundingBox(max);
             if (boundingBox3D_ClosedPlanar3D == null)


### PR DESCRIPTION
## Summary
- Adds `AdjacencyCluster.AddAperturesByApertures`: precomputes each aperture's `Face3D`/`ApertureConstruction`/inflated bounding box once, then runs a zero-allocation AABB pre-filter (bit-identical to `ApertureHost`'s bbox check) before ever cloning a panel. The `SAMAnalytical.AddAperturesByAperture` Grasshopper component's `AdjacencyCluster`/`AnalyticalModel` branch now calls this instead of its own brute-force panel x aperture loop.
- Adds a precomputed `ApertureHost` overload (accepts panel `Plane` + inflated `BoundingBox3D`) so callers processing many apertures against the same panel don't re-deep-clone `PlanarBoundary3D` and rebuild `Face3D` every call. The core `AddApertures(Panel, ApertureConstruction, IClosedPlanar3D, ...)` overload now computes its `Face3D`/`Plane`/bbox once and reuses them, and drops a redundant `Query.IsValid` pre-check (`Panel.AddAperture` already performs the identical check).
- Parallelizes candidate-panel processing inside `AddAperturesByApertures` (`Parallel.For`, gated on >30 candidates per repo convention) with a sequential pre-filter and sequential result assembly, so ordering and cluster mutation stay deterministic.

Root cause of the original 6.1 min runtime: the component ran a brute-force ~30-75M-pair `panels x apertures` loop with no pre-filter, cloned every panel unconditionally, rebuilt each aperture's geometry/construction per pair, and validated each accepted aperture twice.

## Verification
- [x] Local, uncommitted benchmark harness replicated the component's exact original loop against the 1758-space / 8260-panel / 2229-aperture Talybont test model (`AdjacencyCluster.sam` + `Apertures.sam`), producing a Guid-free geometric signature (host-panel Guid, construction name, area, centroid, bounding box) for all 2144 created apertures.
- [x] Signature is byte-identical to the original (pre-change) code after every commit on this branch.
- [x] `SAM.Analytical` and `SAM.Analytical.Grasshopper` build clean (Release).
- [x] Runtime: baseline ~6.1 min -> ~2.2-2.4s on the same model (measured 3x, consistent).
- [x] User confirmed real-world speedup by re-running the actual Grasshopper definition.

## Follow-ups (not fixed here - out of scope, would change behavior)
Found during analysis, filed as separate issues rather than bundled into this perf-only PR:
- `PlanarBoundary3D.Coplanar(Plane)` compares its parameter to itself and always returns `true`, making the coplanarity guard in `Query.IsValid` a no-op (`SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs:235-238`).
- `SAM/SAM.Geometry/Geometry/Planar/Query/Difference.cs:196` - the `Parallel.For` branch differences `ElementAt(0)` instead of `ElementAt(i)` for every iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)