### PR TITLE
fix(PlanarBoundary3D): stop Coplanar(Plane) from comparing parameter to itself

### DIFF
--- a/SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs
+++ b/SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs
@@ -232,9 +232,9 @@ namespace SAM.Analytical
             return Coplanar(planarBoundary3D.plane, tolerance);
         }
 
-        public bool Coplanar(Plane plane_Other, double tolerance = Tolerance.Angle)
+        public bool Coplanar(Plane plane, double tolerance = Tolerance.Angle)
         {
-            return plane.Coplanar(plane_Other, tolerance);
+            return this.plane.Coplanar(plane, tolerance);
         }
 
         public Face3D GetFace3D()

--- a/SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs
+++ b/SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs
@@ -232,9 +232,9 @@ namespace SAM.Analytical
             return Coplanar(planarBoundary3D.plane, tolerance);
         }
 
-        public bool Coplanar(Plane plane, double tolerance = Tolerance.Angle)
+        public bool Coplanar(Plane plane_Other, double tolerance = Tolerance.Angle)
         {
-            return plane.Coplanar(plane, tolerance);
+            return plane.Coplanar(plane_Other, tolerance);
         }
 
         public Face3D GetFace3D()

--- a/SAM/SAM.Tests/PlanarBoundary3DTests.cs
+++ b/SAM/SAM.Tests/PlanarBoundary3DTests.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using SAM.Analytical;
+using SAM.Geometry.Planar;
+using SAM.Geometry.Spatial;
+using Xunit;
+
+namespace SAM.Tests
+{
+    // Regression tests for PlanarBoundary3D.Coplanar(Plane, double). The
+    // second overload used to shadow the "plane" field with its "plane"
+    // parameter and compare that parameter against itself
+    // (return plane.Coplanar(plane, tolerance)), so it always returned true
+    // regardless of the instance's own plane. Query.IsValid (the guard used
+    // by Panel.AddAperture / AddApertures) relies on this method as a cheap
+    // coplanarity check before the more expensive Face3D.Inside containment
+    // test, so the bug silently disabled that guard everywhere.
+    public class PlanarBoundary3DTests
+    {
+        private static PlanarBoundary3D UnitSquareBoundary(Plane plane)
+        {
+            Face3D face3D = new Face3D(plane, new Rectangle2D(1, 1));
+            return new PlanarBoundary3D(face3D);
+        }
+
+        [Fact]
+        public void Coplanar_SamePlane_ReturnsTrue()
+        {
+            Plane plane = new Plane(new Point3D(0, 0, 0), new Vector3D(0, 0, 1));
+
+            PlanarBoundary3D planarBoundary3D_1 = UnitSquareBoundary(plane);
+            PlanarBoundary3D planarBoundary3D_2 = UnitSquareBoundary(plane);
+
+            Assert.True(planarBoundary3D_1.Coplanar(planarBoundary3D_2));
+            Assert.True(planarBoundary3D_1.Coplanar(plane));
+        }
+
+        [Fact]
+        public void Coplanar_ParallelOffsetPlanes_ReturnsTrue()
+        {
+            // Plane.Coplanar (SAM.Geometry.Spatial.Plane.Coplanar) only compares
+            // normal direction and ignores the planes' offset/origin, so two
+            // parallel planes at different heights are still "coplanar" by that
+            // definition. PlanarBoundary3D.Coplanar must match that semantic
+            // rather than introduce its own offset check.
+            Plane plane_1 = new Plane(new Point3D(0, 0, 0), new Vector3D(0, 0, 1));
+            Plane plane_2 = new Plane(new Point3D(0, 0, 5), new Vector3D(0, 0, 1));
+
+            PlanarBoundary3D planarBoundary3D_1 = UnitSquareBoundary(plane_1);
+            PlanarBoundary3D planarBoundary3D_2 = UnitSquareBoundary(plane_2);
+
+            Assert.True(planarBoundary3D_1.Coplanar(planarBoundary3D_2));
+            Assert.True(planarBoundary3D_1.Coplanar(plane_2));
+        }
+
+        [Fact]
+        public void Coplanar_PerpendicularPlanes_ReturnsFalse()
+        {
+            Plane plane_1 = new Plane(new Point3D(0, 0, 0), new Vector3D(0, 0, 1));
+            Plane plane_2 = new Plane(new Point3D(0, 0, 0), new Vector3D(1, 0, 0));
+
+            PlanarBoundary3D planarBoundary3D_1 = UnitSquareBoundary(plane_1);
+            PlanarBoundary3D planarBoundary3D_2 = UnitSquareBoundary(plane_2);
+
+            Assert.False(planarBoundary3D_1.Coplanar(planarBoundary3D_2));
+            Assert.False(planarBoundary3D_1.Coplanar(plane_2));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`PlanarBoundary3D.Coplanar(Plane, double)` (`SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs`) had a parameter named `plane` that shadowed the instance field of the same name:

```csharp
public bool Coplanar(Plane plane, double tolerance = Tolerance.Angle)
{
    return plane.Coplanar(plane, tolerance);   // compares the argument to itself - always true
}
```

Renamed the parameter to `plane_Other` and fixed the body to `return this.plane.Coplanar(plane_Other, tolerance);`, so it actually compares the boundary's own plane against the one passed in.

## Behavior change (please review before merging)
This guard is the coplanarity check inside `Query.IsValid` (`Panel.AddAperture`'s validity check, and the `AddApertures` family). Previously it was a silent no-op, so aperture validity rested entirely on the `Face3D.Inside(InternalPoint3D)` containment test. After this fix, apertures whose plane is not actually coplanar with their host panel's plane (within tolerance) will now be correctly rejected.

**Tolerance-semantics note (flagged, not changed):** `Plane.Coplanar(Plane, tolerance)` treats `tolerance` as a per-component tolerance on unit-normal-vector comparison (`AlmostEqual`), i.e. a distance-style tolerance, and defaults to `Tolerance.Distance` (1e-6). `PlanarBoundary3D.Coplanar` instead defaults to `Tolerance.Angle` (~0.035 rad), passed straight through as that same per-component tolerance rather than converted to an angle-equivalent. This is a much looser guard than `Plane.Coplanar`'s own default and is plausibly intentional, but it isn't semantically an angle - left as-is pending confirmation.

## Verification
- [x] Full `SAM.Analytical` + `SAM.Tests` build clean (Release).
- [x] New tests in `PlanarBoundary3DTests.cs`: coplanar pair -> true; parallel-but-offset planes (matches `Plane.Coplanar`'s own semantic of ignoring offset) -> true; perpendicular planes -> false.
- [x] Full `SAM.Tests` suite: 113/113 passed, 0 regressions - no existing test relied on the old always-true behavior.
- [ ] **Not yet done:** a real-model regression check (like the live Grasshopper test done for #33) - recommended before merge, since this is the one PR of the three with actual behavioral risk.

## Merge order (see companion PRs)
Independent of [#33](https://github.com/SAM-BIM/SAM/pull/33) (perf) and the companion `Difference.cs` fix PR - no shared files. Recommended order:
1. **fix(Geometry): use per-index polygon in parallel Polygon2D Difference** (companion PR) - clear-cut, lowest risk.
2. [#33 - perf(Analytical): AddAperturesByAperture 6.1min -> ~2.4s](https://github.com/SAM-BIM/SAM/pull/33) - already validated live in Grasshopper.
3. **This PR** - last, pending the real-model regression check above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)