### PR TITLE
fix: Week 1 - fix 11 input/output name mismatches across 7 GH components

### DIFF
--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByAperture.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByAperture.cs
@@ -316,7 +316,7 @@ namespace SAM.Analytical.Grasshopper
                         if (double.IsNaN(emissivity))
                         {
                             AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid emissivity for layer");
-                            return;
+                            continue;
                         }
 
                         hi = 3.6 + (4.1 * emissivity / 0.837);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByConstruction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByConstruction.cs
@@ -327,7 +327,7 @@ namespace SAM.Analytical.Grasshopper
                         if (double.IsNaN(emissivity))
                         {
                             AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid emissivity for layer");
-                            return;
+                            continue;
                         }
 
                         hi = 3.6 + (4.1 * emissivity / 0.837);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLayersByMaterials.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLayersByMaterials.cs
@@ -106,14 +106,14 @@ namespace SAM.Analytical.Grasshopper
                     if (material == null)
                     {
                         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                        return;
+                        continue;
                     }
 
                     double thickness = material.GetValue<double>(Core.MaterialParameter.DefaultThickness);
                     if (double.IsNaN(thickness))
                     {
                         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                        return;
+                        continue;
                     }
 
                     thicknesses.Add(thickness);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateIZAM.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateIZAM.cs
@@ -81,7 +81,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<IAirMovementObject> airMovementObjects = analyticalModel.AddAirMovementObjects();
 
-            index = Params.IndexOfOutputParam("analyticalModel");
+            index = Params.IndexOfOutputParam("_analyticalModel");
             if (index != -1)
             {
                 dataAccess.SetData(index, analyticalModel);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateTransparentMaterial.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateTransparentMaterial.cs
@@ -257,7 +257,7 @@ namespace SAM.Analytical.Grasshopper
             }
 
             bool isBlind = transparentMaterial.GetValue<bool>(TransparentMaterialParameter.IsBlind);
-            index = Params.IndexOfInputParam("ignoreThermalTransmittanceCalculations_");
+            index = Params.IndexOfInputParam("isBlind_");
             if (index != -1)
             {
                 bool value = true;

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetSpaces.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetSpaces.cs
@@ -145,7 +145,7 @@ namespace SAM.Analytical.Grasshopper
                 {
                     List<Space> spaces = adjacencyCluster.GetSpaces();
                     if (spaces == null || spaces.Count == 0)
-                        return;
+                        continue;
 
                     foreach (Space space in spaces)
                     {
@@ -234,7 +234,7 @@ namespace SAM.Analytical.Grasshopper
                 {
                     List<Space> spaces = adjacencyCluster.GetSpaces();
                     if (spaces == null || spaces.Count == 0)
-                        return;
+                        continue;
 
                     ProfileLibrary profileLibrary = analyticalModel.ProfileLibrary;
 
@@ -281,7 +281,7 @@ namespace SAM.Analytical.Grasshopper
                     List<Space> spaces = adjacencyCluster.GetSpaces();
                     if (spaces == null || spaces.Count == 0)
                     {
-                        return;
+                        continue;
                     }
 
                     Space space = spaces.Find(x => x != null && x.Name == (string)@object);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyInternalConditionByProfile.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyInternalConditionByProfile.cs
@@ -122,7 +122,7 @@ namespace SAM.Analytical.Grasshopper
                 if (profile is null || profile.ProfileType == ProfileType.Undefined)
                 {
                     AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, string.Format("Invalid ProfileType: {0}", profile?.Name ?? "???"));
-                    return;
+                    continue;
                 }
 
                 profileLibrary.Add(profile);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyVentilationProfileByFunction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyVentilationProfileByFunction.cs
@@ -297,7 +297,7 @@ namespace SAM.Analytical.Grasshopper
             }
 
             List<double> setbacks = new List<double>();
-            index = Params.IndexOfInputParam("_setback_");
+            index = Params.IndexOfInputParam("_setbacks_");
             if (index != -1)
             {
                 if (!dataAccess.GetDataList(index, setbacks))

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemoveFromConstructionManager.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemoveFromConstructionManager.cs
@@ -105,7 +105,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<Construction> constructions = null;
 
-            index = Params.IndexOfInputParam("_constructions");
+            index = Params.IndexOfInputParam("constructions_");
             analyticalObjects = new List<IAnalyticalObject>();
             if (index != -1 && dataAccess.GetDataList(index, analyticalObjects) && analyticalObjects != null)
             {
@@ -129,7 +129,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<ApertureConstruction> apertureConstructions = null;
 
-            index = Params.IndexOfInputParam("_apertureConstructions");
+            index = Params.IndexOfInputParam("apertureConstructions_");
             analyticalObjects = new List<IAnalyticalObject>();
             if (index != -1 && dataAccess.GetDataList(index, analyticalObjects) && analyticalObjects != null)
             {
@@ -153,7 +153,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<IMaterial> materials = null;
 
-            index = Params.IndexOfInputParam("_materials");
+            index = Params.IndexOfInputParam("materials_");
             List<ISAMObject> sAMObjects = new List<ISAMObject>();
             if (index != -1 && dataAccess.GetDataList(index, sAMObjects) && sAMObjects != null)
             {

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetAirflow.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetAirflow.cs
@@ -154,7 +154,7 @@ namespace SAM.Analytical.Grasshopper
                 dataAccess.GetData(index, ref airflow_LpS);
 
             List<Space> spaces = new List<Space>();
-            index = Params.IndexOfInputParam("_spaces");
+            index = Params.IndexOfInputParam("_spaces_");
             if (index != -1)
                 dataAccess.GetDataList(index, spaces);
 

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetDefaultApertureConstruction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetDefaultApertureConstruction.cs
@@ -74,7 +74,7 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            index = Params.IndexOfInputParam("apertures_");
+            index = Params.IndexOfInputParam("_apertures_");
             List<Aperture> apertures = new List<Aperture>();
             if (index != -1)
                 dataAccess.GetDataList(index, apertures);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetDefaultApertureConstructionLayers.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetDefaultApertureConstructionLayers.cs
@@ -74,7 +74,7 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            index = Params.IndexOfInputParam("apertures_");
+            index = Params.IndexOfInputParam("_apertures_");
             List<Aperture> apertures = new List<Aperture>();
             if (index != -1)
                 dataAccess.GetDataList(index, apertures);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateConstructionManager.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateConstructionManager.cs
@@ -105,7 +105,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<Construction> constructions = null;
 
-            index = Params.IndexOfInputParam("_constructions");
+            index = Params.IndexOfInputParam("constructions_");
             analyticalObjects = new List<IAnalyticalObject>();
             if (index != -1 && dataAccess.GetDataList(index, analyticalObjects) && analyticalObjects != null)
             {
@@ -129,7 +129,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<ApertureConstruction> apertureConstructions = null;
 
-            index = Params.IndexOfInputParam("_apertureConstructions");
+            index = Params.IndexOfInputParam("apertureConstructions_");
             analyticalObjects = new List<IAnalyticalObject>();
             if (index != -1 && dataAccess.GetDataList(index, analyticalObjects) && analyticalObjects != null)
             {
@@ -153,7 +153,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<IMaterial> materials = null;
 
-            index = Params.IndexOfInputParam("_materials");
+            index = Params.IndexOfInputParam("materials_");
             List<ISAMObject> sAMObjects = new List<ISAMObject>();
             if (index != -1 && dataAccess.GetDataList(index, sAMObjects) && sAMObjects != null)
             {

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryCreateShellsByTopAndBottom.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryCreateShellsByTopAndBottom.cs
@@ -236,7 +236,7 @@ namespace SAM.Geometry.Grasshopper
 
             List<Shell> shells = Spatial.Create.Shells_ByTopAndBottom(face3Ds, tolerance);
 
-            index = Params.IndexOfInputParam("shells");
+            index = Params.IndexOfOutputParam("shells");
             if (index != -1)
                 dataAccess.SetDataList(index, shells?.ConvertAll(x => new GooSAMGeometry(x)));
         }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryShellContains.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryShellContains.cs
@@ -153,7 +153,7 @@ namespace SAM.Geometry.Grasshopper
                     silverSpacing = silverSpacing_Temp;
             }
 
-            index = Params.IndexOfInputParam("silverSpacing_");
+            index = Params.IndexOfInputParam("allowOnBoundary_");
             bool allowOnBoundary = true;
             if (index != -1)
             {


### PR DESCRIPTION
Fixes 24 P0 bugs across 15 files in the SAM core Grasshopper components.

### Week 1 (name mismatches) -- Commit 1
| File | Bug | Before | After |
|------|-----|--------|-------|
| RemoveFromConstructionManager | 3 input lookups | \_constructions\, \_apertureConstructions\, \_materials\ | \constructions_\, \pertureConstructions_\, \materials_\ |
| UpdateConstructionManager | 3 input lookups | same as above | same fix |
| SetDefaultApertureConstruction | apertures filter | \pertures_\ | \_apertures_\ |
| SetDefaultApertureConstructionLayers | apertures filter | \pertures_\ | \_apertures_\ |
| SetAirflow | spaces filter | \_spaces\ | \_spaces_\ |
| CreateIZAM | output lookup | \nalyticalModel\ | \_analyticalModel\ |
| CreateTransparentMaterial | isBlind input | \ignoreThermalTransmittanceCalculations_\ | \isBlind_\ |

### Week 1 extended (return-vs-continue + more mismatches) -- Commit 2
| File | Bug | Fix |
|------|-----|-----|
| GetSpaces | 3 return exits entire SolveInstance | \eturn\ -> \continue\ |
| ModifyInternalConditionByProfile | return on Undefined profile | \eturn\ -> \continue\ |
| CalculateGlazingValueByAperture | return on NaN emissivity in inner loop | \eturn\ -> \continue\ |
| CalculateGlazingValueByConstruction | same pattern | \eturn\ -> \continue\ |
| CreateConstructionLayersByMaterials | 2 returns on null material/NaN thickness | \eturn\ -> \continue\ |
| ModifyVentilationProfileByFunction | setback name | \_setback_\ -> \_setbacks_\ |
| ShellContains | wrong param looked up twice | \silverSpacing_\ -> \llowOnBoundary_\ |
| CreateShellsByTopAndBottom | input vs output param | \IndexOfInputParam\ -> \IndexOfOutputParam\ |

### Also see: SAM-BIM/SAM_Systems#10 (2 additional System bugs)

### Build
SAM.Analytical.Grasshopper.dll and SAM.Geometry.Grasshopper.dll compile cleanly.