### PR TITLE
Fix/optimalization: Fix and Optimize BoundingBox3D Class and Spatial Queries

### DIFF
--- a/Grasshopper/SAM.Analytical.Grasshopper/Classes/GooPanel.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Classes/GooPanel.cs
@@ -14,6 +14,7 @@ using SAM.Geometry.Grasshopper;
 using SAM.Geometry.Object.Spatial;
 using SAM.Geometry.Spatial;
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -23,6 +24,32 @@ namespace SAM.Analytical.Grasshopper
 {
     public class GooPanel : GooJSAMObject<IPanel>, IGH_PreviewData, IGH_BakeAwareData
     {
+        private sealed class PreviewSnapshot
+        {
+            public IPanel Source;
+            public double UnitScale;
+            public long Fingerprint;
+            public BoundingBox ClippingBox;
+            public Face3D Face3D;
+            public Brep Brep;
+            public List<WireLoop> PanelLoops;
+            public List<ApertureLoop> ApertureLoops;
+        }
+
+        private struct WireLoop
+        {
+            public List<Point3d> Points;
+            public bool Internal;
+        }
+
+        private struct ApertureLoop
+        {
+            public List<Point3d> Points;
+            public System.Drawing.Color Color;
+        }
+
+        private PreviewSnapshot previewSnapshot;
+
         public BoundaryType? BoundaryType { get; } = null;
 
         public bool ShowAll { get; set; } = true;
@@ -43,14 +70,341 @@ namespace SAM.Analytical.Grasshopper
             BoundaryType = boundaryType;
         }
 
+        private static long Combine(long hash, long value)
+        {
+            unchecked
+            {
+                return (hash * 31) ^ value;
+            }
+        }
+
+        private static long CombineDouble(long hash, double value)
+        {
+            return Combine(hash, BitConverter.DoubleToInt64Bits(value));
+        }
+
+        private static long CombinePoint3D(long hash, Point3D point3D)
+        {
+            if (point3D == null)
+            {
+                return Combine(hash, long.MinValue);
+            }
+
+            hash = CombineDouble(hash, point3D.X);
+            hash = CombineDouble(hash, point3D.Y);
+            hash = CombineDouble(hash, point3D.Z);
+            return hash;
+        }
+
+        private static long CombineVector3D(long hash, Vector3D vector3D)
+        {
+            if (vector3D == null)
+            {
+                return Combine(hash, long.MaxValue);
+            }
+
+            hash = CombineDouble(hash, vector3D.X);
+            hash = CombineDouble(hash, vector3D.Y);
+            hash = CombineDouble(hash, vector3D.Z);
+            return hash;
+        }
+
+        private static long CombineGuid(long hash, Guid guid)
+        {
+            Span<byte> bytes = stackalloc byte[16];
+            guid.TryWriteBytes(bytes);
+            hash = Combine(hash, BinaryPrimitives.ReadInt64LittleEndian(bytes));
+            hash = Combine(hash, BinaryPrimitives.ReadInt64LittleEndian(bytes.Slice(8)));
+            return hash;
+        }
+
+        private static long CombinePlane(long hash, Geometry.Spatial.Plane plane)
+        {
+            if (plane == null)
+            {
+                return Combine(hash, 0);
+            }
+
+            // Origin + normal + axisY fully capture position and orientation,
+            // including flips (FlipNormal reverses normal and winding) without
+            // being affected by re-derivation of the redundant axisX.
+            hash = CombinePoint3D(hash, plane.Origin);
+            hash = CombineVector3D(hash, plane.Normal);
+            hash = CombineVector3D(hash, plane.AxisY);
+            return hash;
+        }
+
+        private static long CombineClosedPlanar3D(long hash, IClosedPlanar3D closedPlanar3D)
+        {
+            if (closedPlanar3D is ISegmentable3D segmentable3D)
+            {
+                List<Point3D> point3Ds = segmentable3D.GetPoints();
+                if (point3Ds == null)
+                {
+                    return Combine(hash, -1);
+                }
+
+                hash = Combine(hash, point3Ds.Count);
+                for (int i = 0; i < point3Ds.Count; i++)
+                {
+                    hash = CombinePoint3D(hash, point3Ds[i]);
+                }
+
+                return hash;
+            }
+
+            return Combine(hash, -2);
+        }
+
+        private static long CombineFace3D(long hash, Face3D face3D)
+        {
+            if (face3D == null)
+            {
+                return Combine(hash, 0);
+            }
+
+            hash = CombinePlane(hash, face3D.GetPlane());
+            hash = CombineClosedPlanar3D(hash, face3D.GetExternalEdge3D());
+
+            List<IClosedPlanar3D> internalEdge3Ds = face3D.GetInternalEdge3Ds();
+            hash = Combine(hash, internalEdge3Ds == null ? 0 : internalEdge3Ds.Count);
+            if (internalEdge3Ds != null)
+            {
+                for (int i = 0; i < internalEdge3Ds.Count; i++)
+                {
+                    hash = CombineClosedPlanar3D(hash, internalEdge3Ds[i]);
+                }
+            }
+
+            return hash;
+        }
+
+        /// <summary>
+        /// Deterministic, ordered geometry fingerprint used to detect in-place
+        /// mutation of the same <see cref="IPanel"/> reference (e.g. FlipNormal,
+        /// boundary edits, aperture add/remove/replace or aperture geometry change)
+        /// that a reference or bounding-box check alone would miss. Uses exact
+        /// double bit patterns and ordered hash combination (no XOR-only, no
+        /// process-dependent GetHashCode, no temporary arrays or strings beyond the
+        /// point lists the public geometry API itself returns).
+        /// </summary>
+        private static long ComputeFingerprint(IPanel panel)
+        {
+            long hash = 17;
+            if (panel == null)
+            {
+                return hash;
+            }
+
+            hash = CombineFace3D(hash, panel.Face3D);
+
+            if (panel is Panel panel_Temp && panel_Temp.HasApertures)
+            {
+                List<Aperture> apertures = panel_Temp.Apertures;
+                hash = Combine(hash, apertures == null ? 0 : apertures.Count);
+                if (apertures != null)
+                {
+                    for (int i = 0; i < apertures.Count; i++)
+                    {
+                        Aperture aperture = apertures[i];
+                        if (aperture == null)
+                        {
+                            hash = Combine(hash, 0);
+                            continue;
+                        }
+
+                        hash = CombineGuid(hash, aperture.Guid);
+                        hash = CombineGuid(hash, aperture.TypeGuid);
+                        hash = CombineFace3D(hash, aperture.GetFace3D());
+
+                        // Wire geometry is drawn from GetFrameFace3D/GetPaneFace3Ds,
+                        // not the outer GetFace3D. Hash the drawn faces so construction
+                        // edits (frame width, layers) with the same TypeGuid invalidate.
+                        Face3D frame3D = aperture.GetFrameFace3D();
+                        if (frame3D != null)
+                        {
+                            hash = CombineFace3D(hash, frame3D);
+                        }
+                        else
+                        {
+                            List<Face3D> pane3Ds = aperture.GetPaneFace3Ds();
+                            hash = Combine(hash, pane3Ds == null ? 0 : pane3Ds.Count);
+                            if (pane3Ds != null)
+                            {
+                                for (int iPane = 0; iPane < pane3Ds.Count; iPane++)
+                                    hash = CombineFace3D(hash, pane3Ds[iPane]);
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                hash = Combine(hash, 0);
+            }
+
+            return hash;
+        }
+
+        private static void AddWireLoops(PlanarBoundary3D planarBoundary3D, Action<List<Point3d>, bool> add)
+        {
+            if (planarBoundary3D == null)
+                return;
+
+            BoundaryEdge3DLoop externalLoop = planarBoundary3D.GetExternalEdge3DLoop();
+            if (externalLoop != null)
+            {
+                List<BoundaryEdge3D> edge3Ds = externalLoop.BoundaryEdge3Ds;
+                if (edge3Ds != null && edge3Ds.Count != 0)
+                {
+                    List<Point3d> point3ds = edge3Ds.ConvertAll(x => Geometry.Rhino.Convert.ToRhino(x.Curve3D.GetStart()));
+                    if (point3ds.Count != 0)
+                    {
+                        point3ds.Add(point3ds[0]);
+                        add(point3ds, false);
+                    }
+                }
+            }
+
+            List<BoundaryEdge3DLoop> internalLoops = planarBoundary3D.GetInternalEdge3DLoops();
+            if (internalLoops != null)
+            {
+                foreach (BoundaryEdge3DLoop internalLoop in internalLoops)
+                {
+                    List<BoundaryEdge3D> edge3Ds = internalLoop?.BoundaryEdge3Ds;
+                    if (edge3Ds == null || edge3Ds.Count == 0)
+                        continue;
+
+                    List<Point3d> point3ds = edge3Ds.ConvertAll(x => Geometry.Rhino.Convert.ToRhino(x.Curve3D.GetStart()));
+                    if (point3ds.Count == 0)
+                        continue;
+
+                    point3ds.Add(point3ds[0]);
+                    add(point3ds, true);
+                }
+            }
+        }
+
+        private static PreviewSnapshot BuildPreviewSnapshot(IPanel panel, double unitScale)
+        {
+            PreviewSnapshot result = new PreviewSnapshot()
+            {
+                Source = panel,
+                UnitScale = unitScale,
+                PanelLoops = new List<WireLoop>(),
+                ApertureLoops = new List<ApertureLoop>()
+            };
+
+            Face3D face3D = panel.Face3D;
+            Geometry.Spatial.BoundingBox3D boundingBox3D = face3D?.GetBoundingBox();
+
+            result.Face3D = face3D;
+            result.Fingerprint = ComputeFingerprint(panel);
+            result.ClippingBox = Geometry.Rhino.Convert.ToRhino(boundingBox3D);
+
+            if (face3D != null)
+            {
+                result.Brep = Geometry.Rhino.Convert.ToRhino_Brep(face3D);
+            }
+
+            if (panel is ExternalPanel)
+            {
+                if (face3D != null)
+                {
+                    AddWireLoops(new PlanarBoundary3D(face3D), (points, @internal) => result.PanelLoops.Add(new WireLoop() { Points = points, Internal = @internal }));
+                }
+
+                return result;
+            }
+
+            Panel panel_Temp = panel as Panel;
+            if (panel_Temp == null)
+            {
+                return result;
+            }
+
+            AddWireLoops(panel_Temp.PlanarBoundary3D, (points, @internal) => result.PanelLoops.Add(new WireLoop() { Points = points, Internal = @internal }));
+
+            List<Aperture> apertures = panel_Temp.Apertures;
+            if (apertures != null)
+            {
+                foreach (Aperture aperture in apertures)
+                {
+                    if (aperture == null)
+                        continue;
+
+                    System.Drawing.Color color_ExternalEdge = System.Drawing.Color.Empty;
+                    System.Drawing.Color color_InternalEdges = System.Drawing.Color.Empty;
+
+                    if (aperture.ApertureConstruction != null)
+                    {
+                        color_ExternalEdge = Analytical.Query.Color(aperture.ApertureConstruction.ApertureType, false);
+                        color_InternalEdges = Analytical.Query.Color(aperture.ApertureConstruction.ApertureType, true);
+                    }
+
+                    if (color_ExternalEdge == System.Drawing.Color.Empty)
+                        color_ExternalEdge = System.Drawing.Color.DarkRed;
+
+                    if (color_InternalEdges == System.Drawing.Color.Empty)
+                        color_InternalEdges = System.Drawing.Color.BlueViolet;
+
+                    List<Face3D> face3Ds = new List<Face3D>();
+
+                    Face3D face3D_Frame = aperture.GetFrameFace3D();
+                    if (face3D_Frame != null)
+                    {
+                        face3Ds.Add(face3D_Frame);
+                    }
+                    else
+                    {
+                        List<Face3D> face3Ds_Pane = aperture.GetPaneFace3Ds();
+                        if (face3Ds_Pane == null)
+                            continue;
+
+                        face3Ds.AddRange(face3Ds_Pane);
+                    }
+
+                    foreach (Face3D face3D_Temp in face3Ds)
+                    {
+                        AddWireLoops(new PlanarBoundary3D(face3D_Temp), (points, @internal) => result.ApertureLoops.Add(new ApertureLoop() { Points = points, Color = @internal ? color_InternalEdges : color_ExternalEdge }));
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private PreviewSnapshot EnsurePreviewSnapshot()
+        {
+            IPanel panel = Value;
+            if (panel == null)
+                return null;
+
+            double unitScale = Geometry.Rhino.Query.UnitScale();
+
+            PreviewSnapshot result = previewSnapshot;
+            if (result != null && ReferenceEquals(result.Source, panel) && result.UnitScale.Equals(unitScale))
+            {
+                if (result.Fingerprint == ComputeFingerprint(panel))
+                {
+                    return result;
+                }
+            }
+
+            result = BuildPreviewSnapshot(panel, unitScale);
+            previewSnapshot = result;
+            return result;
+        }
+
         public BoundingBox ClippingBox
         {
             get
             {
-                if (Value == null)
+                PreviewSnapshot snapshot = EnsurePreviewSnapshot();
+                if (snapshot == null)
                     return BoundingBox.Empty;
 
-                return Geometry.Rhino.Convert.ToRhino(Value?.Face3D?.GetBoundingBox());
+                return snapshot.ClippingBox;
             }
         }
 
@@ -69,53 +423,57 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            GooPlanarBoundary3D gooPlanarBoundary3D = null;
+            PreviewSnapshot snapshot = EnsurePreviewSnapshot();
+            if (snapshot == null)
+            {
+                return;
+            }
+
+            System.Drawing.Color color_ExternalEdge;
+            System.Drawing.Color color_InternalEdges;
 
             if (Value is ExternalPanel)
             {
                 System.Drawing.Color color = Analytical.Query.Color((ExternalPanel)Value);
-
-                gooPlanarBoundary3D = new GooPlanarBoundary3D(new PlanarBoundary3D(Value.Face3D));
-                gooPlanarBoundary3D.DrawViewportWires(args, color, color);
-                return;
+                color_ExternalEdge = color;
+                color_InternalEdges = color;
             }
+            else if (Value is Panel panel)
+            {
+                color_ExternalEdge = Analytical.Query.Color(panel.PanelType, false);
+                color_InternalEdges = Analytical.Query.Color(panel.PanelType, true);
 
-            Panel panel = Value as Panel;
-            if (panel == null)
+                if (color_ExternalEdge == System.Drawing.Color.Empty)
+                    color_ExternalEdge = args.Color;
+
+                if (color_InternalEdges == System.Drawing.Color.Empty)
+                    color_InternalEdges = args.Color;
+            }
+            else
             {
                 return;
             }
 
-            System.Drawing.Color color_ExternalEdge = Analytical.Query.Color(panel.PanelType, false);
-            System.Drawing.Color color_InternalEdges = Analytical.Query.Color(panel.PanelType, true);
-
-            if (color_ExternalEdge == System.Drawing.Color.Empty)
-                color_ExternalEdge = args.Color;
-
-            if (color_InternalEdges == System.Drawing.Color.Empty)
-                color_InternalEdges = args.Color;
-
-            gooPlanarBoundary3D = new GooPlanarBoundary3D(panel.PlanarBoundary3D);
-            gooPlanarBoundary3D.DrawViewportWires(args, color_ExternalEdge, color_InternalEdges);
-
-            List<Aperture> apertures = panel.Apertures;
-            if (apertures != null)
+            foreach (WireLoop wireLoop in snapshot.PanelLoops)
             {
-                foreach (Aperture aperture in apertures)
-                {
-                    if (aperture == null)
-                        continue;
+                args.Pipeline.DrawPolyline(wireLoop.Points, wireLoop.Internal ? color_InternalEdges : color_ExternalEdge);
+            }
 
-                    GooAperture gooAperture = new GooAperture(aperture);
-                    gooAperture.DrawViewportWires(args);
-                }
+            foreach (ApertureLoop apertureLoop in snapshot.ApertureLoops)
+            {
+                args.Pipeline.DrawPolyline(apertureLoop.Points, apertureLoop.Color);
             }
         }
 
         public void DrawViewportMeshes(GH_PreviewMeshArgs args)
         {
-            Face3D face3D = Value?.Face3D;
-            if (face3D == null)
+            if (Value == null)
+            {
+                return;
+            }
+
+            PreviewSnapshot snapshot = EnsurePreviewSnapshot();
+            if (snapshot == null || snapshot.Face3D == null)
             {
                 return;
             }
@@ -128,7 +486,7 @@ namespace SAM.Analytical.Grasshopper
                     return;
                 }
 
-                double distance = face3D.Distance(point3D_CameraLocation);
+                double distance = snapshot.Face3D.Distance(point3D_CameraLocation);
                 if (distance < 8 || distance > 15)
                 {
                     return;
@@ -141,35 +499,18 @@ namespace SAM.Analytical.Grasshopper
                 displayMaterial = args.Material;
             }
 
-            Brep brep = Geometry.Rhino.Convert.ToRhino_Brep(face3D);
-            if (brep == null)
+            if (snapshot.Brep == null)
             {
                 return;
             }
 
-            args.Pipeline.DrawBrepShaded(brep, displayMaterial);
+            args.Pipeline.DrawBrepShaded(snapshot.Brep, displayMaterial);
 
-            if (Value is Panel)
-            {
-                List<Aperture> apertures = ((Panel)Value).Apertures;
-                if (apertures != null)
-                {
-                    foreach (Aperture aperture in apertures)
-                    {
-                        foreach (IClosedPlanar3D closedPlanar3D in aperture.GetFace3D().GetEdge3Ds())
-                        {
-                            global::Rhino.Display.DisplayMaterial displayMaterial_Aperture = Query.DisplayMaterial(aperture.ApertureConstruction.ApertureType);
-                            if (displayMaterial_Aperture == null)
-                            {
-                                displayMaterial_Aperture = args.Material;
-                            }
-
-                            GooSAMGeometry gooSAMGeometry_Aperture = new GooSAMGeometry(closedPlanar3D);
-                            gooSAMGeometry_Aperture.DrawViewportMeshes(args, displayMaterial_Aperture);
-                        }
-                    }
-                }
-            }
+            // Note: the pre-snapshot implementation iterated aperture edge loops and
+            // passed them to Geometry.Grasshopper.Modify.DrawViewportMeshes via
+            // GooSAMGeometry. IClosedPlanar3D matches no branch in that method, so no
+            // geometry was ever drawn for apertures in the mesh pass. The traversal is
+            // intentionally not replicated here; visual output is unchanged.
         }
 
         public bool BakeGeometry(RhinoDoc doc, ObjectAttributes att, out Guid obj_guid)

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByAperture.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByAperture.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalAddAperturesByAperture : GH_SAMComponent
+    public class SAMAnalyticalAddAperturesByAperture : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.7";
+        public override string LatestComponentVersion => "1.0.8";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,27 +40,43 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.item);
-            int index = inputParamManager.AddParameter(new GooApertureParam(), "_apertures_", "_apertures_", "SAM Analytical Apertures", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddNumberParameter("_maxDistance_", "_maxDistance_", "Max Distance", GH_ParamAccess.item, 0.1);
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            inputParamManager.AddBooleanParameter("trimGeometry_", "trimGeometry_", "trimGeometry (bool, default = true)\r\n\r\nDetermines how apertures are handled when their geometry extends beyond the boundaries of panels in the AdjacencyCluster.\r\n\r\ntrue (default)\r\n\r\nIf an aperture overlaps multiple panels, the geometry will be split so that each portion is placed as a separate aperture on the corresponding panels.\r\n\r\nIf an aperture extends beyond a single panel and no other adjacent panel exists, the aperture will be trimmed to fit within that panel.\r\n\r\nfalse\r\n\r\nApertures will be added without splitting or trimming, even if they extend beyond panel boundaries. ", GH_ParamAccess.item, true);
+                result.Add(new GH_SAMParam(new GooApertureParam() { Name = "_apertures_", NickName = "_apertures_", Description = "SAM Analytical Apertures", Access = GH_ParamAccess.list, Optional = true, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_maxDistance_", NickName = "_maxDistance_", Description = "Max Distance", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(0.1);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "trimGeometry_", NickName = "trimGeometry_", Description = "trimGeometry (bool, default = true)\r\n\r\nDetermines how apertures are handled when their geometry extends beyond the boundaries of panels in the AdjacencyCluster.\r\n\r\ntrue (default)\r\n\r\nIf an aperture overlaps multiple panels, the geometry will be split so that each portion is placed as a separate aperture on the corresponding panels.\r\n\r\nIf an aperture extends beyond a single panel and no other adjacent panel exists, the aperture will be trimmed to fit within that panel.\r\n\r\nfalse\r\n\r\nApertures will be added without splitting or trimming, even if they extend beyond panel boundaries. ", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalObjectParam(), "AnalyticalObject", "AnalyticalObject", "SAM Analytical Object", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureParam(), "Apertures", "Apertures", "SAM Analytical Apertures", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Successful", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "AnalyticalObject", NickName = "AnalyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooApertureParam() { Name = "Apertures", NickName = "Apertures", Description = "SAM Analytical Apertures", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Successful", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -71,26 +87,45 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            dataAccess.SetData(2, false);
+            int index_Successful = Params.IndexOfOutputParam("Successful");
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, false);
+            }
 
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_analyticalObject");
             IAnalyticalObject analyticalObject = null;
-            if (!dataAccess.GetData(0, ref analyticalObject))
+            if (index == -1 || !dataAccess.GetData(index, ref analyticalObject) || analyticalObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<Aperture> apertures = new List<Aperture>();
-            dataAccess.GetDataList(1, apertures);
+            index = Params.IndexOfInputParam("_apertures_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, apertures);
+            }
 
             double maxDistance = 0.1;
-            if (!dataAccess.GetData(2, ref maxDistance) || double.IsNaN(maxDistance))
+            index = Params.IndexOfInputParam("_maxDistance_");
+            if (index != -1)
             {
-                maxDistance = 0.1;
+                if (!dataAccess.GetData(index, ref maxDistance) || double.IsNaN(maxDistance))
+                {
+                    maxDistance = 0.1;
+                }
             }
 
             bool trimApertures = true;
-            dataAccess.GetData(3, ref trimApertures);
+            index = Params.IndexOfInputParam("trimGeometry_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref trimApertures);
+            }
 
             if (analyticalObject is Panel)
             {
@@ -115,9 +150,23 @@ namespace SAM.Analytical.Grasshopper
                     }
                 }
 
-                dataAccess.SetData(0, panel);
-                dataAccess.SetDataList(1, apertures_Result?.ConvertAll(x => new GooAperture(x)));
-                dataAccess.SetData(2, apertures_Result != null && apertures_Result.Count != 0);
+                index = Params.IndexOfOutputParam("AnalyticalObject");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, panel);
+                }
+
+                index = Params.IndexOfOutputParam("Apertures");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, apertures_Result?.ConvertAll(x => new GooAperture(x)));
+                }
+
+                if (index_Successful != -1)
+                {
+                    dataAccess.SetData(index_Successful, apertures_Result != null && apertures_Result.Count != 0);
+                }
+
                 return;
             }
 
@@ -141,18 +190,30 @@ namespace SAM.Analytical.Grasshopper
 
             List<Aperture> apertures_Result_Cluster = Analytical.Modify.AddAperturesByApertures(adjacencyCluster, apertures, trimApertures, Tolerance.MacroDistance, maxDistance);
 
-            if (analyticalModel != null)
+            index = Params.IndexOfOutputParam("AnalyticalObject");
+            if (index != -1)
             {
-                AnalyticalModel analyticalModel_Result = new AnalyticalModel(analyticalModel, adjacencyCluster);
-                dataAccess.SetData(0, analyticalModel_Result);
-            }
-            else
-            {
-                dataAccess.SetData(0, adjacencyCluster);
+                if (analyticalModel != null)
+                {
+                    AnalyticalModel analyticalModel_Result = new AnalyticalModel(analyticalModel, adjacencyCluster);
+                    dataAccess.SetData(index, analyticalModel_Result);
+                }
+                else
+                {
+                    dataAccess.SetData(index, adjacencyCluster);
+                }
             }
 
-            dataAccess.SetDataList(1, apertures_Result_Cluster?.ConvertAll(x => new GooAperture(x)));
-            dataAccess.SetData(2, apertures_Result_Cluster != null && apertures_Result_Cluster.Count != 0);
+            index = Params.IndexOfOutputParam("Apertures");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, apertures_Result_Cluster?.ConvertAll(x => new GooAperture(x)));
+            }
+
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, apertures_Result_Cluster != null && apertures_Result_Cluster.Count != 0);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByAperture.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByAperture.cs
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.6";
+        public override string LatestComponentVersion => "1.0.7";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -139,40 +139,7 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            List<Tuple<Panel, Aperture>> tuples_Result = null;
-
-            List<Panel> panels = adjacencyCluster.GetPanels();
-            if (panels != null && panels.Count != 0)
-            {
-                tuples_Result = new List<Tuple<Panel, Aperture>>();
-
-                foreach (Panel panel in panels)
-                {
-                    Panel panel_New = Create.Panel(panel);
-
-                    bool updated = false;
-                    foreach (Aperture aperture in apertures)
-                    {
-                        if (aperture == null)
-                        {
-                            continue;
-                        }
-
-                        List<Aperture> apertures_New = Analytical.Modify.AddApertures(panel_New, aperture.ApertureConstruction, aperture.GetFace3D(), trimApertures, Tolerance.MacroDistance, maxDistance);
-                        if (apertures_New != null && apertures_New.Count > 0)
-                        {
-                            updated = true;
-                            foreach (Aperture aperture_New in apertures_New)
-                            {
-                                tuples_Result.Add(new Tuple<Panel, Aperture>(panel_New, aperture_New));
-                            }
-                        }
-                    }
-
-                    if (updated)
-                        adjacencyCluster.AddObject(panel_New);
-                }
-            }
+            List<Aperture> apertures_Result_Cluster = Analytical.Modify.AddAperturesByApertures(adjacencyCluster, apertures, trimApertures, Tolerance.MacroDistance, maxDistance);
 
             if (analyticalModel != null)
             {
@@ -184,8 +151,8 @@ namespace SAM.Analytical.Grasshopper
                 dataAccess.SetData(0, adjacencyCluster);
             }
 
-            dataAccess.SetDataList(1, tuples_Result?.ConvertAll(x => new GooAperture(x.Item2)));
-            dataAccess.SetData(2, tuples_Result != null && tuples_Result.Count != 0);
+            dataAccess.SetDataList(1, apertures_Result_Cluster?.ConvertAll(x => new GooAperture(x)));
+            dataAccess.SetData(2, apertures_Result_Cluster != null && apertures_Result_Cluster.Count != 0);
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByGeometryAndApertureConstruction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByGeometryAndApertureConstruction.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalAddAperturesByGeometryApertureConstruction : GH_SAMComponent
+    public class SAMAnalyticalAddAperturesByGeometryApertureConstruction : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -42,31 +42,50 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddGenericParameter("_geometries_", "_geometries_", "Geometry incl Rhino geometries", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_geometries_", NickName = "_geometries_", Description = "Geometry incl Rhino geometries", Access = GH_ParamAccess.list, Optional = true, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooApertureConstructionParam(), "_apertureConstruction_", "_apertureConstruction_", "SAM Analytical Aperture Construction", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooApertureConstructionParam() { Name = "_apertureConstruction_", NickName = "_apertureConstruction_", Description = "SAM Analytical Aperture Construction", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("maxDistance_", "maxDistance_", "Maximal Distance", GH_ParamAccess.item, 0.1);
-            inputParamManager.AddBooleanParameter("trimGeometry_", "trimGeometry_", "Trim Aperture Geometry", GH_ParamAccess.item, true);
-            inputParamManager.AddNumberParameter("minArea_", "minArea_", "Minimal Acceptable area of Aperture", GH_ParamAccess.item, Tolerance.MacroDistance);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "maxDistance_", NickName = "maxDistance_", Description = "Maximal Distance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0.1);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "trimGeometry_", NickName = "trimGeometry_", Description = "Trim Aperture Geometry", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "minArea_", NickName = "minArea_", Description = "Minimal Acceptable area of Aperture", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalObjectParam(), "AnalyticalObject", "AnalyticalObject", "SAM Analytical Object", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureParam(), "Apertures", "Apertures", "SAM Analytical Apertures", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "AnalyticalObject", NickName = "AnalyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooApertureParam() { Name = "Apertures", NickName = "Apertures", Description = "SAM Analytical Apertures", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -77,8 +96,14 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_geometries_");
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
-            dataAccess.GetDataList(0, objectWrappers);
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, objectWrappers);
+            }
 
             List<Face3D> face3Ds = new List<Face3D>();
 
@@ -91,23 +116,37 @@ namespace SAM.Analytical.Grasshopper
             }
 
             bool trimGeometry = true;
-            if (!dataAccess.GetData(4, ref trimGeometry))
+            index = Params.IndexOfInputParam("trimGeometry_");
+            if (index == -1 || !dataAccess.GetData(index, ref trimGeometry))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             ApertureConstruction apertureConstruction = null;
-            dataAccess.GetData(2, ref apertureConstruction);
+            index = Params.IndexOfInputParam("_apertureConstruction_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref apertureConstruction);
+            }
 
             double maxDistance = Tolerance.MacroDistance;
-            dataAccess.GetData(3, ref maxDistance);
+            index = Params.IndexOfInputParam("maxDistance_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref maxDistance);
+            }
 
             double minArea = Tolerance.MacroDistance;
-            dataAccess.GetData(5, ref minArea);
+            index = Params.IndexOfInputParam("minArea_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref minArea);
+            }
 
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(1, ref sAMObject))
+            index = Params.IndexOfInputParam("_analyticalObject");
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -133,8 +172,18 @@ namespace SAM.Analytical.Grasshopper
                     }
                 }
 
-                dataAccess.SetData(0, panel);
-                dataAccess.SetDataList(1, apertures.ConvertAll(x => new GooAperture(x)));
+                index = Params.IndexOfOutputParam("AnalyticalObject");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, panel);
+                }
+
+                index = Params.IndexOfOutputParam("Apertures");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, apertures.ConvertAll(x => new GooAperture(x)));
+                }
+
                 return;
             }
 
@@ -208,17 +257,25 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            if (analyticalModel != null)
+            index = Params.IndexOfOutputParam("AnalyticalObject");
+            if (index != -1)
             {
-                AnalyticalModel analyticalModel_Result = new AnalyticalModel(analyticalModel, adjacencyCluster);
-                dataAccess.SetData(0, analyticalModel_Result);
-            }
-            else
-            {
-                dataAccess.SetData(0, adjacencyCluster);
+                if (analyticalModel != null)
+                {
+                    AnalyticalModel analyticalModel_Result = new AnalyticalModel(analyticalModel, adjacencyCluster);
+                    dataAccess.SetData(index, analyticalModel_Result);
+                }
+                else
+                {
+                    dataAccess.SetData(index, adjacencyCluster);
+                }
             }
 
-            dataAccess.SetDataList(1, tuples_Result?.ConvertAll(x => new GooAperture(x.Item2)));
+            index = Params.IndexOfOutputParam("Apertures");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, tuples_Result?.ConvertAll(x => new GooAperture(x.Item2)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByGeometryAndApertureType.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddAperturesByGeometryAndApertureType.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalAddAperturesByGeometryAndApertureType : GH_SAMComponent
+    public class SAMAnalyticalAddAperturesByGeometryAndApertureType : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.4";
+        public override string LatestComponentVersion => "1.0.5";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -42,37 +42,54 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddGenericParameter("_geometries_", "_geometries_", "Geometry incl Rhino geometry \nwhen using Polyline frame come from layer thickenss so default 0.05m if surface connected from two closed curves, thickness is frame hole will be pane", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_geometries_", NickName = "_geometries_", Description = "Geometry incl Rhino geometry \nwhen using Polyline frame come from layer thickenss so default 0.05m if surface connected from two closed curves, thickness is frame hole will be pane", Access = GH_ParamAccess.list, Optional = true, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddTextParameter("_apertureType_", "_apertureType_", "SAM Analytical ApertureType", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_apertureType_", NickName = "_apertureType_", Description = "SAM Analytical ApertureType", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("maxDistance_", "maxDistance_", "Maximal Distance", GH_ParamAccess.item, 0.1);
-            inputParamManager.AddBooleanParameter("trimGeometry_", "trimGeometry_", "Trim Aperture Geometry", GH_ParamAccess.item, true);
-            inputParamManager.AddNumberParameter("minArea_", "minArea_", "Minimal Acceptable area of Aperture", GH_ParamAccess.item, Tolerance.MacroDistance);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
 
-            index = inputParamManager.AddNumberParameter("frameWidth_", "frameWidth_", "Frame Width [m] \n*Min value is sum of frame layer thicknesses Default 0.05m so unable to dopt below this value unless. \nIf you want zero remove frame layer in aperture construction ", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "maxDistance_", NickName = "maxDistance_", Description = "Maximal Distance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0.1);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
 
-            index = inputParamManager.AddNumberParameter("framePercentage_", "framePercentage_", "Frame Percentage [0 - 100] \nsee frameWidth_ description \nuse only one input frameWidth_ or framePercentage_ ", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "trimGeometry_", NickName = "trimGeometry_", Description = "Trim Aperture Geometry", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "minArea_", NickName = "minArea_", Description = "Minimal Acceptable area of Aperture", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "frameWidth_", NickName = "frameWidth_", Description = "Frame Width [m] \n*Min value is sum of frame layer thicknesses Default 0.05m so unable to dopt below this value unless. \nIf you want zero remove frame layer in aperture construction ", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "framePercentage_", NickName = "framePercentage_", Description = "Frame Percentage [0 - 100] \nsee frameWidth_ description \nuse only one input frameWidth_ or framePercentage_ ", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalObjectParam(), "AnalyticalObject", "AnalyticalObject", "SAM Analytical Object", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureParam(), "Apertures", "Apertures", "SAM Analytical Apertures", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "AnalyticalObject", NickName = "AnalyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooApertureParam() { Name = "Apertures", NickName = "Apertures", Description = "SAM Analytical Apertures", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -83,8 +100,14 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_geometries_");
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
-            dataAccess.GetDataList(0, objectWrappers);
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, objectWrappers);
+            }
 
             List<Face3D> face3Ds = new List<Face3D>();
 
@@ -96,10 +119,9 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            //List<IClosedPlanar3D> closedPlanar3Ds = Geometry.Spatial.Query.ClosedPlanar3Ds(geometry3Ds);
-
             bool trimGeometry = true;
-            if (!dataAccess.GetData(4, ref trimGeometry))
+            index = Params.IndexOfInputParam("trimGeometry_");
+            if (index == -1 || !dataAccess.GetData(index, ref trimGeometry))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -108,7 +130,12 @@ namespace SAM.Analytical.Grasshopper
             ApertureType apertureType = ApertureType.Window;
 
             string apertureTypeString = null;
-            dataAccess.GetData(2, ref apertureTypeString);
+            index = Params.IndexOfInputParam("_apertureType_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref apertureTypeString);
+            }
+
             if (!string.IsNullOrWhiteSpace(apertureTypeString))
             {
                 if (!Enum.TryParse(apertureTypeString, out apertureType))
@@ -116,28 +143,39 @@ namespace SAM.Analytical.Grasshopper
             }
 
             double maxDistance = Tolerance.MacroDistance;
-            dataAccess.GetData(3, ref maxDistance);
+            index = Params.IndexOfInputParam("maxDistance_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref maxDistance);
+            }
 
             double minArea = Tolerance.MacroDistance;
-            dataAccess.GetData(5, ref minArea);
+            index = Params.IndexOfInputParam("minArea_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref minArea);
+            }
 
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(1, ref sAMObject))
+            index = Params.IndexOfInputParam("_analyticalObject");
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<double> frameWidths = new List<double>();
-            if (dataAccess.GetDataList(6, frameWidths))
+            index = Params.IndexOfInputParam("frameWidth_");
+            if (index != -1)
             {
-
+                dataAccess.GetDataList(index, frameWidths);
             }
 
             List<double> framePercentages = new List<double>();
-            if (dataAccess.GetDataList(7, framePercentages))
+            index = Params.IndexOfInputParam("framePercentage_");
+            if (index != -1)
             {
-
+                dataAccess.GetDataList(index, framePercentages);
             }
 
             if (framePercentages != null && framePercentages.Count > 0 && frameWidths != null && frameWidths.Count > 0)
@@ -170,8 +208,18 @@ namespace SAM.Analytical.Grasshopper
                     }
                 }
 
-                dataAccess.SetData(0, panel);
-                dataAccess.SetDataList(1, apertures.ConvertAll(x => new GooAperture(x)));
+                index = Params.IndexOfOutputParam("AnalyticalObject");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, panel);
+                }
+
+                index = Params.IndexOfOutputParam("Apertures");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, apertures.ConvertAll(x => new GooAperture(x)));
+                }
+
                 return;
             }
 
@@ -243,17 +291,25 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            if (analyticalModel != null)
+            index = Params.IndexOfOutputParam("AnalyticalObject");
+            if (index != -1)
             {
-                AnalyticalModel analyticalModel_Result = new AnalyticalModel(analyticalModel, adjacencyCluster);
-                dataAccess.SetData(0, analyticalModel_Result);
-            }
-            else
-            {
-                dataAccess.SetData(0, adjacencyCluster);
+                if (analyticalModel != null)
+                {
+                    AnalyticalModel analyticalModel_Result = new AnalyticalModel(analyticalModel, adjacencyCluster);
+                    dataAccess.SetData(index, analyticalModel_Result);
+                }
+                else
+                {
+                    dataAccess.SetData(index, adjacencyCluster);
+                }
             }
 
-            dataAccess.SetDataList(1, tuples_Result?.ConvertAll(x => new GooAperture(x.Item2)));
+            index = Params.IndexOfOutputParam("Apertures");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, tuples_Result?.ConvertAll(x => new GooAperture(x.Item2)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddMaterials.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddMaterials.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalAddMaterials : GH_SAMComponent
+    public class SAMAnalyticalAddMaterials : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,19 +40,29 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAnalyticalModelParam(), "_analyticalModel", "_analyticalModel", "SAM Analytical Model", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new global::Grasshopper.Kernel.Parameters.Param_GenericObject(), "_materials", "_materials", "SAM Materials", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalModelParam() { Name = "_analyticalModel", NickName = "_analyticalModel", Description = "SAM Analytical Model", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_materials", NickName = "_materials", Description = "SAM Materials", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalModelParam(), "AnalyticalModel", "AnalyticalModel", "SAM Analytical Model", GH_ParamAccess.item);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalModelParam() { Name = "AnalyticalModel", NickName = "AnalyticalModel", Description = "SAM Analytical Model", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,15 +73,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_analyticalModel");
             AnalyticalModel analyticalModel = null;
-            if (!dataAccess.GetData(0, ref analyticalModel) || analyticalModel == null)
+            if (index == -1 || !dataAccess.GetData(index, ref analyticalModel) || analyticalModel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_materials");
             List<IMaterial> materials = new List<IMaterial>();
-            if (!dataAccess.GetDataList(1, materials) || materials == null)
+            if (index == -1 || !dataAccess.GetDataList(index, materials) || materials == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -90,8 +104,17 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetData(0, new GooAnalyticalModel(analyticalModel));
-            dataAccess.SetDataList(1, successfuls);
+            index = Params.IndexOfOutputParam("AnalyticalModel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAnalyticalModel(analyticalModel));
+            }
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, successfuls);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddSpace.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAddSpace.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalAddSpace : GH_SAMComponent
+    public class SAMAnalyticalAddSpace : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,19 +39,29 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAnalyticalModelParam(), "_analyticalModel", "_analyticalModel", "SAM Analytical Model", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooSpaceParam(), "_space", "_space", "SAM Analytical Space", GH_ParamAccess.list);
-            inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.tree);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalModelParam() { Name = "_analyticalModel", NickName = "_analyticalModel", Description = "SAM Analytical Model", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_space", NickName = "_space", Description = "SAM Analytical Space", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalModelParam(), "AnalyticalModel", "AnalyticalModel", "SAM Analytical Model", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalModelParam() { Name = "AnalyticalModel", NickName = "AnalyticalModel", Description = "SAM Analytical Model", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,22 +72,27 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_analyticalModel");
             AnalyticalModel analyticalModel = null;
-            if (!dataAccess.GetData(0, ref analyticalModel) || analyticalModel == null)
+            if (index == -1 || !dataAccess.GetData(index, ref analyticalModel) || analyticalModel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_space");
             List<Space> spaces = new List<Space>();
-            if (!dataAccess.GetDataList(1, spaces) || spaces == null)
+            if (index == -1 || !dataAccess.GetDataList(index, spaces) || spaces == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_panels");
             global::Grasshopper.Kernel.Data.GH_Structure<GooPanel> structure_GooPanels;
-            if (!dataAccess.GetDataTree(2, out structure_GooPanels))
+            if (index == -1 || !dataAccess.GetDataTree(index, out structure_GooPanels))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -96,7 +111,11 @@ namespace SAM.Analytical.Grasshopper
                 analyticalModel.AddSpace(spaces[i], gooPanels.ConvertAll(x => x.Value));
             }
 
-            dataAccess.SetData(0, new GooAnalyticalModel(analyticalModel));
+            index = Params.IndexOfOutputParam("AnalyticalModel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAnalyticalModel(analyticalModel));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAirFlow.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalAirFlow.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalAirflow : GH_SAMComponent
+    public class SAMAnalyticalAirflow : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.2";
+        public override string LatestComponentVersion => "1.0.3";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,26 +40,39 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooSpaceParam(), "_space", "_space", "SAM Analytical Space", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_space", NickName = "_space", Description = "SAM Analytical Space", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddNumberParameter("Supply", "Supply", "Supply Airflow [m3/s]", GH_ParamAccess.item);
-            outputParamManager.AddNumberParameter("Exhaust", "Exhasut", "Exhaust Airflow [m3/s]", GH_ParamAccess.item);
-            outputParamManager.AddNumberParameter("Supply_LpS", "Supply_LpS", "Supply Airflow [l/s]", GH_ParamAccess.item);
-            outputParamManager.AddNumberParameter("Exhaust_LpS", "Exhasut_LpS", "Exhaust Airflow [l/s]", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Supply", NickName = "Supply", Description = "Supply Airflow [m3/s]", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Exhaust", NickName = "Exhasut", Description = "Exhaust Airflow [m3/s]", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Supply_LpS", NickName = "Supply_LpS", Description = "Supply Airflow [l/s]", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Exhaust_LpS", NickName = "Exhasut_LpS", Description = "Exhaust Airflow [l/s]", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_space");
             Space space = null;
-            if (!dataAccess.GetData(0, ref space) || space == null)
+            if (index == -1 || !dataAccess.GetData(index, ref space) || space == null)
             {
 
             }
@@ -66,10 +80,29 @@ namespace SAM.Analytical.Grasshopper
             double exhaustAirflow = Analytical.Query.CalculatedExhaustAirFlow(space);
             double supplyAirflow = Analytical.Query.CalculatedSupplyAirFlow(space);
 
-            dataAccess.SetData(0, supplyAirflow);
-            dataAccess.SetData(1, exhaustAirflow);
-            dataAccess.SetData(2, supplyAirflow * 1000);
-            dataAccess.SetData(3, exhaustAirflow * 1000);
+            index = Params.IndexOfOutputParam("Supply");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, supplyAirflow);
+            }
+
+            index = Params.IndexOfOutputParam("Exhaust");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, exhaustAirflow);
+            }
+
+            index = Params.IndexOfOutputParam("Supply_LpS");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, supplyAirflow * 1000);
+            }
+
+            index = Params.IndexOfOutputParam("Exhaust_LpS");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, exhaustAirflow * 1000);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalApertureConstructions.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalApertureConstructions.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalApertureConstructions : GH_SAMComponent
+    public class SAMAnalyticalApertureConstructions : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,26 +41,34 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_SAMAnalytical", "_SAMAnalytical", "SAM Analytical Object ie.Panel, AdjacencyCluster", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_SAMAnalytical", NickName = "_SAMAnalytical", Description = "SAM Analytical Object ie.Panel, AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("panelType_", "panelType_", "PanelType", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "panelType_", NickName = "panelType_", Description = "PanelType", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("apertureType_", "apertureType_", "ApertureType", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "apertureType_", NickName = "apertureType_", Description = "ApertureType", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooApertureConstructionParam(), "ApertureConstructions", "ApertureConstructions", "SAM Analytical Aperture Constructions", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Successful", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooApertureConstructionParam() { Name = "ApertureConstructions", NickName = "ApertureConstructions", Description = "SAM Analytical Aperture Constructions", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Successful", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -71,10 +79,17 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            dataAccess.SetData(1, false);
+            int index = -1;
 
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, false);
+            }
+
+            index = Params.IndexOfInputParam("_SAMAnalytical");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || sAMObject == null)
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || sAMObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -102,7 +117,11 @@ namespace SAM.Analytical.Grasshopper
             GH_ObjectWrapper objectWrapper; ;
 
             objectWrapper = null;
-            dataAccess.GetData(1, ref objectWrapper);
+            index = Params.IndexOfInputParam("panelType_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref objectWrapper);
+            }
 
             PanelType panelType = PanelType.Undefined;
 
@@ -115,7 +134,11 @@ namespace SAM.Analytical.Grasshopper
             }
 
             objectWrapper = null;
-            dataAccess.GetData(2, ref objectWrapper);
+            index = Params.IndexOfInputParam("apertureType_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref objectWrapper);
+            }
 
             ApertureType apertureType = ApertureType.Undefined;
 
@@ -130,8 +153,17 @@ namespace SAM.Analytical.Grasshopper
 
             List<ApertureConstruction> apertureConstructions = Analytical.Query.ApertureConstructions(panels, apertureType, panelType);
 
-            dataAccess.SetDataList(0, apertureConstructions?.ConvertAll(x => new GooApertureConstruction(x)));
-            dataAccess.SetData(1, apertureConstructions != null);
+            index = Params.IndexOfOutputParam("ApertureConstructions");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, apertureConstructions?.ConvertAll(x => new GooApertureConstruction(x)));
+            }
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, apertureConstructions != null);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateFloorArea.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateFloorArea.cs
@@ -130,81 +130,68 @@ namespace SAM.Analytical.Grasshopper
                         maxTiltDifference = maxTiltDifference_Temp;
                 }
 
-                Dictionary<Space, double> dictionary_Area = [];
-                Dictionary<Space, List<Panel>> dictionary_Panel = [];
-                List<Space> spaces_Temp = [];
+                List<Space> spaces_Temp = new List<Space>();
                 foreach (Space space in spaces)
                 {
                     if (space == null)
-                    {
                         continue;
-                    }
 
                     Space space_Temp = adjacencyCluster.GetObject<Space>(space.Guid);
                     if (space_Temp == null)
-                    {
-                        return;
-                    }
+                        continue;
 
                     spaces_Temp.Add(space_Temp);
-                    dictionary_Area[space_Temp] = double.NaN;
-                    dictionary_Panel[space_Temp] = [];
                 }
 
-                Parallel.For(0, spaces_Temp.Count, (int i) =>
-                {
+                int count = spaces_Temp.Count;
+                List<Panel>[] panelLists = new List<Panel>[count];
+                double[] areas = Enumerable.Repeat(double.NaN, count).ToArray();
 
+                Parallel.For(0, count, (int i) =>
+                {
                     Space space_Temp = spaces_Temp[i];
                     if (space_Temp == null)
-                    {
                         return;
-                    }
 
                     List<Panel> panels = Analytical.Query.GeomericalFloorPanels(adjacencyCluster, space_Temp, maxTiltDifference);
                     if (panels == null || panels.Count == 0)
-                    {
                         return;
-                    }
 
-                    dictionary_Panel[space_Temp] = panels;
-                    dictionary_Area[space_Temp] = panels.ConvertAll(x => x.GetArea()).Sum();
+                    panelLists[i] = panels;
+                    areas[i] = panels.ConvertAll(x => x.GetArea()).Sum();
                 });
 
                 DataTree<GooPanel> dataTree_Panel = new DataTree<GooPanel>();
-                if (dictionary_Panel != null && dictionary_Panel.Count > 0)
+                int pathIndex = 0;
+                for (int i = 0; i < count; i++)
                 {
-                    int count = 0;
-                    foreach (KeyValuePair<Space, List<Panel>> keyValuePair in dictionary_Panel)
-                    {
-                        GH_Path path = new GH_Path(count);
-                        keyValuePair.Value.ForEach(x => dataTree_Panel.Add(new GooPanel(x), path));
-                        count++;
-                    }
+                    List<Panel> panelList = panelLists[i];
+                    if (panelList == null || panelList.Count == 0)
+                        continue;
+
+                    GH_Path path = new GH_Path(pathIndex);
+                    panelList.ForEach(x => dataTree_Panel.Add(new GooPanel(x), path));
+                    pathIndex++;
                 }
 
                 index = Params.IndexOfOutputParam("Panels");
                 if (index != -1)
                     dataAccess.SetDataTree(index, dataTree_Panel);
 
-                index = Params.IndexOfOutputParam("Area");
+                index = Params.IndexOfOutputParam("Areas");
                 if (index != -1)
-                    dataAccess.SetDataList(index, dictionary_Area?.Values);
+                    dataAccess.SetDataList(index, areas);
 
                 index = Params.IndexOfOutputParam("Analytical");
                 if (index != -1)
                 {
                     adjacencyCluster = new AdjacencyCluster(adjacencyCluster);
-                    foreach (KeyValuePair<Space, double> keyValuePair in dictionary_Area)
+                    for (int i = 0; i < count; i++)
                     {
-                        Space space = new Space(keyValuePair.Key);
-                        space.SetValue(SpaceParameter.Area, keyValuePair.Value);
+                        Space space = new Space(spaces_Temp[i]);
+                        space.SetValue(SpaceParameter.Area, areas[i]);
                         adjacencyCluster.AddObject(space);
-
-                        int index_Space = spaces_Temp.IndexOf(keyValuePair.Key);
-                        if (index_Space != -1)
-                        {
-                            spaces_Temp[index_Space] = space;
-                        }
+                        spaces_Temp[i] = space;
                     }
 
                     if (sAMObject is AnalyticalModel)
@@ -217,12 +204,8 @@ namespace SAM.Analytical.Grasshopper
 
                 index = Params.IndexOfOutputParam("Spaces");
                 if (index != -1)
-                    dataAccess.SetDataList(index, spaces_Temp?.ConvertAll(x => new GooSpace(x)));
-
-
+                    dataAccess.SetDataList(index, spaces_Temp.ConvertAll(x => new GooSpace(x)));
             }
-
-
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByAperture.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByAperture.cs
@@ -316,7 +316,7 @@ namespace SAM.Analytical.Grasshopper
                         if (double.IsNaN(emissivity))
                         {
                             AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid emissivity for layer");
-                            return;
+                            continue;
                         }
 
                         hi = 3.6 + (4.1 * emissivity / 0.837);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByConstruction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByConstruction.cs
@@ -327,7 +327,7 @@ namespace SAM.Analytical.Grasshopper
                         if (double.IsNaN(emissivity))
                         {
                             AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid emissivity for layer");
-                            return;
+                            continue;
                         }
 
                         hi = 3.6 + (4.1 * emissivity / 0.837);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCopyApertureConstructionLayers.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCopyApertureConstructionLayers.cs
@@ -3,12 +3,14 @@
 
 using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
+using SAM.Core;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalCopyApertureConstructionLayers : GH_SAMComponent
+    public class SAMAnalyticalCopyApertureConstructionLayers : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,25 +40,40 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooApertureConstructionParam(), "apertureConstructionSource", "apertureConstructionSource", "Source SAM Analytical ApertureConstruction", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooApertureConstructionParam(), "apertureConstructionDestination", "apertureConstructionDestination", "Destination SAM Analytical ApertureConstruction", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            int index = -1;
-            index = inputParamManager.AddBooleanParameter("_frame_", "_frame_", "Copy Frame ConstructionLayers", GH_ParamAccess.item, true);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooApertureConstructionParam() { Name = "apertureConstructionSource", NickName = "apertureConstructionSource", Description = "Source SAM Analytical ApertureConstruction", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddBooleanParameter("_pane_", "_pane_", "Copy Pane ConstructionLayers", GH_ParamAccess.item, true);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooApertureConstructionParam() { Name = "apertureConstructionDestination", NickName = "apertureConstructionDestination", Description = "Destination SAM Analytical ApertureConstruction", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_frame_", NickName = "_frame_", Description = "Copy Frame ConstructionLayers", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_pane_", NickName = "_pane_", Description = "Copy Pane ConstructionLayers", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooApertureConstructionParam(), "apertureConstruction", "apertureConstruction", "SAM Analytical Construction", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooApertureConstructionParam() { Name = "apertureConstruction", NickName = "apertureConstruction", Description = "SAM Analytical Construction", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,27 +84,39 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             ApertureConstruction apertureConstruction_Source = null;
-            if (!dataAccess.GetData(0, ref apertureConstruction_Source))
+            index = Params.IndexOfInputParam("apertureConstructionSource");
+            if (index == -1 || !dataAccess.GetData(index, ref apertureConstruction_Source))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Invalid Data");
                 return;
             }
 
             ApertureConstruction apertureConstruction_Destination = null;
-            if (!dataAccess.GetData(1, ref apertureConstruction_Destination))
+            index = Params.IndexOfInputParam("apertureConstructionDestination");
+            if (index == -1 || !dataAccess.GetData(index, ref apertureConstruction_Destination))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Invalid Data");
                 return;
             }
 
             bool frame = true;
-            if (!dataAccess.GetData(2, ref frame))
-                frame = true;
+            index = Params.IndexOfInputParam("_frame_");
+            if (index != -1)
+            {
+                if (!dataAccess.GetData(index, ref frame))
+                    frame = true;
+            }
 
             bool pane = true;
-            if (!dataAccess.GetData(3, ref pane))
-                pane = true;
+            index = Params.IndexOfInputParam("_pane_");
+            if (index != -1)
+            {
+                if (!dataAccess.GetData(index, ref pane))
+                    pane = true;
+            }
 
             ApertureConstruction result = new ApertureConstruction(apertureConstruction_Destination);
 
@@ -97,7 +126,11 @@ namespace SAM.Analytical.Grasshopper
             if (pane)
                 result = new ApertureConstruction(result, apertureConstruction_Source.PaneConstructionLayers, result.FrameConstructionLayers);
 
-            dataAccess.SetData(0, new GooApertureConstruction(result));
+            index = Params.IndexOfOutputParam("apertureConstruction");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooApertureConstruction(result));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCopyConstructionLayers.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCopyConstructionLayers.cs
@@ -3,12 +3,14 @@
 
 using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
+using SAM.Core;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalCopyConstructionLayers : GH_SAMComponent
+    public class SAMAnalyticalCopyConstructionLayers : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,18 +40,31 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooConstructionParam(), "constructionSource", "constructionSource", "Source SAM Analytical Construction", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooConstructionParam(), "constructionDestination", "constructionDestination", "Destination SAM Analytical Construction", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "constructionSource", NickName = "constructionSource", Description = "Source SAM Analytical Construction", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "constructionDestination", NickName = "constructionDestination", Description = "Destination SAM Analytical Construction", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooConstructionParam(), "construction", "construction", "SAM Analytical Construction", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "construction", NickName = "construction", Description = "SAM Analytical Construction", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,15 +75,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             Construction construction_Source = null;
-            if (!dataAccess.GetData(0, ref construction_Source))
+            index = Params.IndexOfInputParam("constructionSource");
+            if (index == -1 || !dataAccess.GetData(index, ref construction_Source))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Invalid Data");
                 return;
             }
 
             Construction construction_Destination = null;
-            if (!dataAccess.GetData(1, ref construction_Destination))
+            index = Params.IndexOfInputParam("constructionDestination");
+            if (index == -1 || !dataAccess.GetData(index, ref construction_Destination))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Invalid Data");
                 return;
@@ -76,7 +95,11 @@ namespace SAM.Analytical.Grasshopper
 
             Construction result = new Construction(construction_Destination, construction_Source.ConstructionLayers);
 
-            dataAccess.SetData(0, new GooConstruction(result));
+            index = Params.IndexOfOutputParam("construction");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooConstruction(result));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateAdjacencyCluster.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateAdjacencyCluster.cs
@@ -4,6 +4,7 @@
 using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using SAM.Analytical.Grasshopper.Properties;
+using SAM.Core;
 using SAM.Core.Grasshopper;
 using SAM.Geometry;
 using SAM.Geometry.Grasshopper;
@@ -16,7 +17,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalCreateAdjacencyCluster : GH_SAMComponent
+    public class SAMAnalyticalCreateAdjacencyCluster : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -26,7 +27,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -47,24 +48,39 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddGenericParameter("_geometry", "_geometry", "SAM or Rhino Geometry, Use only Top Floors or Roof shape ONLY", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                global::Grasshopper.Kernel.Parameters.Param_GenericObject param_GenericObject = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_geometry", NickName = "_geometry", Description = "SAM or Rhino Geometry, Use only Top Floors or Roof shape ONLY", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten };
+                result.Add(new GH_SAMParam(param_GenericObject, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("elevation_Ground_", "elevation_Ground_", "Ground Elevation, Number", GH_ParamAccess.item, 0);
-            inputParamManager.AddNumberParameter("tolerance_", "tolerance_", "Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "elevation_Ground_", NickName = "elevation_Ground_", Description = "Ground Elevation, Number", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
 
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "tolerance_", NickName = "tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAdjacencyClusterParam(), "AdjacencyCluster", "AdjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "AdjacencyCluster", NickName = "AdjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -75,9 +91,12 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<GH_ObjectWrapper> objectWrapperList = new List<GH_ObjectWrapper>();
 
-            if (!dataAccess.GetDataList(0, objectWrapperList) || objectWrapperList == null)
+            index = Params.IndexOfInputParam("_geometry");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -114,10 +133,14 @@ namespace SAM.Analytical.Grasshopper
             }
 
             double tolerance = Core.Tolerance.Distance;
-            if (!dataAccess.GetData(2, ref tolerance))
+            index = Params.IndexOfInputParam("tolerance_");
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref tolerance))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
             List<Face3D> face3Ds = new List<Face3D>();
@@ -231,7 +254,8 @@ namespace SAM.Analytical.Grasshopper
             }
 
             double elevation_Ground = double.NaN;
-            if (!dataAccess.GetData(1, ref elevation_Ground))
+            index = Params.IndexOfInputParam("elevation_Ground_");
+            if (index == -1 || !dataAccess.GetData(index, ref elevation_Ground))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -239,7 +263,11 @@ namespace SAM.Analytical.Grasshopper
 
             AdjacencyCluster adjacencyCluster = Create.AdjacencyCluster(face3Ds, elevation_Ground, tolerance);
 
-            dataAccess.SetData(0, new GooAdjacencyCluster(adjacencyCluster));
+            index = Params.IndexOfOutputParam("AdjacencyCluster");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAdjacencyCluster(adjacencyCluster));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateAnalyticalModelBySpaces.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateAnalyticalModelBySpaces.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalCreateAnalyticalModelBySpaces : GH_SAMComponent
+    public class SAMAnalyticalCreateAnalyticalModelBySpaces : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -42,34 +42,46 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddTextParameter("_name_", "_name_", "Analytical Model Name", GH_ParamAccess.item, "000000_SAM_AnalyticalModel");
-            inputParamManager.AddTextParameter("_description_", "_description_", "SAM Description", GH_ParamAccess.item, string.Format("Delivered by SAM https://github.com/HoareLea/SAM [{0}]", DateTime.Now.ToString("yyyy/MM/dd")));
-            index = inputParamManager.AddParameter(new GooWeatherDataParam(), "weatherData_", "weatherData_", "SAM WeatherData", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name_", NickName = "_name_", Description = "Analytical Model Name", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("000000_SAM_AnalyticalModel");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
 
-            global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean();
-            param_Boolean.SetPersistentData(false);
-            index = inputParamManager.AddParameter(param_Boolean, "_saveWeatherData_", "_saveWeatherData_", "Save WeatherData", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_description_", NickName = "_description_", Description = "SAM Description", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData(string.Format("Delivered by SAM https://github.com/HoareLea/SAM [{0}]", DateTime.Now.ToString("yyyy/MM/dd")));
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooSpaceParam(), "_spaces", "_spaces", "SAM Analytical Spaces", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
-            inputParamManager[index].Optional = false;
+                result.Add(new GH_SAMParam(new GooWeatherDataParam() { Name = "weatherData_", NickName = "weatherData_", Description = "SAM WeatherData", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooProfileLibraryParam(), "profileLibrary_", "profileLibrary_", "SAM Profile Library", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_saveWeatherData_", NickName = "_saveWeatherData_", Description = "Save WeatherData", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_spaces", NickName = "_spaces", Description = "SAM Analytical Spaces", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooProfileLibraryParam() { Name = "profileLibrary_", NickName = "profileLibrary_", Description = "SAM Profile Library", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalModelParam(), "AnalyticalModel", "AnalyticalModel", "SAM Analytical Model", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalModelParam() { Name = "AnalyticalModel", NickName = "AnalyticalModel", Description = "SAM Analytical Model", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -80,24 +92,32 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             string name = null;
-            if (!dataAccess.GetData(0, ref name) || name == null)
+            index = Params.IndexOfInputParam("_name_");
+            if (index == -1 || !dataAccess.GetData(index, ref name) || name == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             string description = null;
-            if (!dataAccess.GetData(1, ref description) || description == null)
+            index = Params.IndexOfInputParam("_description_");
+            if (index == -1 || !dataAccess.GetData(index, ref description) || description == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             WeatherData weatherData = null;
-            if (!dataAccess.GetData(2, ref weatherData))
+            index = Params.IndexOfInputParam("weatherData_");
+            if (index != -1)
             {
-                weatherData = null;
+                if (!dataAccess.GetData(index, ref weatherData))
+                {
+                    weatherData = null;
+                }
             }
 
             Location location = weatherData?.Location;
@@ -107,13 +127,21 @@ namespace SAM.Analytical.Grasshopper
             }
 
             bool saveWeatherData = false;
-            if (!dataAccess.GetData(3, ref saveWeatherData))
+            index = Params.IndexOfInputParam("_saveWeatherData_");
+            if (index != -1)
             {
-                saveWeatherData = false;
+                if (!dataAccess.GetData(index, ref saveWeatherData))
+                {
+                    saveWeatherData = false;
+                }
             }
 
             List<Space> spaces = new List<Space>();
-            dataAccess.GetDataList(4, spaces);
+            index = Params.IndexOfInputParam("_spaces");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, spaces);
+            }
 
             AdjacencyCluster adjacencyCluster = new AdjacencyCluster();
             if (spaces != null)
@@ -122,7 +150,11 @@ namespace SAM.Analytical.Grasshopper
             }
 
             ProfileLibrary profileLibrary = null;
-            dataAccess.GetData(5, ref profileLibrary);
+            index = Params.IndexOfInputParam("profileLibrary_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref profileLibrary);
+            }
 
             if (profileLibrary == null)
                 profileLibrary = ActiveSetting.Setting.GetValue<ProfileLibrary>(AnalyticalSettingParameter.DefaultProfileLibrary);
@@ -136,7 +168,11 @@ namespace SAM.Analytical.Grasshopper
                 analyticalModel.SetValue(AnalyticalModelParameter.WeatherData, new WeatherData(weatherData));
             }
 
-            dataAccess.SetData(0, new GooAnalyticalModel(analyticalModel));
+            index = Params.IndexOfOutputParam("AnalyticalModel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAnalyticalModel(analyticalModel));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLayersByMaterials.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLayersByMaterials.cs
@@ -106,14 +106,14 @@ namespace SAM.Analytical.Grasshopper
                     if (material == null)
                     {
                         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                        return;
+                        continue;
                     }
 
                     double thickness = material.GetValue<double>(Core.MaterialParameter.DefaultThickness);
                     if (double.IsNaN(thickness))
                     {
                         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                        return;
+                        continue;
                     }
 
                     thicknesses.Add(thickness);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLayersByNames.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLayersByNames.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalCreateConstructionLayersByNames : GH_SAMComponent
+    public class SAMAnalyticalCreateConstructionLayersByNames : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,25 +41,33 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddTextParameter("_names", "_names", "Contruction Layer Name", GH_ParamAccess.list);
-            index = inputParamManager.AddNumberParameter("_thicknesses_", "_thicknesses_", "Contruction Layer Thicknesses [m]", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_names", NickName = "_names", Description = "Contruction Layer Name", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            GooMaterialLibraryParam gooMaterialLibraryParam = new GooMaterialLibraryParam();
-            gooMaterialLibraryParam.Optional = true;
-            inputParamManager.AddParameter(gooMaterialLibraryParam, "_materialLibrary_", "_materialLibrary_", "SAM Material Library", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_thicknesses_", NickName = "_thicknesses_", Description = "Contruction Layer Thicknesses [m]", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "_materialLibrary_", NickName = "_materialLibrary_", Description = "SAM Material Library", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooConstructionLayerParam(), "ConstructionLayers", "ConstructionLayers", "SAM Analytical Construction Layers", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooConstructionLayerParam() { Name = "ConstructionLayers", NickName = "ConstructionLayers", Description = "SAM Analytical Construction Layers", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -70,20 +78,31 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<string> names = new List<string>();
-            if (!dataAccess.GetDataList(0, names))
+            index = Params.IndexOfInputParam("_names");
+            if (index == -1 || !dataAccess.GetDataList(index, names))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<double> thicknesses = new List<double>();
-            dataAccess.GetDataList(1, thicknesses);
+            index = Params.IndexOfInputParam("_thicknesses_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, thicknesses);
+            }
 
             if (names.Count != thicknesses.Count)
             {
                 MaterialLibrary materialLibrary = null;
-                dataAccess.GetData(2, ref materialLibrary);
+                index = Params.IndexOfInputParam("_materialLibrary_");
+                if (index != -1)
+                {
+                    dataAccess.GetData(index, ref materialLibrary);
+                }
 
                 if (materialLibrary == null)
                     materialLibrary = ActiveSetting.Setting.GetValue<MaterialLibrary>(AnalyticalSettingParameter.DefaultMaterialLibrary);
@@ -128,7 +147,11 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetDataList(0, constructionLayers?.ConvertAll(x => new GooConstructionLayer(x)));
+            index = Params.IndexOfOutputParam("ConstructionLayers");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, constructionLayers?.ConvertAll(x => new GooConstructionLayer(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLibrary.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLibrary.cs
@@ -3,13 +3,14 @@
 
 using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
+using SAM.Core;
 using SAM.Core.Grasshopper;
 using System;
 using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalCreateConstructionLibrary : GH_SAMComponent
+    public class SAMAnalyticalCreateConstructionLibrary : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.3";
+        public override string LatestComponentVersion => "1.0.4";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,22 +40,33 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddTextParameter("_name_", "_name_", "Name", GH_ParamAccess.item, "Default Construction Library");
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            GooConstructionParam gooConstructionParam = new GooConstructionParam();
-            gooConstructionParam.Optional = true;
-            inputParamManager.AddParameter(gooConstructionParam, "_constructions_", "_constructions_", "SAM Analytical Constructions", GH_ParamAccess.list);
+                global::Grasshopper.Kernel.Parameters.Param_String param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name_", NickName = "_name_", Description = "Name", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("Default Construction Library");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "_constructions_", NickName = "_constructions_", Description = "SAM Analytical Constructions", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooConstructionLibraryParam(), "ConstructionLibrary", "ConstructionLibrary", "SAM Analytical ConstructionLibrary", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "ConstructionLibrary", NickName = "ConstructionLibrary", Description = "SAM Analytical ConstructionLibrary", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,20 +77,31 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             string name = null;
-            if (!dataAccess.GetData(0, ref name) || name == null)
+            index = Params.IndexOfInputParam("_name_");
+            if (index == -1 || !dataAccess.GetData(index, ref name) || name == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<Construction> constructions = new List<Construction>();
-            dataAccess.GetDataList(1, constructions);
+            index = Params.IndexOfInputParam("_constructions_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, constructions);
+            }
 
             ConstructionLibrary result = new ConstructionLibrary(name);
             constructions?.ForEach(x => result.Add(x));
 
-            dataAccess.SetData(0, new GooConstructionLibrary(result));
+            index = Params.IndexOfOutputParam("ConstructionLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooConstructionLibrary(result));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateDegreeOfActivityByTemperature.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateDegreeOfActivityByTemperature.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalCreateDegreeOfActivityByTemperature : GH_SAMComponent
+    public class SAMAnalyticalCreateDegreeOfActivityByTemperature : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,26 +39,42 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddTextParameter("_name_", "_name_", "Name ,default = Activity level", GH_ParamAccess.item, string.Empty);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name_", NickName = "_name_", Description = "Name ,default = Activity level", Access = GH_ParamAccess.item, Optional = true };
+                param_String.SetPersistentData(string.Empty);
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
 
-            index = inputParamManager.AddIntegerParameter("_activityLevel_", "_activityLevel_", "Activity level [1 - 4], I=100 W/p, II=125 W/p, III=170 W/p, IV=210 W/p ", GH_ParamAccess.item, 2);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_Integer param_Integer;
+                param_Integer = new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "_activityLevel_", NickName = "_activityLevel_", Description = "Activity level [1 - 4], I=100 W/p, II=125 W/p, III=170 W/p, IV=210 W/p ", Access = GH_ParamAccess.item, Optional = true };
+                param_Integer.SetPersistentData(2);
+                result.Add(new GH_SAMParam(param_Integer, ParamVisibility.Binding));
 
-            index = inputParamManager.AddNumberParameter("_temperature_", "_temperature_", "Temperature [degC], will range between 16-28 default = 24 degC", GH_ParamAccess.item, 24);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_temperature_", NickName = "_temperature_", Description = "Temperature [degC], will range between 16-28 default = 24 degC", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(24);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooDegreeOfActivityParam(), "DegreeOfActivity", "DegreeOfActivity", "SAM Analytical DegreeOfActivity", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooDegreeOfActivityParam() { Name = "DegreeOfActivity", NickName = "DegreeOfActivity", Description = "SAM Analytical DegreeOfActivity", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -68,11 +85,21 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            string name = null;
-            dataAccess.GetData(0, ref name);
+            int index = -1;
 
+            index = Params.IndexOfInputParam("_name_");
+            string name = null;
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref name);
+            }
+
+            index = Params.IndexOfInputParam("_activityLevel_");
             int activityLevel = 0;
-            dataAccess.GetData(1, ref activityLevel);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref activityLevel);
+            }
 
             if (activityLevel < 1 || activityLevel > 4)
             {
@@ -80,8 +107,12 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
+            index = Params.IndexOfInputParam("_temperature_");
             double temperature = 0;
-            dataAccess.GetData(2, ref temperature);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref temperature);
+            }
 
             if (string.IsNullOrEmpty(name))
             {
@@ -105,7 +136,11 @@ namespace SAM.Analytical.Grasshopper
                 name = string.Format("Activity Level {0} ({1}C)", id, System.Math.Round(temperature, 0));
             }
 
-            dataAccess.SetData(0, new GooDegreeOfActivity(Create.DegreeOfActivity((ActivityLevel)activityLevel, name, temperature)));
+            index = Params.IndexOfOutputParam("DegreeOfActivity");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooDegreeOfActivity(Create.DegreeOfActivity((ActivityLevel)activityLevel, name, temperature)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateIZAM.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateIZAM.cs
@@ -81,7 +81,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<IAirMovementObject> airMovementObjects = analyticalModel.AddAirMovementObjects();
 
-            index = Params.IndexOfOutputParam("analyticalModel");
+            index = Params.IndexOfOutputParam("_analyticalModel");
             if (index != -1)
             {
                 dataAccess.SetData(index, analyticalModel);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreatePanelByBottomAndHeight.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreatePanelByBottomAndHeight.cs
@@ -14,7 +14,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalCreatePanelByBottomAndHeight : GH_SAMComponent
+    public class SAMAnalyticalCreatePanelByBottomAndHeight : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -24,7 +24,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.2";
+        public override string LatestComponentVersion => "1.0.3";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -44,35 +44,37 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddGenericParameter("_bottom", "_bottom", "Bottom Edge Geometry", GH_ParamAccess.item);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_bottom", NickName = "_bottom", Description = "Bottom Edge Geometry", Access = GH_ParamAccess.item, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("panelType_", "panelType_", "PanelType", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "panelType_", NickName = "panelType_", Description = "PanelType", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooConstructionParam(), "construction_", "construction_", "SAM Analytical Construction", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "construction_", NickName = "construction_", Description = "SAM Analytical Construction", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            inputParamManager.AddGenericParameter(
-                "_height",
-                "_height",
-                "Panel height. Accepts a single numeric value (e.g. 2.0) or a domain (e.g. 2 to 4) defining the vertical range used to generate the panel.",
-                GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_height", NickName = "_height", Description = "Panel height. Accepts a single numeric value (e.g. 2.0) or a domain (e.g. 2 to 4) defining the vertical range used to generate the panel.", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddNumberParameter("_minElevation", "_minElevation", "Min Elevation", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_minElevation", NickName = "_minElevation", Description = "Min Elevation", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "SAM Analytical Panels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -83,8 +85,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_bottom");
             GH_ObjectWrapper @objectWrapper = null;
-            if (!dataAccess.GetData(0, ref @objectWrapper))
+            if (index == -1 || !dataAccess.GetData(index, ref @objectWrapper))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -111,8 +116,9 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
+            index = Params.IndexOfInputParam("_height");
             GH_ObjectWrapper gH_ObjectWrapper = null;
-            if (!dataAccess.GetData(3, ref gH_ObjectWrapper))
+            if (index == -1 || !dataAccess.GetData(index, ref gH_ObjectWrapper))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -140,9 +146,9 @@ namespace SAM.Analytical.Grasshopper
             }
             else if (@object is string text)
             {
-                if (text.ToUpper().IndexOf("TO") is int index && index > 0)
+                if (text.ToUpper().IndexOf("TO") is int index_To && index_To > 0)
                 {
-                    if (!Core.Query.TryConvert(text.Substring(0, index).Trim(), out double min) || !Core.Query.TryConvert(text.Substring(index + 2).Trim(), out double max))
+                    if (!Core.Query.TryConvert(text.Substring(0, index_To).Trim(), out double min) || !Core.Query.TryConvert(text.Substring(index_To + 2).Trim(), out double max))
                     {
                         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                         return;
@@ -173,7 +179,11 @@ namespace SAM.Analytical.Grasshopper
             PanelType panelType = PanelType.Undefined;
 
             objectWrapper = null;
-            dataAccess.GetData(1, ref objectWrapper);
+            index = Params.IndexOfInputParam("panelType_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref objectWrapper);
+            }
             if (objectWrapper != null)
             {
                 if (objectWrapper.Value is GH_String)
@@ -183,11 +193,16 @@ namespace SAM.Analytical.Grasshopper
             }
 
             Construction construction = null;
-            dataAccess.GetData(2, ref construction);
+            index = Params.IndexOfInputParam("construction_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref construction);
+            }
 
             double minElevation = double.NaN;
 
-            if (dataAccess.GetData(4, ref minElevation))
+            index = Params.IndexOfInputParam("_minElevation");
+            if (index != -1 && dataAccess.GetData(index, ref minElevation))
             {
                 for (int i = 0; i < segmentable3Ds.Count; i++)
                 {
@@ -199,7 +214,11 @@ namespace SAM.Analytical.Grasshopper
 
             List<Panel> panels = Create.Panels(segmentable3Ds, height, panelType, construction);
 
-            dataAccess.SetDataList(0, panels?.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels?.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreatePanelByPanels.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreatePanelByPanels.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalCreatePanelByPanels : GH_SAMComponent
+    public class SAMAnalyticalCreatePanelByPanels : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -23,7 +23,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -43,37 +43,53 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            inputParamManager.AddGenericParameter("_elevation", "_elevation", "Elevation or Plane", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            int index = inputParamManager.AddGenericParameter("panelType_", "panelType_", "PanelType", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_elevation", NickName = "_elevation", Description = "Elevation or Plane", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "panelType_", NickName = "panelType_", Description = "PanelType", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "New Created Panels", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooPanelParam(), "UpperPanels", "UpperPanels", "Upper SAM Analytical Panels", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooPanelParam(), "LowerPanels", "LowerPanels", "Lower SAM Analytical Panels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "New Created Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "UpperPanels", NickName = "UpperPanels", Description = "Upper SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "LowerPanels", NickName = "LowerPanels", Description = "Lower SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panels");
             List<Panel> panels = new List<Panel>();
-            if (!dataAccess.GetDataList(0, panels) || panels == null)
+            if (index == -1 || !dataAccess.GetDataList(index, panels) || panels == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
 
+            index = Params.IndexOfInputParam("_elevation");
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(1, ref objectWrapper) || objectWrapper == null)
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -139,7 +155,11 @@ namespace SAM.Analytical.Grasshopper
             PanelType panelType = PanelType.Undefined;
 
             objectWrapper = null;
-            dataAccess.GetData(2, ref objectWrapper);
+            index = Params.IndexOfInputParam("panelType_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref objectWrapper);
+            }
             if (objectWrapper != null)
             {
                 if (objectWrapper.Value is GH_String)
@@ -177,9 +197,23 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetDataList(0, panels_Result?.ConvertAll(x => new GooPanel(x)));
-            dataAccess.SetDataList(1, panels_Upper.ConvertAll(x => new GooPanel(x)));
-            dataAccess.SetDataList(2, panels_Lower.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels_Result?.ConvertAll(x => new GooPanel(x)));
+            }
+
+            index = Params.IndexOfOutputParam("UpperPanels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels_Upper.ConvertAll(x => new GooPanel(x)));
+            }
+
+            index = Params.IndexOfOutputParam("LowerPanels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels_Lower.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateShadeByFeatureShade.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateShadeByFeatureShade.cs
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -56,10 +56,10 @@ namespace SAM.Analytical.Grasshopper
                 global::Grasshopper.Kernel.Parameters.Param_String param_String;
 
                 param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name", NickName = "_name", Description = "SAM Name", Optional = true, Access = GH_ParamAccess.item };
-                result.Add(new GH_SAMParam(gooFeatureShadeParam, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
 
                 param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_description", NickName = "_description", Description = "SAM Description", Optional = true, Access = GH_ParamAccess.item };
-                result.Add(new GH_SAMParam(gooFeatureShadeParam, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
 
                 global::Grasshopper.Kernel.Parameters.Param_Number paramNumber;
 

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateTransparentMaterial.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateTransparentMaterial.cs
@@ -257,7 +257,7 @@ namespace SAM.Analytical.Grasshopper
             }
 
             bool isBlind = transparentMaterial.GetValue<bool>(TransparentMaterialParameter.IsBlind);
-            index = Params.IndexOfInputParam("ignoreThermalTransmittanceCalculations_");
+            index = Params.IndexOfInputParam("isBlind_");
             if (index != -1)
             {
                 bool value = true;

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalDataTree.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalDataTree.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalDataTree : GH_SAMComponent
+    public class SAMAnalyticalDataTree : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,19 +41,28 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.item);
-
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("tree", "tree", "SAM Analytical Apertures", GH_ParamAccess.tree);
-            outputParamManager.AddParameter(new GooSpaceParam(), "spaces", "spaces", "SAM Analytical Spaces", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "tree", NickName = "tree", Description = "SAM Analytical Apertures", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "spaces", NickName = "spaces", Description = "SAM Analytical Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,8 +73,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_analyticalObject");
             IAnalyticalObject analyticalObject = null;
-            if (!dataAccess.GetData(0, ref analyticalObject))
+            if (index == -1 || !dataAccess.GetData(index, ref analyticalObject))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -114,8 +126,17 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetDataTree(0, dataTree);
-            dataAccess.SetDataList(1, spaces?.ConvertAll(x => new GooSpace(x)));
+            index = Params.IndexOfOutputParam("tree");
+            if (index != -1)
+            {
+                dataAccess.SetDataTree(index, dataTree);
+            }
+
+            index = Params.IndexOfOutputParam("spaces");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, spaces?.ConvertAll(x => new GooSpace(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalExtendPanelByPanels.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalExtendPanelByPanels.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalExtendPanelByPanels : GH_SAMComponent
+    public class SAMAnalyticalExtendPanelByPanels : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// </summary>
         protected override System.Drawing.Bitmap Icon => Core.Convert.ToBitmap(Resources.SAM_Small);
 
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -36,19 +36,36 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panelsToBeExtended", "_panelsToBeExtended", "SAM Analytical Panels To Be Extended", GH_ParamAccess.list);
-            inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            inputParamManager.AddNumberParameter("_tolerance_", "_tolerance", "Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panelsToBeExtended", NickName = "_panelsToBeExtended", Description = "SAM Analytical Panels To Be Extended", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "SAM Analytical Panels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -59,22 +76,27 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panelsToBeExtended");
             List<Panel> panels_ToBeExtended = new List<Panel>();
-            if (!dataAccess.GetDataList(0, panels_ToBeExtended))
+            if (index == -1 || !dataAccess.GetDataList(index, panels_ToBeExtended))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_panels");
             List<Panel> panels = new List<Panel>();
-            if (!dataAccess.GetDataList(1, panels))
+            if (index == -1 || !dataAccess.GetDataList(index, panels))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_tolerance_");
             double tolerance = Core.Tolerance.Distance;
-            if (!dataAccess.GetData(2, ref tolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -82,7 +104,11 @@ namespace SAM.Analytical.Grasshopper
 
             List<Panel> result = Analytical.Query.Extend(panels_ToBeExtended, panels, tolerance);
 
-            dataAccess.SetDataList(0, result?.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result?.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalExtendPanelByPlane.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalExtendPanelByPlane.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalExtendPanelByPlane : GH_SAMComponent
+    public class SAMAnalyticalExtendPanelByPlane : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// </summary>
         protected override System.Drawing.Bitmap Icon => Core.Convert.ToBitmap(Resources.SAM_Small);
 
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -37,19 +37,36 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            inputParamManager.AddPlaneParameter("_plane", "_plane", "Plane", GH_ParamAccess.item);
-            inputParamManager.AddNumberParameter("_tolerance_", "_tolerance", "Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Plane() { Name = "_plane", NickName = "_plane", Description = "Plane", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "SAM Analytical Panels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,15 +77,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panels");
             List<Panel> panels = new List<Panel>();
-            if (!dataAccess.GetDataList(0, panels))
+            if (index == -1 || !dataAccess.GetDataList(index, panels))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_plane");
             Plane plane_Rhino = Plane.Unset;
-            if (!dataAccess.GetData(1, ref plane_Rhino) || plane_Rhino == Plane.Unset)
+            if (index == -1 || !dataAccess.GetData(index, ref plane_Rhino) || plane_Rhino == Plane.Unset)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -76,8 +97,9 @@ namespace SAM.Analytical.Grasshopper
 
             Geometry.Spatial.Plane plane = Geometry.Rhino.Convert.ToSAM(plane_Rhino);
 
+            index = Params.IndexOfInputParam("_tolerance_");
             double tolerance = Core.Tolerance.Distance;
-            if (!dataAccess.GetData(2, ref tolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -85,7 +107,11 @@ namespace SAM.Analytical.Grasshopper
 
             List<Panel> result = panels.ConvertAll(x => Analytical.Query.Extend(x, plane, Core.Tolerance.MacroDistance, tolerance));
 
-            dataAccess.SetDataList(0, result?.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result?.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalExternalVector3D.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalExternalVector3D.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalExternalVector3D : GH_SAMComponent
+    public class SAMAnalyticalExternalVector3D : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,19 +39,29 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAdjacencyClusterParam(), "_adjacencyCluster", "_adjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_panel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooSpaceParam(), "_space", "_space", "SAM Analytical Space", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_space", NickName = "_space", Description = "SAM Analytical Space", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("Vector3D", "Vector3D", "External Vector3D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Vector3D", NickName = "Vector3D", Description = "External Vector3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -61,28 +72,37 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_adjacencyCluster");
             AdjacencyCluster adjacencyCluster = null;
-            if (!dataAccess.GetData(0, ref adjacencyCluster) || adjacencyCluster == null)
+            if (index == -1 || !dataAccess.GetData(index, ref adjacencyCluster) || adjacencyCluster == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_panel");
             Panel panel = null;
-            if (!dataAccess.GetData(1, ref panel) || panel == null)
+            if (index == -1 || !dataAccess.GetData(index, ref panel) || panel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_space");
             Space space = null;
-            if (!dataAccess.GetData(2, ref space) || space == null)
+            if (index == -1 || !dataAccess.GetData(index, ref space) || space == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            dataAccess.SetData(0, Analytical.Query.ExternalVector3D(adjacencyCluster, space, panel));
+            index = Params.IndexOfOutputParam("Vector3D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, Analytical.Query.ExternalVector3D(adjacencyCluster, space, panel));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilter.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilter.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalFilter : GH_SAMComponent
+    public class SAMAnalyticalFilter : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,19 +40,29 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAdjacencyClusterParam(), "_adjacencyCluster", "_adjacencyCluster", "SAM Analytical Adjacency Cluster", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooSpaceParam(), "_spaces", "_spaces", "SAM Analytical Spaces", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Analytical Adjacency Cluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_spaces", NickName = "_spaces", Description = "SAM Analytical Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAdjacencyClusterParam(), "AdjacencyCluster", "AdjacencyCluster", "SAM Analytical Adjacency Cluster", GH_ParamAccess.item);
-            outputParamManager.AddGenericParameter("Objects", "Objects", "SAM Objects", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "AdjacencyCluster", NickName = "AdjacencyCluster", Description = "SAM Analytical Adjacency Cluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Objects", NickName = "Objects", Description = "SAM Objects", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,15 +73,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_adjacencyCluster");
             AdjacencyCluster adjacencyCluster = null;
-            if (!dataAccess.GetData(0, ref adjacencyCluster) || adjacencyCluster == null)
+            if (index == -1 || !dataAccess.GetData(index, ref adjacencyCluster) || adjacencyCluster == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_spaces");
             List<Space> spaces = new List<Space>();
-            if (!dataAccess.GetDataList(1, spaces) || spaces == null)
+            if (index == -1 || !dataAccess.GetDataList(index, spaces) || spaces == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -98,8 +112,17 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetData(0, new GooAdjacencyCluster(adjacencyCluster_New));
-            dataAccess.SetDataList(1, objects);
+            index = Params.IndexOfOutputParam("AdjacencyCluster");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAdjacencyCluster(adjacencyCluster_New));
+            }
+
+            index = Params.IndexOfOutputParam("Objects");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, objects);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilterByElevation.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilterByElevation.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalFilterByElevation : GH_SAMComponent
+    public class SAMAnalyticalFilterByElevation : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.2";
+        public override string LatestComponentVersion => "1.0.3";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,25 +40,38 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddGenericParameter("_analyticals", "_analyticals", "SAM Analytical Panels or Spaces", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_analyticals", NickName = "_analyticals", Description = "SAM Analytical Panels or Spaces", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("_elevation", "_elevation", "Elevation", GH_ParamAccess.item);
-            index = inputParamManager.AddNumberParameter("_tolerance", "_tolerance", "Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_elevation", NickName = "_elevation", Description = "Elevation", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance", NickName = "_tolerance", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("Analyticals", "Analyticals", "SAM Analytical Panels or Spaces", GH_ParamAccess.list);
-            outputParamManager.AddGenericParameter("UpperAnalyticals", "UpperAnalyticals", "Upper SAM Analytical Panels or Spaces", GH_ParamAccess.list);
-            outputParamManager.AddGenericParameter("LowerAnalyticals", "LowerAnalyticals", "Lower SAM Analytical Panels or Spaces", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Analyticals", NickName = "Analyticals", Description = "SAM Analytical Panels or Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "UpperAnalyticals", NickName = "UpperAnalyticals", Description = "Upper SAM Analytical Panels or Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "LowerAnalyticals", NickName = "LowerAnalyticals", Description = "Lower SAM Analytical Panels or Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -69,8 +82,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analyticals");
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
-            if (!dataAccess.GetDataList(0, objectWrappers))
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrappers))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -85,8 +101,9 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
+            index = Params.IndexOfInputParam("_elevation");
             GH_ObjectWrapper objectWrapper_Elevation = null;
-            if (!dataAccess.GetData(1, ref objectWrapper_Elevation))
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper_Elevation))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -128,8 +145,9 @@ namespace SAM.Analytical.Grasshopper
                 elevation = panel.MinElevation();
             }
 
+            index = Params.IndexOfInputParam("_tolerance");
             double tolerance = double.NaN;
-            if (!dataAccess.GetData(2, ref tolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -168,9 +186,23 @@ namespace SAM.Analytical.Grasshopper
             spaces_Lower?.ForEach(x => result_Lower.Add(x));
             spaces_Upper?.ForEach(x => result_Upper.Add(x));
 
-            dataAccess.SetDataList(0, result);
-            dataAccess.SetDataList(1, result_Upper);
-            dataAccess.SetDataList(2, result_Lower);
+            index = Params.IndexOfOutputParam("Analyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result);
+            }
+
+            index = Params.IndexOfOutputParam("UpperAnalyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result_Upper);
+            }
+
+            index = Params.IndexOfOutputParam("LowerAnalyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result_Lower);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilterByMaxRectangle3D.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilterByMaxRectangle3D.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalFilterByMaxRectangle3D : GH_SAMComponent
+    public class SAMAnalyticalFilterByMaxRectangle3D : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,24 +39,39 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddNumberParameter("_panelMinDimension", "_panelMinDimension", "Minimal dimesion for Panel Rectangle3D", GH_ParamAccess.item, 0);
-            index = inputParamManager.AddNumberParameter("_apertureMinDimension", "_apertureMinDimension", "Minimal dimesion for Aperture Rectangle3D", GH_ParamAccess.item, 0);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_panelMinDimension", NickName = "_panelMinDimension", Description = "Minimal dimesion for Panel Rectangle3D", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0.0);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_apertureMinDimension", NickName = "_apertureMinDimension", Description = "Minimal dimesion for Aperture Rectangle3D", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0.0);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "in", "in", "SAM Analytical Panels", GH_ParamAccess.list);
-            outputParamManager.AddGenericParameter("out", "out", "out", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "in", NickName = "in", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "out", NickName = "out", Description = "out", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,22 +82,27 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_panels");
             List<Panel> panels = new List<Panel>();
-            if (!dataAccess.GetDataList(0, panels))
+            if (index == -1 || !dataAccess.GetDataList(index, panels))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_panelMinDimension");
             double panelMinDimension = 0;
-            if (!dataAccess.GetData(1, ref panelMinDimension))
+            if (index == -1 || !dataAccess.GetData(index, ref panelMinDimension))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_apertureMinDimension");
             double apertureMinDimension = 0;
-            if (!dataAccess.GetData(2, ref apertureMinDimension))
+            if (index == -1 || !dataAccess.GetData(index, ref apertureMinDimension))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -125,8 +145,18 @@ namespace SAM.Analytical.Grasshopper
                     }
                 }
             }
-            dataAccess.SetDataList(0, panels_In?.ConvertAll(x => new GooPanel(x)));
-            dataAccess.SetDataList(1, objects_Out);
+
+            index = Params.IndexOfOutputParam("in");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels_In?.ConvertAll(x => new GooPanel(x)));
+            }
+
+            index = Params.IndexOfOutputParam("out");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, objects_Out);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilterByPanelAreaAndThinnessRatio.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilterByPanelAreaAndThinnessRatio.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalFilterByPanelAreaAndThinnessRatio : GH_SAMComponent
+    public class SAMAnalyticalFilterByPanelAreaAndThinnessRatio : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,23 +39,40 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_analytical", "_analytical", "SAM Analytical AdjacencyCluster or AnalyticalModel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            int index = -1;
-            index = inputParamManager.AddNumberParameter("_minArea_", "_minArea_", "Minimal Area", GH_ParamAccess.item, 0.003);
-            index = inputParamManager.AddNumberParameter("_minThinnessRatio_", "_minThinnessRatio_", "Minimal Thinness Ratio", GH_ParamAccess.item, 0.003);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical AdjacencyCluster or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_minArea_", NickName = "_minArea_", Description = "Minimal Area", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0.003);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_minThinnessRatio_", NickName = "_minThinnessRatio_", Description = "Minimal Thinness Ratio", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0.003);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("Analytical", "Analytical", "SAM Analytical AdjacencyCluster or AnalyticalModel", GH_ParamAccess.item);
-            outputParamManager.AddParameter(new GooPanelParam(), "In", "In", "SAM Analytical Panels left in SAMAnlayticalCluster", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooPanelParam(), "Out", "Out", "SAM Analytical Panels removed from SAMAnlayticalCluster", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Analytical", NickName = "Analytical", Description = "SAM Analytical AdjacencyCluster or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "In", NickName = "In", Description = "SAM Analytical Panels left in SAMAnlayticalCluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Out", NickName = "Out", Description = "SAM Analytical Panels removed from SAMAnlayticalCluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -66,19 +83,24 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analytical");
             Core.SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || sAMObject == null)
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || sAMObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_minArea_");
             double minArea = 0.003;
-            if (!dataAccess.GetData(1, ref minArea))
+            if (index == -1 || !dataAccess.GetData(index, ref minArea))
                 minArea = 0.003;
 
+            index = Params.IndexOfInputParam("_minThinnessRatio_");
             double minThinnessRatio = 0.003;
-            if (!dataAccess.GetData(2, ref minThinnessRatio))
+            if (index == -1 || !dataAccess.GetData(index, ref minThinnessRatio))
                 minThinnessRatio = 0.003;
 
             AdjacencyCluster adjacencyCluster = null;
@@ -100,9 +122,24 @@ namespace SAM.Analytical.Grasshopper
 
             if (panels == null || panels.Count == 0)
             {
-                dataAccess.SetData(0, sAMObject);
-                dataAccess.SetDataList(1, null);
-                dataAccess.SetDataList(2, null);
+                index = Params.IndexOfOutputParam("Analytical");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, sAMObject);
+                }
+
+                index = Params.IndexOfOutputParam("In");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, null);
+                }
+
+                index = Params.IndexOfOutputParam("Out");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, null);
+                }
+
                 return;
             }
 
@@ -132,21 +169,34 @@ namespace SAM.Analytical.Grasshopper
                 panels_Out.Add(Create.Panel(panel));
             }
 
-            if (sAMObject is AdjacencyCluster)
+            index = Params.IndexOfOutputParam("Analytical");
+            if (index != -1)
             {
-                dataAccess.SetData(0, new GooAdjacencyCluster(adjacencyCluster));
-            }
-            else if (sAMObject is AnalyticalModel)
-            {
-                dataAccess.SetData(0, new GooAnalyticalModel(new AnalyticalModel((AnalyticalModel)sAMObject, adjacencyCluster)));
-            }
-            else
-            {
-                dataAccess.SetData(0, sAMObject);
+                if (sAMObject is AdjacencyCluster)
+                {
+                    dataAccess.SetData(index, new GooAdjacencyCluster(adjacencyCluster));
+                }
+                else if (sAMObject is AnalyticalModel)
+                {
+                    dataAccess.SetData(index, new GooAnalyticalModel(new AnalyticalModel((AnalyticalModel)sAMObject, adjacencyCluster)));
+                }
+                else
+                {
+                    dataAccess.SetData(index, sAMObject);
+                }
             }
 
-            dataAccess.SetDataList(1, panels_In?.ConvertAll(x => new GooPanel(x)));
-            dataAccess.SetDataList(2, panels_Out?.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("In");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels_In?.ConvertAll(x => new GooPanel(x)));
+            }
+
+            index = Params.IndexOfOutputParam("Out");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels_Out?.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilterBySpaces.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFilterBySpaces.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalFilterBySpaces : GH_SAMComponent
+    public class SAMAnalyticalFilterBySpaces : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,18 +39,28 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_analytical", "_analytical", "SAM Analytical AdjacencyCluster or AnalyticalModel", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooSpaceParam(), "Spaces", "Spaces", "SAM Geometry Spaces", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical AdjacencyCluster or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "Spaces", NickName = "Spaces", Description = "SAM Geometry Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalObjectParam(), "analytical", "analytical", "SAM Analytical AdjacencyCluster or AnalyticalModel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "analytical", NickName = "analytical", Description = "SAM Analytical AdjacencyCluster or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -61,8 +71,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analytical");
             IAnalyticalObject analyticalObject = null;
-            if (!dataAccess.GetData(0, ref analyticalObject) || analyticalObject == null)
+            if (index == -1 || !dataAccess.GetData(index, ref analyticalObject) || analyticalObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -78,8 +91,9 @@ namespace SAM.Analytical.Grasshopper
                 adjacencyCluster = ((AnalyticalModel)analyticalObject).AdjacencyCluster;
             }
 
+            index = Params.IndexOfInputParam("Spaces");
             List<Space> spaces = new List<Space>();
-            if (!dataAccess.GetDataList(1, spaces) || spaces == null)
+            if (index == -1 || !dataAccess.GetDataList(index, spaces) || spaces == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -98,7 +112,11 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetData(0, new GooAnalyticalObject(analyticalObject));
+            index = Params.IndexOfOutputParam("analytical");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAnalyticalObject(analyticalObject));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFlipPanel.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalFlipPanel.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalFlipPanel : GH_SAMComponent
+    public class SAMAnalyticalFlipPanel : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,21 +39,29 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooPanelParam(), "panel_", "panel_", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "panel_", NickName = "panel_", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panel", "Panel", "SAM Analytical Panel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panel", NickName = "Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,8 +72,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("panel_");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel) || panel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Connect valid SAM Panel");
                 return;
@@ -73,7 +85,11 @@ namespace SAM.Analytical.Grasshopper
             panel = Create.Panel(panel);
             panel.FlipNormal(true, false);
 
-            dataAccess.SetData(0, new GooPanel(panel));
+            index = Params.IndexOfOutputParam("Panel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooPanel(panel));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGeometry.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGeometry.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGeometry : GH_SAMComponent
+    public class SAMAnalyticalGeometry : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,20 +41,44 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_SAMAnalytical", "_SAMAnalytical", "SAM Analytical Object", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_cutApertures", "_cutApertures", "Cut Apertures If Applicable", GH_ParamAccess.item, false);
-            inputParamManager.AddBooleanParameter("_includeFrame", "_includeFrame", "Include Frame", GH_ParamAccess.item, false);
-            inputParamManager.AddNumberParameter("_tolerance_", "_tolerance_", "Tolerance", GH_ParamAccess.item, 0.00001);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_SAMAnalytical", NickName = "_SAMAnalytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_cutApertures", NickName = "_cutApertures", Description = "Cut Apertures If Applicable", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_includeFrame", NickName = "_includeFrame", Description = "Include Frame", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0.00001);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGeometryParameter("Geometry", "Geometry", "Geometry in GH ie.Surface", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Geometry() { Name = "Geometry", NickName = "Geometry", Description = "Geometry in GH ie.Surface", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,29 +89,35 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_SAMAnalytical");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || sAMObject == null)
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || sAMObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             bool cutApertures = false;
-            if (!dataAccess.GetData(1, ref cutApertures))
+            index = Params.IndexOfInputParam("_cutApertures");
+            if (index == -1 || !dataAccess.GetData(index, ref cutApertures))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             bool includeFrame = false;
-            if (!dataAccess.GetData(2, ref includeFrame))
+            index = Params.IndexOfInputParam("_includeFrame");
+            if (index == -1 || !dataAccess.GetData(index, ref includeFrame))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             double tolerance = 0.00001;
-            if (!dataAccess.GetData(3, ref tolerance))
+            index = Params.IndexOfInputParam("_tolerance_");
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -125,7 +155,11 @@ namespace SAM.Analytical.Grasshopper
                     result.AddRange(breps);
             }
 
-            dataAccess.SetDataList(0, result);
+            index = Params.IndexOfOutputParam("Geometry");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetAdjacentSpaceNames.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetAdjacentSpaceNames.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetAdjacentSpaceNames : GH_SAMComponent
+    public class SAMAnalyticalGetAdjacentSpaceNames : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -42,23 +42,32 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster oor AnalyticalModel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            GooPanelParam gooPanelParam = new GooPanelParam();
-            gooPanelParam.Optional = true;
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster oor AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            inputParamManager.AddParameter(gooPanelParam, "panles", "panels", "SAM Analytical Panels", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "panels", NickName = "panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            outputParamManager.AddTextParameter("SpaceNames", "SpaceNames", "Space Names", GH_ParamAccess.tree);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "SpaceNames", NickName = "SpaceNames", Description = "Space Names", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -69,8 +78,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analyticalObject");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || sAMObject == null)
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || sAMObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -89,7 +101,11 @@ namespace SAM.Analytical.Grasshopper
             }
 
             List<Panel> panels = new List<Panel>();
-            dataAccess.GetDataList(1, panels);
+            index = Params.IndexOfInputParam("panels");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, panels);
+            }
 
             List<Panel> panels_Temp = adjacencyCluster.GetPanels();
             if (panels != null && panels.Count != 0)
@@ -110,8 +126,17 @@ namespace SAM.Analytical.Grasshopper
                 count++;
             }
 
-            dataAccess.SetDataList(0, panels_Temp.ConvertAll(x => new GooPanel(x)));
-            dataAccess.SetDataTree(1, dataTree_Names);
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels_Temp.ConvertAll(x => new GooPanel(x)));
+            }
+
+            index = Params.IndexOfOutputParam("SpaceNames");
+            if (index != -1)
+            {
+                dataAccess.SetDataTree(index, dataTree_Names);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetDefaultApertureConstructions.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetDefaultApertureConstructions.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetDefaultApertureConstructions : GH_SAMComponent
+    public class SAMAnalyticalGetDefaultApertureConstructions : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,23 +40,35 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddTextParameter("_apertureTypes_", "_apertureTypes_", "SAM Analytical ApertureTypes", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
 
-            index = inputParamManager.AddTextParameter("_panelTypes_", "_panelTypes_", "SAM Analytical PanelTypes", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_apertureTypes_", NickName = "_apertureTypes_", Description = "SAM Analytical ApertureTypes", Access = GH_ParamAccess.list, Optional = true };
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_panelTypes_", NickName = "_panelTypes_", Description = "SAM Analytical PanelTypes", Access = GH_ParamAccess.list, Optional = true };
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooApertureConstructionParam(), "ApertureConstructions", "ApertureConstructions", "SAM Analytical Aperture Constructions", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooApertureConstructionParam() { Name = "ApertureConstructions", NickName = "ApertureConstructions", Description = "SAM Analytical Aperture Constructions", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,10 +79,16 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<string> values = null;
 
             values = new List<string>();
-            dataAccess.GetDataList(0, values);
+            index = Params.IndexOfInputParam("_apertureTypes_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, values);
+            }
 
             List<ApertureType> apertureTypes = null;
             if (values != null && values.Count > 0)
@@ -98,7 +116,11 @@ namespace SAM.Analytical.Grasshopper
             }
 
             values = new List<string>();
-            dataAccess.GetDataList(1, values);
+            index = Params.IndexOfInputParam("_panelTypes_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, values);
+            }
 
             List<PanelType> panelTypes = null;
             if (values != null && values.Count > 0)
@@ -139,7 +161,11 @@ namespace SAM.Analytical.Grasshopper
                         apertureConstructions.Add(apertureConstruction);
                 }
 
-            dataAccess.SetDataList(0, apertureConstructions?.ConvertAll(x => new GooApertureConstruction(x)));
+            index = Params.IndexOfOutputParam("ApertureConstructions");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, apertureConstructions?.ConvertAll(x => new GooApertureConstruction(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetDefaultConstructions.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetDefaultConstructions.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetDefaultConstructions : GH_SAMComponent
+    public class SAMAnalyticalGetDefaultConstructions : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,18 +40,31 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = inputParamManager.AddTextParameter("_panelTypes_", "_panelTypes_", "SAM PanelTypes", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_panelTypes_", NickName = "_panelTypes_", Description = "SAM PanelTypes", Access = GH_ParamAccess.list, Optional = true };
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooConstructionParam(), "Constructions", "Construction", "SAM Geometry Spaces", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "Constructions", NickName = "Construction", Description = "SAM Geometry Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,8 +75,14 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<string> panelTypeStrings = new List<string>();
-            dataAccess.GetDataList(0, panelTypeStrings);
+            index = Params.IndexOfInputParam("_panelTypes_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, panelTypeStrings);
+            }
 
             List<PanelType> panelTypes = null;
             if (panelTypeStrings != null && panelTypeStrings.Count > 0)
@@ -90,7 +109,11 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            dataAccess.SetDataList(0, panelTypes.ConvertAll(x => new GooConstruction(Analytical.Query.DefaultConstruction(x))));
+            index = Params.IndexOfOutputParam("Constructions");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panelTypes.ConvertAll(x => new GooConstruction(Analytical.Query.DefaultConstruction(x))));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetDefaultGasMaterials.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetDefaultGasMaterials.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetDefaultGasMaterials : GH_SAMComponent
+    public class SAMAnalyticalGetDefaultGasMaterials : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,18 +40,31 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = inputParamManager.AddTextParameter("_defaultGasType_", "_defaultGasType_", "SAM Analytical DefaultGasType", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_defaultGasType_", NickName = "_defaultGasType_", Description = "SAM Analytical DefaultGasType", Access = GH_ParamAccess.list, Optional = true };
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooMaterialParam(), "GasMaterials", "GasMaterials", "SAM GasMaterials", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooMaterialParam() { Name = "GasMaterials", NickName = "GasMaterials", Description = "SAM GasMaterials", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,8 +75,14 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<string> defaultGasTypeStrings = new List<string>();
-            dataAccess.GetDataList(0, defaultGasTypeStrings);
+            index = Params.IndexOfInputParam("_defaultGasType_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, defaultGasTypeStrings);
+            }
 
             List<DefaultGasType> defaultGasTypes = null;
             if (defaultGasTypeStrings != null && defaultGasTypeStrings.Count > 0)
@@ -90,7 +109,11 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            dataAccess.SetDataList(0, defaultGasTypes.ConvertAll(x => new GooMaterial(Analytical.Query.DefaultGasMaterial(x))));
+            index = Params.IndexOfOutputParam("GasMaterials");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, defaultGasTypes.ConvertAll(x => new GooMaterial(Analytical.Query.DefaultGasMaterial(x))));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetExternalMaterials.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetExternalMaterials.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetExternalMaterials : GH_SAMComponent
+    public class SAMAnalyticalGetExternalMaterials : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -42,29 +42,36 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAdjacencyClusterParam(), "_adjacencyCluster", "_adjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            GooSpaceParam gooSpaceParam = new GooSpaceParam();
-            gooSpaceParam.Optional = true;
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            inputParamManager.AddParameter(gooSpaceParam, "_spaces_", "_spaces_", "SAM Analytical Spaces", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_spaces_", NickName = "_spaces_", Description = "SAM Analytical Spaces", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
 
-            GooMaterialLibraryParam gooMaterialLibraryParam = new GooMaterialLibraryParam();
-            gooMaterialLibraryParam.Optional = true;
-            inputParamManager.AddParameter(gooMaterialLibraryParam, "_materialLibrary", "_materialLibrary", "SAM MaterialLibrary", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "_materialLibrary", NickName = "_materialLibrary", Description = "SAM MaterialLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSpaceParam(), "Spaces", "Spaces", "SAM Spaces", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooMaterialParam(), "Materials", "Materials", "SAM Materials", GH_ParamAccess.tree);
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "Panels", GH_ParamAccess.tree);
-            outputParamManager.AddNumberParameter("Areas", "Areas", "Areas", GH_ParamAccess.tree);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "Spaces", NickName = "Spaces", Description = "SAM Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooMaterialParam() { Name = "Materials", NickName = "Materials", Description = "SAM Materials", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "Panels", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Areas", NickName = "Areas", Description = "Areas", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -75,21 +82,32 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_adjacencyCluster");
             AdjacencyCluster adjacencyCluster = null;
-            if (!dataAccess.GetData(0, ref adjacencyCluster) || adjacencyCluster == null)
+            if (index == -1 || !dataAccess.GetData(index, ref adjacencyCluster) || adjacencyCluster == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<Space> spaces = new List<Space>();
-            dataAccess.GetDataList(1, spaces);
+            index = Params.IndexOfInputParam("_spaces_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, spaces);
+            }
 
             if (spaces == null || spaces.Count == 0)
                 spaces = adjacencyCluster.GetSpaces();
 
             MaterialLibrary materialLibrary = null;
-            dataAccess.GetData(2, ref materialLibrary);
+            index = Params.IndexOfInputParam("_materialLibrary");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref materialLibrary);
+            }
             if (materialLibrary == null)
                 materialLibrary = ActiveSetting.Setting.GetValue<MaterialLibrary>(AnalyticalSettingParameter.DefaultMaterialLibrary);
 
@@ -121,10 +139,29 @@ namespace SAM.Analytical.Grasshopper
                     count++;
                 }
 
-                dataAccess.SetDataList(0, spaces_Temp.ConvertAll(x => new GooSpace(x)));
-                dataAccess.SetDataTree(1, dataTree_Materials);
-                dataAccess.SetDataTree(2, dataTree_Panels);
-                dataAccess.SetDataTree(3, dataTree_Areas);
+                index = Params.IndexOfOutputParam("Spaces");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, spaces_Temp.ConvertAll(x => new GooSpace(x)));
+                }
+
+                index = Params.IndexOfOutputParam("Materials");
+                if (index != -1)
+                {
+                    dataAccess.SetDataTree(index, dataTree_Materials);
+                }
+
+                index = Params.IndexOfOutputParam("Panels");
+                if (index != -1)
+                {
+                    dataAccess.SetDataTree(index, dataTree_Panels);
+                }
+
+                index = Params.IndexOfOutputParam("Areas");
+                if (index != -1)
+                {
+                    dataAccess.SetDataTree(index, dataTree_Areas);
+                }
             }
         }
     }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetInternalConditionTextMap.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetInternalConditionTextMap.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetInternalConditionTextMap : GH_SAMComponent
+    public class SAMAnalyticalGetInternalConditionTextMap : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,17 +39,27 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooTextMapParam(), "TextMap", "TextMap", "SAM Core TextMap", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooTextMapParam() { Name = "TextMap", NickName = "TextMap", Description = "SAM Core TextMap", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -59,7 +70,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            dataAccess.SetData(0, new GooTextMap(ActiveSetting.Setting.GetValue<Core.TextMap>(AnalyticalSettingParameter.InternalConditionTextMap)));
+            int index = Params.IndexOfOutputParam("TextMap");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooTextMap(ActiveSetting.Setting.GetValue<Core.TextMap>(AnalyticalSettingParameter.InternalConditionTextMap)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetInternalConstructionLayers.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetInternalConstructionLayers.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetInternalConstructionLayers : GH_SAMComponent
+    public class SAMAnalyticalGetInternalConstructionLayers : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,25 +41,34 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAdjacencyClusterParam(), "_adjacencyCluster", "_adjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            GooSpaceParam gooSpaceParam = new GooSpaceParam();
-            gooSpaceParam.Optional = true;
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            inputParamManager.AddParameter(gooSpaceParam, "_spaces", "_spaces", "SAM Analytical Spaces", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_spaces", NickName = "_spaces", Description = "SAM Analytical Spaces", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSpaceParam(), "Spaces", "Spaces", "SAM Spaces", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooConstructionLayerParam(), "ConstructionLayers", "ConstructionLayers", "SAM Analytical ConstructionLayers", GH_ParamAccess.tree);
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "Panels", GH_ParamAccess.tree);
-            outputParamManager.AddNumberParameter("Areas", "Areas", "Areas", GH_ParamAccess.tree);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "Spaces", NickName = "Spaces", Description = "SAM Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooConstructionLayerParam() { Name = "ConstructionLayers", NickName = "ConstructionLayers", Description = "SAM Analytical ConstructionLayers", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "Panels", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Areas", NickName = "Areas", Description = "Areas", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -70,20 +79,46 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            dataAccess.SetDataList(0, null);
-            dataAccess.SetDataList(1, null);
-            dataAccess.SetDataList(2, null);
-            dataAccess.SetDataList(3, null);
+            int index = -1;
 
+            index = Params.IndexOfOutputParam("Spaces");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, null);
+            }
+
+            index = Params.IndexOfOutputParam("ConstructionLayers");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, null);
+            }
+
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, null);
+            }
+
+            index = Params.IndexOfOutputParam("Areas");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, null);
+            }
+
+            index = Params.IndexOfInputParam("_adjacencyCluster");
             AdjacencyCluster adjacencyCluster = null;
-            if (!dataAccess.GetData(0, ref adjacencyCluster) || adjacencyCluster == null)
+            if (index == -1 || !dataAccess.GetData(index, ref adjacencyCluster) || adjacencyCluster == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<Space> spaces = new List<Space>();
-            dataAccess.GetDataList(1, spaces);
+            index = Params.IndexOfInputParam("_spaces");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, spaces);
+            }
 
             if (spaces == null || spaces.Count == 0)
                 spaces = adjacencyCluster.GetSpaces();
@@ -116,10 +151,29 @@ namespace SAM.Analytical.Grasshopper
                     count++;
                 }
 
-                dataAccess.SetDataList(0, spaces.ConvertAll(x => new GooSpace(x)));
-                dataAccess.SetDataTree(1, dataTree_ConstructionLayers);
-                dataAccess.SetDataTree(2, dataTree_Panels);
-                dataAccess.SetDataTree(3, dataTree_Areas);
+                index = Params.IndexOfOutputParam("Spaces");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, spaces.ConvertAll(x => new GooSpace(x)));
+                }
+
+                index = Params.IndexOfOutputParam("ConstructionLayers");
+                if (index != -1)
+                {
+                    dataAccess.SetDataTree(index, dataTree_ConstructionLayers);
+                }
+
+                index = Params.IndexOfOutputParam("Panels");
+                if (index != -1)
+                {
+                    dataAccess.SetDataTree(index, dataTree_Panels);
+                }
+
+                index = Params.IndexOfOutputParam("Areas");
+                if (index != -1)
+                {
+                    dataAccess.SetDataTree(index, dataTree_Areas);
+                }
             }
         }
     }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetInternalMaterials.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetInternalMaterials.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetInternalMaterials : GH_SAMComponent
+    public class SAMAnalyticalGetInternalMaterials : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -42,29 +42,36 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAdjacencyClusterParam(), "_adjacencyCluster", "_adjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            GooSpaceParam gooSpaceParam = new GooSpaceParam();
-            gooSpaceParam.Optional = true;
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            inputParamManager.AddParameter(gooSpaceParam, "_spaces_", "_spaces_", "SAM Analytical Spaces", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_spaces_", NickName = "_spaces_", Description = "SAM Analytical Spaces", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
 
-            GooMaterialLibraryParam gooMaterialLibraryParam = new GooMaterialLibraryParam();
-            gooMaterialLibraryParam.Optional = true;
-            inputParamManager.AddParameter(gooMaterialLibraryParam, "_materialLibrary", "_materialLibrary", "SAM MaterialLibrary", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "_materialLibrary", NickName = "_materialLibrary", Description = "SAM MaterialLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSpaceParam(), "Spaces", "Spaces", "SAM Spaces", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooMaterialParam(), "Materials", "Materials", "SAM Materials", GH_ParamAccess.tree);
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "Panels", GH_ParamAccess.tree);
-            outputParamManager.AddNumberParameter("Areas", "Areas", "Areas", GH_ParamAccess.tree);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "Spaces", NickName = "Spaces", Description = "SAM Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooMaterialParam() { Name = "Materials", NickName = "Materials", Description = "SAM Materials", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "Panels", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Areas", NickName = "Areas", Description = "Areas", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -75,21 +82,32 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_adjacencyCluster");
             AdjacencyCluster adjacencyCluster = null;
-            if (!dataAccess.GetData(0, ref adjacencyCluster) || adjacencyCluster == null)
+            if (index == -1 || !dataAccess.GetData(index, ref adjacencyCluster) || adjacencyCluster == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<Space> spaces = new List<Space>();
-            dataAccess.GetDataList(1, spaces);
+            index = Params.IndexOfInputParam("_spaces_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, spaces);
+            }
 
             if (spaces == null || spaces.Count == 0)
                 spaces = adjacencyCluster.GetSpaces();
 
             MaterialLibrary materialLibrary = null;
-            dataAccess.GetData(2, ref materialLibrary);
+            index = Params.IndexOfInputParam("_materialLibrary");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref materialLibrary);
+            }
             if (materialLibrary == null)
                 materialLibrary = ActiveSetting.Setting.GetValue<MaterialLibrary>(AnalyticalSettingParameter.DefaultMaterialLibrary);
 
@@ -121,10 +139,29 @@ namespace SAM.Analytical.Grasshopper
                     count++;
                 }
 
-                dataAccess.SetDataList(0, spaces_Temp.ConvertAll(x => new GooSpace(x)));
-                dataAccess.SetDataTree(1, dataTree_Materials);
-                dataAccess.SetDataTree(2, dataTree_Panels);
-                dataAccess.SetDataTree(3, dataTree_Areas);
+                index = Params.IndexOfOutputParam("Spaces");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, spaces_Temp.ConvertAll(x => new GooSpace(x)));
+                }
+
+                index = Params.IndexOfOutputParam("Materials");
+                if (index != -1)
+                {
+                    dataAccess.SetDataTree(index, dataTree_Materials);
+                }
+
+                index = Params.IndexOfOutputParam("Panels");
+                if (index != -1)
+                {
+                    dataAccess.SetDataTree(index, dataTree_Panels);
+                }
+
+                index = Params.IndexOfOutputParam("Areas");
+                if (index != -1)
+                {
+                    dataAccess.SetDataTree(index, dataTree_Areas);
+                }
             }
         }
     }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetPanels.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetPanels.cs
@@ -24,7 +24,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.1.0";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -51,7 +51,7 @@ namespace SAM.Analytical.Grasshopper
             get
             {
                 List<GH_SAMParam> result = new List<GH_SAMParam>();
-                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Object such as AdjacencyCluster or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam { Name = "_analyticals", NickName = "_analyticals", Description = "SAM Analytical Object such as AdjacencyCluster, AnalyticalModel or Panel", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
                 result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject { Name = "_objects", NickName = "_objects", Description = "Objects such as Point, SAM Analytical Construction, Aperture etc.", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
                 global::Grasshopper.Kernel.Parameters.Param_Number number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item };
@@ -85,37 +85,67 @@ namespace SAM.Analytical.Grasshopper
         {
             int index = -1;
 
-            index = Params.IndexOfInputParam("_analytical");
+            index = Params.IndexOfInputParam("_analyticals");
             if (index == -1)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            IAnalyticalObject analyticalObject_Temp = null;
-            if (!dataAccess.GetData(index, ref analyticalObject_Temp) || analyticalObject_Temp == null)
+            List<IAnalyticalObject> analyticalObjects = new List<IAnalyticalObject>();
+            if (!dataAccess.GetDataList(index, analyticalObjects) || analyticalObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-
-            AdjacencyCluster adjacencyCluster = null;
-            AnalyticalModel analyticalModel = null;
-            if (analyticalObject_Temp is AdjacencyCluster)
-            {
-                adjacencyCluster = (AdjacencyCluster)analyticalObject_Temp;
-            }
-            else if (analyticalObject_Temp is AnalyticalModel)
-            {
-                analyticalModel = (AnalyticalModel)analyticalObject_Temp;
-                adjacencyCluster = analyticalModel.AdjacencyCluster;
-            }
-
-
-            if (adjacencyCluster == null)
+            analyticalObjects.RemoveAll(x => x == null);
+            if (analyticalObjects.Count == 0)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                return;
+            }
+
+            List<Panel> panels_Source = new List<Panel>();
+            List<AdjacencyCluster> adjacencyClusters = new List<AdjacencyCluster>();
+            List<AnalyticalModel> analyticalModels = new List<AnalyticalModel>();
+
+            foreach (IAnalyticalObject analyticalObject in analyticalObjects)
+            {
+                if (analyticalObject is Panel)
+                {
+                    panels_Source.Add((Panel)analyticalObject);
+                }
+                else if (analyticalObject is AdjacencyCluster)
+                {
+                    adjacencyClusters.Add((AdjacencyCluster)analyticalObject);
+                }
+                else if (analyticalObject is AnalyticalModel)
+                {
+                    analyticalModels.Add((AnalyticalModel)analyticalObject);
+                }
+            }
+
+            List<Panel> panels_Pool = new List<Panel>();
+            panels_Pool.AddRange(panels_Source);
+
+            foreach (AnalyticalModel analyticalModel in analyticalModels)
+            {
+                List<Panel> panels = analyticalModel?.AdjacencyCluster?.GetPanels();
+                if (panels != null && panels.Count > 0)
+                    panels_Pool.AddRange(panels);
+            }
+
+            foreach (AdjacencyCluster adjacencyCluster in adjacencyClusters)
+            {
+                List<Panel> panels = adjacencyCluster?.GetPanels();
+                if (panels != null && panels.Count > 0)
+                    panels_Pool.AddRange(panels);
+            }
+
+            if (panels_Pool.Count == 0)
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "No panels found");
                 return;
             }
 
@@ -145,6 +175,7 @@ namespace SAM.Analytical.Grasshopper
 
             DataTree<GooPanel> dataTree = new DataTree<GooPanel>();
             List<Tuple<GH_Path, ISAMGeometry3D>> tuples = new List<Tuple<GH_Path, ISAMGeometry3D>>();
+            bool hasGeometry = false;
 
             for (int i = 0; i < objectWrappers.Count; i++)
             {
@@ -160,28 +191,49 @@ namespace SAM.Analytical.Grasshopper
 
                 if (@object is Aperture)
                 {
-                    Panel panel = adjacencyCluster.GetPanel((Aperture)@object);
-                    if (panel != null)
+                    Aperture aperture = (Aperture)@object;
+                    foreach (Panel panel in panels_Pool)
                     {
-                        dataTree.Add(new GooPanel(Create.Panel(panel)), path);
+                        if (panel != null && panel.HasAperture(aperture.Guid))
+                        {
+                            dataTree.Add(new GooPanel(Create.Panel(panel)), path);
+                            break;
+                        }
                     }
                 }
                 else if (@object is ApertureConstruction)
                 {
-                    List<Panel> panels = adjacencyCluster.GetPanels((ApertureConstruction)@object);
-                    panels?.ForEach(x => dataTree.Add(new GooPanel(Create.Panel(x)), path));
+                    ApertureConstruction apertureConstruction = (ApertureConstruction)@object;
+                    foreach (Panel panel in panels_Pool)
+                    {
+                        if (panel == null)
+                            continue;
+
+                        List<Aperture> apertures = panel.Apertures;
+                        if (apertures == null || apertures.Count == 0)
+                            continue;
+
+                        if (apertures.Exists(x => x != null && x.TypeGuid == apertureConstruction.Guid))
+                            dataTree.Add(new GooPanel(Create.Panel(panel)), path);
+                    }
                 }
                 else if (@object is Construction)
                 {
-                    List<Panel> panels = adjacencyCluster.GetPanels((Construction)@object);
-                    panels?.ForEach(x => dataTree.Add(new GooPanel(Create.Panel(x)), path));
+                    Construction construction = (Construction)@object;
+                    foreach (Panel panel in panels_Pool)
+                    {
+                        if (panel != null && panel.TypeGuid == construction.Guid)
+                            dataTree.Add(new GooPanel(Create.Panel(panel)), path);
+                    }
                 }
                 else if (@object is Point3D)
                 {
+                    hasGeometry = true;
                     tuples.Add(new Tuple<GH_Path, ISAMGeometry3D>(path, (Point3D)@object));
                 }
                 else if (@object is Geometry.Planar.Point2D)
                 {
+                    hasGeometry = true;
                     Geometry.Planar.Point2D point2D = (Geometry.Planar.Point2D)@object;
                     tuples.Add(new Tuple<GH_Path, ISAMGeometry3D>(path, new Point3D(point2D.X, point2D.Y, 0)));
                 }
@@ -189,33 +241,51 @@ namespace SAM.Analytical.Grasshopper
                 {
                     Point3D point3D = Geometry.Grasshopper.Convert.ToSAM((GH_Point)@object);
                     if (point3D != null)
+                    {
+                        hasGeometry = true;
                         tuples.Add(new Tuple<GH_Path, ISAMGeometry3D>(path, point3D));
+                    }
                 }
                 else if (@object is global::Rhino.Geometry.Point3d)
                 {
                     Point3D point3D = Geometry.Rhino.Convert.ToSAM((global::Rhino.Geometry.Point3d)@object);
                     if (point3D != null)
+                    {
+                        hasGeometry = true;
                         tuples.Add(new Tuple<GH_Path, ISAMGeometry3D>(path, point3D));
+                    }
                 }
                 else
                 {
-                    if (Geometry.Grasshopper.Query.TryGetSAMGeometries(objectWrapper, out List<Face3D> face3Ds) && face3Ds != null)
+                    if (Geometry.Grasshopper.Query.TryGetSAMGeometries(objectWrapper, out List<Face3D> face3Ds) && face3Ds != null && face3Ds.Count > 0)
                     {
+                        hasGeometry = true;
                         face3Ds.ForEach(x => tuples.Add(new Tuple<GH_Path, ISAMGeometry3D>(path, x)));
                     }
-                    else if (Geometry.Grasshopper.Query.TryGetSAMGeometries(objectWrapper, out List<Plane> planes) && planes != null)
+                    else if (Geometry.Grasshopper.Query.TryGetSAMGeometries(objectWrapper, out List<Plane> planes) && planes != null && planes.Count > 0)
                     {
+                        hasGeometry = true;
                         planes.ForEach(x => tuples.Add(new Tuple<GH_Path, ISAMGeometry3D>(path, x)));
                     }
                 }
             }
 
-            if (tuples != null && tuples.Count != 0)
+            if (hasGeometry && tuples.Count > 0)
             {
-                List<Tuple<Panel, Face3D>> tuples_Temp = adjacencyCluster.GetPanels()?.ConvertAll(x => new Tuple<Panel, Face3D>(x, x?.Face3D));
-                tuples_Temp.RemoveAll(x => x.Item2 == null || x.Item1 == null);
+                List<Tuple<Panel, Face3D>> tuples_Temp = new List<Tuple<Panel, Face3D>>();
+                foreach (Panel panel in panels_Pool)
+                {
+                    if (panel == null)
+                        continue;
 
-                if (tuples_Temp != null && tuples_Temp.Count > 0)
+                    Face3D face3D = panel.Face3D;
+                    if (face3D == null)
+                        continue;
+
+                    tuples_Temp.Add(new Tuple<Panel, Face3D>(panel, face3D));
+                }
+
+                if (tuples_Temp.Count > 0)
                 {
                     foreach (Tuple<GH_Path, ISAMGeometry3D> tuple_Geometry in tuples)
                     {
@@ -232,14 +302,10 @@ namespace SAM.Analytical.Grasshopper
                             foreach (Tuple<Panel, Face3D> tuple_Panel in tuples_Temp)
                             {
                                 Face3D face3D = tuple_Panel.Item2;
-                                if (face3D == null)
-                                {
-                                    continue;
-                                }
 
                                 if (face3D.InRange(point3D, tolerance) || face3D.Inside(point3D, tolerance))
                                 {
-                                    dataTree.Add(new GooPanel(tuple_Panel.Item1), tuple_Geometry.Item1);
+                                    dataTree.Add(new GooPanel(Create.Panel(tuple_Panel.Item1)), tuple_Geometry.Item1);
                                 }
                             }
                         }
@@ -250,10 +316,6 @@ namespace SAM.Analytical.Grasshopper
                             foreach (Tuple<Panel, Face3D> tuple_Panel in tuples_Temp)
                             {
                                 Face3D face3D_Panel = tuple_Panel.Item2;
-                                if (face3D_Panel == null)
-                                {
-                                    continue;
-                                }
 
                                 if (face3D.Inside(face3D_Panel))
                                 {
@@ -268,10 +330,6 @@ namespace SAM.Analytical.Grasshopper
                             foreach (Tuple<Panel, Face3D> tuple_Panel in tuples_Temp)
                             {
                                 Face3D face3D_Panel = tuple_Panel.Item2;
-                                if (face3D_Panel == null)
-                                {
-                                    continue;
-                                }
 
                                 if (plane.On(face3D_Panel, tolerance))
                                 {
@@ -282,6 +340,7 @@ namespace SAM.Analytical.Grasshopper
                     }
                 }
             }
+
             index = Params.IndexOfOutputParam("panels");
             if (index != -1)
                 dataAccess.SetDataTree(index, dataTree);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetPanelsByConstruction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetPanelsByConstruction.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetPanelsByConstruction : GH_SAMComponent
+    public class SAMAnalyticalGetPanelsByConstruction : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,22 +40,31 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddParameter(new GooConstructionParam(), "_construction", "_construction", "SAM Analytical Construction", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "_construction", NickName = "_construction", Description = "SAM Analytical Construction", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "Panels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -66,15 +75,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_analyticalObject");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects) || sAMObjects == null)
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects) || sAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_construction");
             Construction construction = null;
-            if (!dataAccess.GetData(1, ref construction) || construction == null)
+            if (index == -1 || !dataAccess.GetData(index, ref construction) || construction == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -117,7 +130,11 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetDataList(0, panels.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetSortedKeys.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetSortedKeys.cs
@@ -6,10 +6,11 @@ using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGetSortedKeys : GH_SAMComponent
+    public class SAMAnalyticalGetSortedKeys : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,21 +40,36 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooTextMapParam(), "_textMap", "_textMap", "SAM Core TextMap", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_text", "_text", "Serached Text", GH_ParamAccess.item);
-            int index = inputParamManager.AddBooleanParameter("_caseSensitive_", "_caseSensitive_", "case Sensitive", GH_ParamAccess.item, false);
-            inputParamManager[index].Optional = true;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
+                result.Add(new GH_SAMParam(new GooTextMapParam() { Name = "_textMap", NickName = "_textMap", Description = "SAM Core TextMap", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_text", NickName = "_text", Description = "Serached Text", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_caseSensitive_", NickName = "_caseSensitive_", Description = "case Sensitive", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddTextParameter("Keys", "Keys", "Keys", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "Keys", NickName = "Keys", Description = "Keys", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,25 +80,39 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_textMap");
             TextMap textMap = null;
-            if (!dataAccess.GetData(0, ref textMap) || textMap == null)
+            if (index == -1 || !dataAccess.GetData(index, ref textMap) || textMap == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_text");
             string text = null;
-            if (!dataAccess.GetData(1, ref text) || string.IsNullOrEmpty(text))
+            if (index == -1 || !dataAccess.GetData(index, ref text) || string.IsNullOrEmpty(text))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             bool caseSensitive = false;
-            if (!dataAccess.GetData(2, ref caseSensitive))
-                caseSensitive = false;
+            index = Params.IndexOfInputParam("_caseSensitive_");
+            if (index != -1)
+            {
+                if (!dataAccess.GetData(index, ref caseSensitive))
+                {
+                    caseSensitive = false;
+                }
+            }
 
-            dataAccess.SetDataList(0, textMap.GetSortedKeys(text, caseSensitive));
+            index = Params.IndexOfOutputParam("Keys");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, textMap.GetSortedKeys(text, caseSensitive));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetSpaces.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGetSpaces.cs
@@ -145,7 +145,7 @@ namespace SAM.Analytical.Grasshopper
                 {
                     List<Space> spaces = adjacencyCluster.GetSpaces();
                     if (spaces == null || spaces.Count == 0)
-                        return;
+                        continue;
 
                     foreach (Space space in spaces)
                     {
@@ -234,7 +234,7 @@ namespace SAM.Analytical.Grasshopper
                 {
                     List<Space> spaces = adjacencyCluster.GetSpaces();
                     if (spaces == null || spaces.Count == 0)
-                        return;
+                        continue;
 
                     ProfileLibrary profileLibrary = analyticalModel.ProfileLibrary;
 
@@ -281,7 +281,7 @@ namespace SAM.Analytical.Grasshopper
                     List<Space> spaces = adjacencyCluster.GetSpaces();
                     if (spaces == null || spaces.Count == 0)
                     {
-                        return;
+                        continue;
                     }
 
                     Space space = spaces.Find(x => x != null && x.Name == (string)@object);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGrid.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalGrid.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalGrid : GH_SAMComponent
+    public class SAMAnalyticalGrid : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,27 +41,47 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_SAManalytical", "_SAManalytical", "SAM Analytical Object", GH_ParamAccess.list);
-            index = inputParamManager.AddPlaneParameter("plane_", "plane_", "GH Plane", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_SAManalytical", NickName = "_SAManalytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddPointParameter("origin_", "origin_", "GH Origin Point", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_Plane param_Plane;
+                param_Plane = new global::Grasshopper.Kernel.Parameters.Param_Plane() { Name = "plane_", NickName = "plane_", Description = "GH Plane", Access = GH_ParamAccess.item, Optional = true };
+                result.Add(new GH_SAMParam(param_Plane, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("_x_", "_x_", "Grid size on X Axis", GH_ParamAccess.item, 0.2);
-            inputParamManager.AddNumberParameter("_y_", "_y_", "Grid size on Y Axis", GH_ParamAccess.item, 0.2);
+                global::Grasshopper.Kernel.Parameters.Param_Point param_Point;
+                param_Point = new global::Grasshopper.Kernel.Parameters.Param_Point() { Name = "origin_", NickName = "origin_", Description = "GH Origin Point", Access = GH_ParamAccess.item, Optional = true };
+                result.Add(new GH_SAMParam(param_Point, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_x_", NickName = "_x_", Description = "Grid size on X Axis", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(0.2);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_y_", NickName = "_y_", Description = "Grid size on Y Axis", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(0.2);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddLineParameter("Lines", "Lines", "Lines", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Line() { Name = "Lines", NickName = "Lines", Description = "Lines", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -72,8 +92,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects))
+            index = Params.IndexOfInputParam("_SAManalytical");
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -104,7 +127,9 @@ namespace SAM.Analytical.Grasshopper
             Geometry.Spatial.Plane plane = null;
 
             Plane plane_Rhino = Plane.Unset;
-            dataAccess.GetData(1, ref plane_Rhino);
+            index = Params.IndexOfInputParam("plane_");
+            if (index != -1)
+                dataAccess.GetData(index, ref plane_Rhino);
             if (plane_Rhino.IsValid && plane_Rhino != Plane.Unset)
                 plane = Geometry.Rhino.Convert.ToSAM(plane_Rhino);
 
@@ -112,24 +137,32 @@ namespace SAM.Analytical.Grasshopper
             Geometry.Spatial.Point3D origin = null;
 
             Point3d origin_Rhino = Point3d.Unset;
-            dataAccess.GetData(2, ref origin_Rhino);
+            index = Params.IndexOfInputParam("origin_");
+            if (index != -1)
+                dataAccess.GetData(index, ref origin_Rhino);
             if (origin_Rhino.IsValid && origin_Rhino != Point3d.Unset)
                 origin = Geometry.Rhino.Convert.ToSAM(origin_Rhino);
 
             double x = 0.2;
-            dataAccess.GetData(3, ref x);
+            index = Params.IndexOfInputParam("_x_");
+            if (index != -1)
+                dataAccess.GetData(index, ref x);
             if (double.IsNaN(x))
                 x = 0.2;
 
             double y = 0.2;
-            dataAccess.GetData(4, ref y);
+            index = Params.IndexOfInputParam("_y_");
+            if (index != -1)
+                dataAccess.GetData(index, ref y);
             if (double.IsNaN(y))
                 y = 0.2;
 
 
             List<Geometry.Spatial.Segment3D> segment3Ds = Geometry.Object.Spatial.Query.Grid(panels, x, y, plane, origin, Tolerance.Angle, Tolerance.Distance, true);
 
-            dataAccess.SetDataList(0, segment3Ds?.ConvertAll(segment2D => Geometry.Rhino.Convert.ToRhino_Line(segment2D)));
+            index = Params.IndexOfOutputParam("Lines");
+            if (index != -1)
+                dataAccess.SetDataList(index, segment3Ds?.ConvertAll(segment2D => Geometry.Rhino.Convert.ToRhino_Line(segment2D)));
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalHeatTransferCoefficientByDefaultGasType.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalHeatTransferCoefficientByDefaultGasType.cs
@@ -8,10 +8,11 @@ using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalHeatTransferCoefficientByDefaultGasType : GH_SAMComponent
+    public class SAMAnalyticalHeatTransferCoefficientByDefaultGasType : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,27 +42,50 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
-            Param_GenericObject genericObjectParameter = null;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddGenericParameter("_defaultGasType_", "_defaultGasType_", "DefaultGasType", GH_ParamAccess.item);
-            genericObjectParameter = (Param_GenericObject)inputParamManager[index];
-            genericObjectParameter.PersistentData.Append(new GH_ObjectWrapper(DefaultGasType.Argon.ToString()));
+                global::Grasshopper.Kernel.Parameters.Param_GenericObject param_GenericObject;
+                param_GenericObject = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_defaultGasType_", NickName = "_defaultGasType_", Description = "DefaultGasType", Access = GH_ParamAccess.item, Optional = true };
+                param_GenericObject.PersistentData.Append(new GH_ObjectWrapper(DefaultGasType.Argon.ToString()));
+                result.Add(new GH_SAMParam(param_GenericObject, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("_width_", "_width_", "Cavity width [m]", GH_ParamAccess.item, 0.012);
-            inputParamManager.AddNumberParameter("_meanTemperature_", "_meanTemperature_", "Mean Temperature [K]", GH_ParamAccess.item, 283);
-            inputParamManager.AddNumberParameter("_temperatureDifference_", "_temperatureDifference_", "Mean temperature difference across the cavity [K]", GH_ParamAccess.item, 15);
-            inputParamManager.AddNumberParameter("_angle_", "_angle_", "Angle in radians (measured in 2D from Upward direction (0, 1) Vector2D.SignedAngle(Vector2D)), angle less than 0 considered as downward direction", GH_ParamAccess.item, System.Math.PI / 2);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_width_", NickName = "_width_", Description = "Cavity width [m]", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(0.012);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_meanTemperature_", NickName = "_meanTemperature_", Description = "Mean Temperature [K]", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(283);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_temperatureDifference_", NickName = "_temperatureDifference_", Description = "Mean temperature difference across the cavity [K]", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(15);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_angle_", NickName = "_angle_", Description = "Angle in radians (measured in 2D from Upward direction (0, 1) Vector2D.SignedAngle(Vector2D)), angle less than 0 considered as downward direction", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(System.Math.PI / 2);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddNumberParameter("HeatTransferCoefficient", "HeatTransferCoefficient", "Heat Transfer Coefficient [W/m2K]", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "HeatTransferCoefficient", NickName = "HeatTransferCoefficient", Description = "Heat Transfer Coefficient [W/m2K]", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -72,8 +96,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(0, ref objectWrapper))
+            index = Params.IndexOfInputParam("_defaultGasType_");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -87,28 +114,32 @@ namespace SAM.Analytical.Grasshopper
             }
 
             double width = double.NaN;
-            if (!dataAccess.GetData(1, ref width) || double.IsNaN(width))
+            index = Params.IndexOfInputParam("_width_");
+            if (index == -1 || !dataAccess.GetData(index, ref width) || double.IsNaN(width))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             double meanTemperature = double.NaN;
-            if (!dataAccess.GetData(2, ref meanTemperature) || double.IsNaN(meanTemperature))
+            index = Params.IndexOfInputParam("_meanTemperature_");
+            if (index == -1 || !dataAccess.GetData(index, ref meanTemperature) || double.IsNaN(meanTemperature))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             double temperatureDifference = double.NaN;
-            if (!dataAccess.GetData(3, ref temperatureDifference) || double.IsNaN(temperatureDifference))
+            index = Params.IndexOfInputParam("_temperatureDifference_");
+            if (index == -1 || !dataAccess.GetData(index, ref temperatureDifference) || double.IsNaN(temperatureDifference))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             double angle = double.NaN;
-            if (!dataAccess.GetData(4, ref angle) || double.IsNaN(angle))
+            index = Params.IndexOfInputParam("_angle_");
+            if (index == -1 || !dataAccess.GetData(index, ref angle) || double.IsNaN(angle))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -118,7 +149,9 @@ namespace SAM.Analytical.Grasshopper
 
             double HeatTransferCoefficient = Analytical.Query.HeatTransferCoefficient(gasMaterial, temperatureDifference, width, meanTemperature, angle);
 
-            dataAccess.SetData(0, HeatTransferCoefficient);
+            index = Params.IndexOfOutputParam("HeatTransferCoefficient");
+            if (index != -1)
+                dataAccess.SetData(index, HeatTransferCoefficient);
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalInsideSpace.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalInsideSpace.cs
@@ -7,10 +7,11 @@ using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalInsideSpace : GH_SAMComponent
+    public class SAMAnalyticalInsideSpace : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,19 +41,29 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAdjacencyClusterParam(), "_adjacencyCluster", "_adjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooSpaceParam(), "_space", "_space", "SAM Analytical Space", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_point", "_point", "Point", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_space", NickName = "_space", Description = "SAM Analytical Space", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_point", NickName = "_point", Description = "Point", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddBooleanParameter("Inside", "Inside", "Point Inside Space", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Inside", NickName = "Inside", Description = "Point Inside Space", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,22 +74,27 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             AdjacencyCluster adjacencyCluster = null;
-            if (!dataAccess.GetData(0, ref adjacencyCluster) || adjacencyCluster == null)
+            index = Params.IndexOfInputParam("_adjacencyCluster");
+            if (index == -1 || !dataAccess.GetData(index, ref adjacencyCluster) || adjacencyCluster == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             Space space = null;
-            if (!dataAccess.GetData(1, ref space) || space == null)
+            index = Params.IndexOfInputParam("_space");
+            if (index == -1 || !dataAccess.GetData(index, ref space) || space == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(2, ref objectWrapper))
+            index = Params.IndexOfInputParam("_point");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -94,7 +110,9 @@ namespace SAM.Analytical.Grasshopper
                 point3D = ((Geometry.Spatial.Point3D)objectWrapper.Value);
             }
 
-            dataAccess.SetData(0, Analytical.Query.Inside(adjacencyCluster, space, point3D));
+            index = Params.IndexOfOutputParam("Inside");
+            if (index != -1)
+                dataAccess.SetData(index, Analytical.Query.Inside(adjacencyCluster, space, point3D));
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalLabelPanel.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalLabelPanel.cs
@@ -18,7 +18,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalLabelPanel : GH_SAMComponent, IGH_PreviewObject, IGH_BakeAwareObject
+    public class SAMAnalyticalLabelPanel : GH_SAMVariableOutputParameterComponent, IGH_PreviewObject, IGH_BakeAwareObject
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -28,7 +28,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -48,23 +48,38 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_panel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_name_", "_name_", "Parameter Name", GH_ParamAccess.item, "Name");
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddNumberParameter("_height_", "_height_", "Text Height", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name_", NickName = "_name_", Description = "Parameter Name", Access = GH_ParamAccess.item, Optional = true };
+                param_String.SetPersistentData("Name");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_height_", NickName = "_height_", Description = "Text Height", Access = GH_ParamAccess.item, Optional = true };
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            int index = outputParamManager.AddTextParameter("Value", "Value", "Value", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "Value", NickName = "Value", Description = "Value", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -75,15 +90,20 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            index = Params.IndexOfInputParam("_panel");
+            if (index == -1 || !dataAccess.GetData(index, ref panel))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             string name = null;
-            dataAccess.GetData(1, ref name);
+            index = Params.IndexOfInputParam("_name_");
+            if (index != -1)
+                dataAccess.GetData(index, ref name);
             if (string.IsNullOrEmpty(name))
                 name = "Name";
 
@@ -95,7 +115,9 @@ namespace SAM.Analytical.Grasshopper
             if (double.TryParse(text, out value))
                 text = value.Round(RhinoDoc.ActiveDoc.ModelAbsoluteTolerance).ToString();
 
-            dataAccess.SetData(0, text);
+            index = Params.IndexOfOutputParam("Value");
+            if (index != -1)
+                dataAccess.SetData(index, text);
         }
 
         public override BoundingBox ClippingBox
@@ -123,19 +145,26 @@ namespace SAM.Analytical.Grasshopper
 
         private List<Text3d> GetText3ds()
         {
+            int index;
+
             string name = null;
-            global::Grasshopper.Kernel.Types.IGH_Goo goo = Params.Input[1].VolatileData.AllData(true)?.First();
-            if (goo != null)
-                name = (goo as dynamic).Value;
+            index = Params.IndexOfInputParam("_name_");
+            if (index != -1)
+            {
+                global::Grasshopper.Kernel.Types.IGH_Goo goo = Params.Input[index].VolatileData.AllData(true)?.First();
+                if (goo != null)
+                    name = (goo as dynamic).Value;
+            }
 
             double height = double.NaN;
 
-            if (Params.Input.Count > 2)
+            index = Params.IndexOfInputParam("_height_");
+            if (index != -1)
             {
-                IGH_StructureEnumerator structureEnumerator = Params.Input[2].VolatileData.AllData(true);
+                IGH_StructureEnumerator structureEnumerator = Params.Input[index].VolatileData.AllData(true);
                 if (structureEnumerator != null && structureEnumerator.Count() > 0)
                 {
-                    goo = structureEnumerator.First();
+                    global::Grasshopper.Kernel.Types.IGH_Goo goo = structureEnumerator.First();
                     if (goo != null)
                         height = (goo as dynamic).Value;
                 }
@@ -143,65 +172,69 @@ namespace SAM.Analytical.Grasshopper
 
             List<Text3d> result = new List<Text3d>();
 
-            foreach (GooPanel gooPanel in Params.Input[0].VolatileData.AllData(true))
+            index = Params.IndexOfInputParam("_panel");
+            if (index != -1)
             {
-                IPanel panel = gooPanel.Value;
-                if (panel == null)
+                foreach (GooPanel gooPanel in Params.Input[index].VolatileData.AllData(true))
                 {
-                    continue;
+                    IPanel panel = gooPanel.Value;
+                    if (panel == null)
+                    {
+                        continue;
+                    }
+
+                    string text;
+                    if (!panel.TryGetValue(name, out text, true))
+                        text = "???";
+
+                    double value = double.NaN;
+                    if (double.TryParse(text, out value))
+                        text = value.Round(RhinoDoc.ActiveDoc.ModelAbsoluteTolerance).ToString();
+
+                    Vector3D normal = panel.Face3D?.GetPlane()?.Normal;
+                    normal.Round(Tolerance.Distance);
+
+                    Point3D point3D = panel.Face3D?.GetInternalPoint3D();
+
+                    // point3D = point3D.GetMoved(normal * 0.1) as Point3D; //TEMP SOLUTION FOR TESTING
+
+                    global::Rhino.Geometry.Plane plane = Geometry.Rhino.Convert.ToRhino(new Geometry.Spatial.Plane(point3D, normal));
+                    Vector3d normal_Rhino = Geometry.Rhino.Convert.ToRhino(normal);
+                    if (normal.Z >= 0)
+                    {
+                        if (normal.Z != 1)
+                            plane.Rotate(System.Math.PI, normal_Rhino);
+                    }
+                    else
+                    {
+                        plane.Flip();
+                        plane.Rotate(-System.Math.PI / 2, normal_Rhino);
+                    }
+
+                    double height_Temp = height;
+                    if (double.IsNaN(height_Temp))
+                    {
+                        int length = text.Length;
+                        if (length < 10)
+                            length = 10;
+
+                        BoundingBox2D boundingBox2D = panel.Face3D.ExternalEdge2D.GetBoundingBox();
+                        double max = System.Math.Max(boundingBox2D.Width, boundingBox2D.Height);
+
+                        height_Temp = max / (length * 2);
+                    }
+
+                    TextHorizontalAlignment textHorizontalAlignment = TextHorizontalAlignment.Center;
+                    TextVerticalAlignment textVerticalAlignment = TextVerticalAlignment.MiddleOfBottom;
+                    Text3d text3d = new Text3d("\n" + text, plane, height_Temp);  // TODO: add enter in front of Panel Data
+                    text3d.HorizontalAlignment = textHorizontalAlignment;
+                    text3d.VerticalAlignment = textVerticalAlignment;
+                    //text3d.FontFace = "RhSS"; //this was reason text not to display
+                    text3d.Italic = true;
+                    text3d.Bold = false;
+
+                    result.Add(text3d);
                 }
-
-                string text;
-                if (!panel.TryGetValue(name, out text, true))
-                    text = "???";
-
-                double value = double.NaN;
-                if (double.TryParse(text, out value))
-                    text = value.Round(RhinoDoc.ActiveDoc.ModelAbsoluteTolerance).ToString();
-
-                Vector3D normal = panel.Face3D?.GetPlane()?.Normal;
-                normal.Round(Tolerance.Distance);
-
-                Point3D point3D = panel.Face3D?.GetInternalPoint3D();
-
-                // point3D = point3D.GetMoved(normal * 0.1) as Point3D; //TEMP SOLUTION FOR TESTING
-
-                global::Rhino.Geometry.Plane plane = Geometry.Rhino.Convert.ToRhino(new Geometry.Spatial.Plane(point3D, normal));
-                Vector3d normal_Rhino = Geometry.Rhino.Convert.ToRhino(normal);
-                if (normal.Z >= 0)
-                {
-                    if (normal.Z != 1)
-                        plane.Rotate(System.Math.PI, normal_Rhino);
-                }
-                else
-                {
-                    plane.Flip();
-                    plane.Rotate(-System.Math.PI / 2, normal_Rhino);
-                }
-
-                double height_Temp = height;
-                if (double.IsNaN(height_Temp))
-                {
-                    int length = text.Length;
-                    if (length < 10)
-                        length = 10;
-
-                    BoundingBox2D boundingBox2D = panel.Face3D.ExternalEdge2D.GetBoundingBox();
-                    double max = System.Math.Max(boundingBox2D.Width, boundingBox2D.Height);
-
-                    height_Temp = max / (length * 2);
-                }
-
-                TextHorizontalAlignment textHorizontalAlignment = TextHorizontalAlignment.Center;
-                TextVerticalAlignment textVerticalAlignment = TextVerticalAlignment.MiddleOfBottom;
-                Text3d text3d = new Text3d("\n" + text, plane, height_Temp);  // TODO: add enter in front of Panel Data
-                text3d.HorizontalAlignment = textHorizontalAlignment;
-                text3d.VerticalAlignment = textVerticalAlignment;
-                //text3d.FontFace = "RhSS"; //this was reason text not to display
-                text3d.Italic = true;
-                text3d.Bold = false;
-
-                result.Add(text3d);
             }
 
             return result;

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalLabelSpace.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalLabelSpace.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalLabelSpace : GH_SAMComponent, IGH_PreviewObject
+    public class SAMAnalyticalLabelSpace : GH_SAMVariableOutputParameterComponent, IGH_PreviewObject
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -25,7 +25,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -45,25 +45,40 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooSpaceParam(), "_space", "_space", "SAM Analytical Space", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_name_", "_name_", "Parameter Name", GH_ParamAccess.item, "Name");
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_space", NickName = "_space", Description = "SAM Analytical Space", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddNumberParameter("_height_", "_height_", "Text Height", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name_", NickName = "_name_", Description = "Parameter Name", Access = GH_ParamAccess.item, Optional = true };
+                param_String.SetPersistentData("Name");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_height_", NickName = "_height_", Description = "Text Height", Access = GH_ParamAccess.item, Optional = true };
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddTextParameter("Text", "Text", "Text", GH_ParamAccess.item);
-            outputParamManager.AddPointParameter("Location", "Location", "Location", GH_ParamAccess.item);
-            outputParamManager.AddNumberParameter("Size", "Size", "Size", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "Text", NickName = "Text", Description = "Text", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Point() { Name = "Location", NickName = "Location", Description = "Location", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Size", NickName = "Size", Description = "Size", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -74,22 +89,28 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             ISpace space = null;
-            if (!dataAccess.GetData(0, ref space))
+            index = Params.IndexOfInputParam("_space");
+            if (index == -1 || !dataAccess.GetData(index, ref space))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             string parameterName = null;
-            dataAccess.GetData(1, ref parameterName);
+            index = Params.IndexOfInputParam("_name_");
+            if (index != -1)
+                dataAccess.GetData(index, ref parameterName);
             if (string.IsNullOrEmpty(parameterName))
             {
                 parameterName = "Name";
             }
 
             double height = double.NaN;
-            if (!dataAccess.GetData(2, ref height) || height == 0)
+            index = Params.IndexOfInputParam("_height_");
+            if (index == -1 || !dataAccess.GetData(index, ref height) || height == 0)
             {
                 height = double.NaN;
             }
@@ -101,9 +122,15 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            dataAccess.SetData(0, text3D.Text);
-            dataAccess.SetData(1, text3D.TextPlane.Origin);
-            dataAccess.SetData(2, text3D.Height);
+            index = Params.IndexOfOutputParam("Text");
+            if (index != -1)
+                dataAccess.SetData(index, text3D.Text);
+            index = Params.IndexOfOutputParam("Location");
+            if (index != -1)
+                dataAccess.SetData(index, text3D.TextPlane.Origin);
+            index = Params.IndexOfOutputParam("Size");
+            if (index != -1)
+                dataAccess.SetData(index, text3D.Height);
         }
 
         public override BoundingBox ClippingBox
@@ -131,19 +158,26 @@ namespace SAM.Analytical.Grasshopper
 
         private List<Text3d> GetText3ds()
         {
+            int index;
+
             string parameterName = null;
-            global::Grasshopper.Kernel.Types.IGH_Goo goo = Params.Input[1].VolatileData.AllData(true)?.First();
-            if (goo != null)
-                parameterName = (goo as dynamic).Value;
+            index = Params.IndexOfInputParam("_name_");
+            if (index != -1)
+            {
+                global::Grasshopper.Kernel.Types.IGH_Goo goo = Params.Input[index].VolatileData.AllData(true)?.First();
+                if (goo != null)
+                    parameterName = (goo as dynamic).Value;
+            }
 
             double height = double.NaN;
 
-            if (Params.Input.Count > 2)
+            index = Params.IndexOfInputParam("_height_");
+            if (index != -1)
             {
-                IGH_StructureEnumerator structureEnumerator = Params.Input[2].VolatileData.AllData(true);
+                IGH_StructureEnumerator structureEnumerator = Params.Input[index].VolatileData.AllData(true);
                 if (structureEnumerator != null && structureEnumerator.Count() > 0)
                 {
-                    goo = structureEnumerator.First();
+                    global::Grasshopper.Kernel.Types.IGH_Goo goo = structureEnumerator.First();
                     if (goo != null)
                     {
                         height = (goo as dynamic).Value;
@@ -153,18 +187,22 @@ namespace SAM.Analytical.Grasshopper
 
             List<Text3d> result = [];
 
-            foreach (GooSpace gooSpace in Params.Input[0].VolatileData.AllData(true))
+            index = Params.IndexOfInputParam("_space");
+            if (index != -1)
             {
-                ISpace space = gooSpace.Value;
-                if (space == null)
+                foreach (GooSpace gooSpace in Params.Input[index].VolatileData.AllData(true))
                 {
-                    continue;
-                }
+                    ISpace space = gooSpace.Value;
+                    if (space == null)
+                    {
+                        continue;
+                    }
 
-                Text3d text3d = GetText3d(space, parameterName, height);
-                if (text3d is not null)
-                {
-                    result.Add(text3d);
+                    Text3d text3d = GetText3d(space, parameterName, height);
+                    if (text3d is not null)
+                    {
+                        result.Add(text3d);
+                    }
                 }
             }
 

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMechanicalSystemTypes.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMechanicalSystemTypes.cs
@@ -6,10 +6,11 @@ using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalMechanicalSystemTypes : GH_SAMComponent
+    public class SAMAnalyticalMechanicalSystemTypes : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,23 +40,34 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Object", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            GooSystemTypeLibraryParam gooSystemTypeLibraryParam = new GooSystemTypeLibraryParam();
-            gooSystemTypeLibraryParam.Optional = true;
-            inputParamManager.AddParameter(gooSystemTypeLibraryParam, "_systemTypeLibrary_", "_systemTypeLibrary_", "SAM SystemTypeLibrary", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                GooSystemTypeLibraryParam gooSystemTypeLibraryParam = new GooSystemTypeLibraryParam() { Name = "_systemTypeLibrary_", NickName = "_systemTypeLibrary_", Description = "SAM SystemTypeLibrary", Access = GH_ParamAccess.item, Optional = true };
+                result.Add(new GH_SAMParam(gooSystemTypeLibraryParam, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSystemTypeParam(), "Ventilation", "Ventilation", "SAM Analytical Ventilation System Type", GH_ParamAccess.item);
-            outputParamManager.AddParameter(new GooSystemTypeParam(), "Heating", "Heating", "SAM Analytical Heating System Type", GH_ParamAccess.item);
-            outputParamManager.AddParameter(new GooSystemTypeParam(), "Cooling", "Cooling", "SAM Analytical Cooling System Type", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSystemTypeParam() { Name = "Ventilation", NickName = "Ventilation", Description = "SAM Analytical Ventilation System Type", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSystemTypeParam() { Name = "Heating", NickName = "Heating", Description = "SAM Analytical Heating System Type", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSystemTypeParam() { Name = "Cooling", NickName = "Cooling", Description = "SAM Analytical Cooling System Type", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -66,15 +78,20 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || sAMObject == null)
+            index = Params.IndexOfInputParam("_analytical");
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || sAMObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             SystemTypeLibrary systemTypeLibrary = null;
-            dataAccess.GetData(1, ref systemTypeLibrary);
+            index = Params.IndexOfInputParam("_systemTypeLibrary_");
+            if (index != -1)
+                dataAccess.GetData(index, ref systemTypeLibrary);
 
             if (systemTypeLibrary == null)
                 systemTypeLibrary = ActiveSetting.Setting.GetValue<SystemTypeLibrary>(AnalyticalSettingParameter.DefaultSystemTypeLibrary);
@@ -92,9 +109,15 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            dataAccess.SetData(0, new GooSystemType(internalCondition.GetSystemType<VentilationSystemType>(systemTypeLibrary)));
-            dataAccess.SetData(1, new GooSystemType(internalCondition.GetSystemType<HeatingSystemType>(systemTypeLibrary)));
-            dataAccess.SetData(2, new GooSystemType(internalCondition.GetSystemType<CoolingSystemType>(systemTypeLibrary)));
+            index = Params.IndexOfOutputParam("Ventilation");
+            if (index != -1)
+                dataAccess.SetData(index, new GooSystemType(internalCondition.GetSystemType<VentilationSystemType>(systemTypeLibrary)));
+            index = Params.IndexOfOutputParam("Heating");
+            if (index != -1)
+                dataAccess.SetData(index, new GooSystemType(internalCondition.GetSystemType<HeatingSystemType>(systemTypeLibrary)));
+            index = Params.IndexOfOutputParam("Cooling");
+            if (index != -1)
+                dataAccess.SetData(index, new GooSystemType(internalCondition.GetSystemType<CoolingSystemType>(systemTypeLibrary)));
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeCoplanarApertures.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeCoplanarApertures.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalMergeCoplanarApertures : GH_SAMComponent
+    public class SAMAnalyticalMergeCoplanarApertures : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,25 +41,41 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("_tolerance", "_tolerance", "Tolerance", GH_ParamAccess.item, Tolerance.MacroDistance);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance", NickName = "_tolerance", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "analyticalObject", "analyticalObject", "SAM Analytical Object", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureParam(), "mergedApertures", "mergedApertures", "mergedApertures", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureParam(), "redundantApertures", "redundantApertures", "redundantApertures", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "analyticalObject", NickName = "analyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooApertureParam() { Name = "mergedApertures", NickName = "mergedApertures", Description = "mergedApertures", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooApertureParam() { Name = "redundantApertures", NickName = "redundantApertures", Description = "redundantApertures", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -70,8 +86,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(2, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -79,18 +98,23 @@ namespace SAM.Analytical.Grasshopper
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_analyticalObject");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects) || sAMObjects == null)
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects) || sAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_tolerance");
             double tolerance = Tolerance.MacroDistance;
-            if (!dataAccess.GetData(1, ref tolerance))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref tolerance))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
             List<Aperture> redundantApertures = null;
@@ -171,9 +195,23 @@ namespace SAM.Analytical.Grasshopper
             if (analyticalModels != null)
                 result.AddRange(analyticalModels.Cast<SAMObject>());
 
-            dataAccess.SetDataList(0, result);
-            dataAccess.SetDataList(1, mergedApertures?.ConvertAll(x => new GooAperture(x)));
-            dataAccess.SetDataList(2, redundantApertures?.ConvertAll(x => new GooAperture(x)));
+            index = Params.IndexOfOutputParam("analyticalObject");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result);
+            }
+
+            index = Params.IndexOfOutputParam("mergedApertures");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, mergedApertures?.ConvertAll(x => new GooAperture(x)));
+            }
+
+            index = Params.IndexOfOutputParam("redundantApertures");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, redundantApertures?.ConvertAll(x => new GooAperture(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeCoplanarPanels.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeCoplanarPanels.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalMergeCoplanarPanels : GH_SAMComponent
+    public class SAMAnalyticalMergeCoplanarPanels : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,26 +41,49 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("_offset", "_offset", "Offset", GH_ParamAccess.item, Tolerance.Distance);
-            inputParamManager.AddNumberParameter("_minArea", "_minArea", "Minimal Area", GH_ParamAccess.item, Tolerance.MacroDistance);
-            inputParamManager.AddNumberParameter("_tolerance", "_tolerance", "Tolerance", GH_ParamAccess.item, Tolerance.MacroDistance);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_offset", NickName = "_offset", Description = "Offset", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_minArea", NickName = "_minArea", Description = "Minimal Area", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance", NickName = "_tolerance", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "AnalyticalObject", "AnalyticalObject", "SAM Analytical Object", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooPanelParam(), "RedundantPanels", "RedundantPanels", "RedundantPanels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "AnalyticalObject", NickName = "AnalyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "RedundantPanels", NickName = "RedundantPanels", Description = "RedundantPanels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -71,8 +94,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(4, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -80,32 +106,45 @@ namespace SAM.Analytical.Grasshopper
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_offset");
             double offset = Tolerance.Distance;
-            if (!dataAccess.GetData(1, ref offset))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref offset))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
+            index = Params.IndexOfInputParam("_analyticalObject");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects) || sAMObjects == null)
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects) || sAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_minArea");
             double minArea = Tolerance.MacroDistance;
-            if (!dataAccess.GetData(2, ref minArea))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref minArea))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
+            index = Params.IndexOfInputParam("_tolerance");
             double tolerance = Tolerance.MacroDistance;
-            if (!dataAccess.GetData(3, ref tolerance))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref tolerance))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
             List<Panel> redundantPanels = new List<Panel>();
@@ -146,8 +185,17 @@ namespace SAM.Analytical.Grasshopper
             if (analyticalModels != null)
                 result.AddRange(analyticalModels.Cast<SAMObject>());
 
-            dataAccess.SetDataList(0, result);
-            dataAccess.SetDataList(1, redundantPanels?.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("AnalyticalObject");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result);
+            }
+
+            index = Params.IndexOfOutputParam("RedundantPanels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, redundantPanels?.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeCoplanarPanelsBySpace.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeCoplanarPanelsBySpace.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalMergeCoplanarPanelsBySpace : GH_SAMComponent
+    public class SAMAnalyticalMergeCoplanarPanelsBySpace : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,24 +40,49 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.item);
-            inputParamManager.AddNumberParameter("_offset", "_offset", "Offset", GH_ParamAccess.item, Tolerance.Distance);
-            inputParamManager.AddNumberParameter("_minArea", "_minArea", "Minimal Area", GH_ParamAccess.item, Tolerance.MacroDistance);
-            inputParamManager.AddNumberParameter("_tolerance", "_tolerance", "Tolerance", GH_ParamAccess.item, Tolerance.MacroDistance);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_offset", NickName = "_offset", Description = "Offset", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_minArea", NickName = "_minArea", Description = "Minimal Area", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance", NickName = "_tolerance", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "AnalyticalObject", "AnalyticalObject", "SAM Analytical Object", GH_ParamAccess.item);
-            outputParamManager.AddParameter(new GooPanelParam(), "RedundantPanels", "RedundantPanels", "RedundantPanels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "AnalyticalObject", NickName = "AnalyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "RedundantPanels", NickName = "RedundantPanels", Description = "RedundantPanels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -68,8 +93,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(4, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -77,32 +105,45 @@ namespace SAM.Analytical.Grasshopper
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_offset");
             double offset = Tolerance.Distance;
-            if (!dataAccess.GetData(1, ref offset))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref offset))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
+            index = Params.IndexOfInputParam("_analyticalObject");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || sAMObject == null)
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || sAMObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_minArea");
             double minArea = Tolerance.MacroDistance;
-            if (!dataAccess.GetData(2, ref minArea))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref minArea))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
+            index = Params.IndexOfInputParam("_tolerance");
             double tolerance = Tolerance.MacroDistance;
-            if (!dataAccess.GetData(3, ref tolerance))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref tolerance))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
             List<Panel> redundantPanels = new List<Panel>();
@@ -112,8 +153,17 @@ namespace SAM.Analytical.Grasshopper
                 sAMObject = Analytical.Query.MergeCoplanarPanelsBySpace(sAMObject as dynamic, offset, ref redundantPanels, true, true, minArea, tolerance);
             }
 
-            dataAccess.SetData(0, sAMObject);
-            dataAccess.SetDataList(1, redundantPanels?.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("AnalyticalObject");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, sAMObject);
+            }
+
+            index = Params.IndexOfOutputParam("RedundantPanels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, redundantPanels?.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeOverlapApertures.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeOverlapApertures.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalMergeOverlapApertures : GH_SAMComponent
+    public class SAMAnalyticalMergeOverlapApertures : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,25 +41,47 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddBooleanParameter("_validateConstruction_", "_validateConstruction_", "Validate Construction - Merge Only Apertures with the Same ApertureConstruction", GH_ParamAccess.item, false);
-            inputParamManager.AddNumberParameter("_minArea_", "_minArea_", "Minimal Area for Aperture", GH_ParamAccess.item, Tolerance.MacroDistance);
-            inputParamManager.AddNumberParameter("_tolerance_", "_tolerance_", "Tolerance", GH_ParamAccess.item, Tolerance.Distance);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_validateConstruction_", NickName = "_validateConstruction_", Description = "Validate Construction - Merge Only Apertures with the Same ApertureConstruction", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_minArea_", NickName = "_minArea_", Description = "Minimal Area for Aperture", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "AnalyticalObject", "AnalyticalObject", "SAM Analytical Object", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "AnalyticalObject", NickName = "AnalyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -70,8 +92,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(4, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -79,29 +104,42 @@ namespace SAM.Analytical.Grasshopper
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_validateConstruction_");
             bool validateConstruction = false;
-            if (!dataAccess.GetData(1, ref validateConstruction))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref validateConstruction))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
+            index = Params.IndexOfInputParam("_minArea_");
             double minArea = Tolerance.MacroDistance;
-            if (!dataAccess.GetData(2, ref minArea))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref minArea))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
+            index = Params.IndexOfInputParam("_tolerance_");
             double tolerance = Tolerance.Distance;
-            if (!dataAccess.GetData(3, ref tolerance))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref tolerance))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
+            index = Params.IndexOfInputParam("_analyticalObject");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects) || sAMObjects == null)
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects) || sAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -143,7 +181,11 @@ namespace SAM.Analytical.Grasshopper
             if (analyticalModels != null)
                 result.AddRange(analyticalModels.Cast<SAMObject>());
 
-            dataAccess.SetDataList(0, result);
+            index = Params.IndexOfOutputParam("AnalyticalObject");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeOverlapPanels.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMergeOverlapPanels.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalMergeOverlapPanels : GH_SAMComponent
+    public class SAMAnalyticalMergeOverlapPanels : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,26 +41,48 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("_offset_", "_offset_", "Offset", GH_ParamAccess.item, Tolerance.Distance);
-            inputParamManager.AddBooleanParameter("_defaultConstruction_", "_defaultConstruction_", "Set default Construtcion for Panels", GH_ParamAccess.item, false);
-            inputParamManager.AddNumberParameter("_tolerance_", "_tolerance_", "Tolerance", GH_ParamAccess.item, Tolerance.Distance);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_offset_", NickName = "_offset_", Description = "Offset", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_defaultConstruction_", NickName = "_defaultConstruction_", Description = "Set default Construtcion for Panels", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "AnalyticalObject", "AnalyticalObject", "SAM Analytical Object", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooPanelParam(), "RedundantPanels", "RedundantPanels", "RedundantPanels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "AnalyticalObject", NickName = "AnalyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "RedundantPanels", NickName = "RedundantPanels", Description = "RedundantPanels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -71,8 +93,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(4, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -80,32 +105,45 @@ namespace SAM.Analytical.Grasshopper
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_offset_");
             double offset = Tolerance.Distance;
-            if (!dataAccess.GetData(1, ref offset))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref offset))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
+            index = Params.IndexOfInputParam("_tolerance_");
             double tolerance = Tolerance.Distance;
-            if (!dataAccess.GetData(3, ref tolerance))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref tolerance))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
+            index = Params.IndexOfInputParam("_analyticalObject");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects) || sAMObjects == null)
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects) || sAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_defaultConstruction_");
             bool setDefaultConstruction = false;
-            if (!dataAccess.GetData(2, ref setDefaultConstruction))
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                if (!dataAccess.GetData(index, ref setDefaultConstruction))
+                {
+                    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                    return;
+                }
             }
 
             List<Panel> redundantPanels = new List<Panel>();
@@ -146,8 +184,17 @@ namespace SAM.Analytical.Grasshopper
             if (analyticalModels != null)
                 result.AddRange(analyticalModels.Cast<SAMObject>());
 
-            dataAccess.SetDataList(0, result);
-            dataAccess.SetDataList(1, redundantPanels?.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("AnalyticalObject");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result);
+            }
+
+            index = Params.IndexOfOutputParam("RedundantPanels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, redundantPanels?.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyInternalConditionByProfile.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyInternalConditionByProfile.cs
@@ -122,7 +122,7 @@ namespace SAM.Analytical.Grasshopper
                 if (profile is null || profile.ProfileType == ProfileType.Undefined)
                 {
                     AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, string.Format("Invalid ProfileType: {0}", profile?.Name ?? "???"));
-                    return;
+                    continue;
                 }
 
                 profileLibrary.Add(profile);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyMechanicalSystems.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyMechanicalSystems.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalModifyMechanicalSystems : GH_SAMComponent
+    public class SAMAnalyticalModifyMechanicalSystems : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,44 +41,44 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_analytical", "_analytical", "SAM Analytical", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            GooSystemTypeLibraryParam gooSystemTypeLibraryParam = new GooSystemTypeLibraryParam();
-            gooSystemTypeLibraryParam.Optional = true;
-            inputParamManager.AddParameter(gooSystemTypeLibraryParam, "_systemTypeLibrary_", "_systemTypeLibrary_", "SAM SystemTypeLibrary", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            GooSpaceParam gooSpaceParam = new GooSpaceParam();
-            gooSpaceParam.Optional = true;
-            inputParamManager.AddParameter(gooSpaceParam, "_spaces_", "_spaces_", "SAM Analytical Spaces", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new GooSystemTypeLibraryParam() { Name = "_systemTypeLibrary_", NickName = "_systemTypeLibrary_", Description = "SAM SystemTypeLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            int index = -1;
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_spaces_", NickName = "_spaces_", Description = "SAM Analytical Spaces", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddTextParameter("supplyUnitName_", "_upplyUnitName", "Supply Unit Name", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "supplyUnitName_", NickName = "_upplyUnitName", Description = "Supply Unit Name", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddTextParameter("exhaustUnitName_", "exhaustUnitName_", "Exhaust Unit Name", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "exhaustUnitName_", NickName = "exhaustUnitName_", Description = "Exhaust Unit Name", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooSystemTypeParam(), "coolingSystemType_", "coolingSystemType_", "Cooling System Type", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooSystemTypeParam() { Name = "coolingSystemType_", NickName = "coolingSystemType_", Description = "Cooling System Type", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooSystemTypeParam(), "heatingSystemType_", "heatingSystemType_", "Heating System Type", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooSystemTypeParam() { Name = "heatingSystemType_", NickName = "heatingSystemType_", Description = "Heating System Type", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooSystemTypeParam(), "ventilationSystemType_", "ventilationSystemType_", "Ventilation System Type", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooSystemTypeParam() { Name = "ventilationSystemType_", NickName = "ventilationSystemType_", Description = "Ventilation System Type", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalObjectParam(), "analytical", "analytical", "SAM Analytical", GH_ParamAccess.item);
-            outputParamManager.AddParameter(new GooSystemParam(), "mechanicalSystems", "mechanicalSystems", "mechanicalSystems", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "analytical", NickName = "analytical", Description = "SAM Analytical", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSystemParam() { Name = "mechanicalSystems", NickName = "mechanicalSystems", Description = "mechanicalSystems", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -89,37 +89,65 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_analytical");
             IAnalyticalObject analyticalObject = null;
-            if (!dataAccess.GetData(0, ref analyticalObject) || analyticalObject == null)
+            if (index == -1 || !dataAccess.GetData(index, ref analyticalObject) || analyticalObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_systemTypeLibrary_");
             SystemTypeLibrary systemTypeLibrary = null;
-            dataAccess.GetData(1, ref systemTypeLibrary);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref systemTypeLibrary);
+            }
 
             if (systemTypeLibrary == null)
                 systemTypeLibrary = ActiveSetting.Setting.GetValue<SystemTypeLibrary>(AnalyticalSettingParameter.DefaultSystemTypeLibrary);
 
+            index = Params.IndexOfInputParam("_spaces_");
             List<Space> spaces = new List<Space>();
-            if (!dataAccess.GetDataList(2, spaces))
+            if (index != -1 && !dataAccess.GetDataList(index, spaces))
                 spaces = null;
 
+            index = Params.IndexOfInputParam("supplyUnitName_");
             string supplyUnitName = null;
-            dataAccess.GetData(3, ref supplyUnitName);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref supplyUnitName);
+            }
 
+            index = Params.IndexOfInputParam("exhaustUnitName_");
             string exhaustUnitName = null;
-            dataAccess.GetData(4, ref exhaustUnitName);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref exhaustUnitName);
+            }
 
+            index = Params.IndexOfInputParam("coolingSystemType_");
             ISystemType coolingSystemType = null;
-            dataAccess.GetData(5, ref coolingSystemType);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref coolingSystemType);
+            }
 
+            index = Params.IndexOfInputParam("heatingSystemType_");
             ISystemType heatingSystemType = null;
-            dataAccess.GetData(6, ref heatingSystemType);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref heatingSystemType);
+            }
 
+            index = Params.IndexOfInputParam("ventilationSystemType_");
             ISystemType ventilationSystemType = null;
-            dataAccess.GetData(7, ref ventilationSystemType);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref ventilationSystemType);
+            }
 
             List<MechanicalSystem> mechanicalSystems = new List<MechanicalSystem>();
 
@@ -223,8 +251,17 @@ namespace SAM.Analytical.Grasshopper
                 analyticalObject = new AnalyticalModel((AnalyticalModel)analyticalObject, adjacencyCluster);
             }
 
-            dataAccess.SetData(0, analyticalObject);
-            dataAccess.SetDataList(1, mechanicalSystems);
+            index = Params.IndexOfOutputParam("analytical");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, analyticalObject);
+            }
+
+            index = Params.IndexOfOutputParam("mechanicalSystems");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, mechanicalSystems);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyVentilationProfileByFunction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalModifyVentilationProfileByFunction.cs
@@ -297,7 +297,7 @@ namespace SAM.Analytical.Grasshopper
             }
 
             List<double> setbacks = new List<double>();
-            index = Params.IndexOfInputParam("_setback_");
+            index = Params.IndexOfInputParam("_setbacks_");
             if (index != -1)
             {
                 if (!dataAccess.GetDataList(index, setbacks))

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMovePanel.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalMovePanel.cs
@@ -6,10 +6,11 @@ using Rhino.Geometry;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalMovePanel : GH_SAMComponent
+    public class SAMAnalyticalMovePanel : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,18 +40,31 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_SAMPanel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddVectorParameter("_vector", "_vector", "Vector", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_SAMPanel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Vector() { Name = "_vector", NickName = "_vector", Description = "Vector", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panel", "Panel", "SAM Analytical Panel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panel", NickName = "Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -61,15 +75,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel) || panel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             Vector3d vector3d = new Vector3d();
-            if (!dataAccess.GetData(1, ref vector3d))
+            index = Params.IndexOfInputParam("_vector");
+            if (index == -1 || !dataAccess.GetData(index, ref vector3d))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -80,7 +98,11 @@ namespace SAM.Analytical.Grasshopper
             Panel result = Create.Panel(panel);
             result.Move(vector3D);
 
-            dataAccess.SetData(0, result);
+            index = Params.IndexOfOutputParam("Panel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, result);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalNormalsDisplay.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalNormalsDisplay.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalNormalsDisplay : GH_SAMComponent
+    public class SAMAnalyticalNormalsDisplay : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,27 +41,49 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Object", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddPointParameter("InternalPoint", "InternalPoint", "Internal Point", GH_ParamAccess.list);
-            outputParamManager.AddVectorParameter("Normal", "Normal", "Normal Vector", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Point() { Name = "InternalPoint", NickName = "InternalPoint", Description = "Internal Point", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Vector() { Name = "Normal", NickName = "Normal", Description = "Normal Vector", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            dataAccess.SetDataList(0, null);
-            dataAccess.SetDataList(1, null);
+            int index_InternalPoint = Params.IndexOfOutputParam("InternalPoint");
+            int index_Normal = Params.IndexOfOutputParam("Normal");
 
+            if (index_InternalPoint != -1)
+            {
+                dataAccess.SetDataList(index_InternalPoint, null);
+            }
+            if (index_Normal != -1)
+            {
+                dataAccess.SetDataList(index_Normal, null);
+            }
+
+            int index = Params.IndexOfInputParam("_analytical");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject))
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || sAMObject == null)
                 return;
 
             List<PlanarBoundary3D> planarBoundary3Ds = null;
@@ -110,9 +132,14 @@ namespace SAM.Analytical.Grasshopper
                 normals.Add(normal);
             }
 
-
-            dataAccess.SetDataList(0, internalPoints);
-            dataAccess.SetDataList(1, normals);
+            if (index_InternalPoint != -1)
+            {
+                dataAccess.SetDataList(index_InternalPoint, internalPoints);
+            }
+            if (index_Normal != -1)
+            {
+                dataAccess.SetDataList(index_Normal, normals);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalOffsetAperturesOnEdge.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalOffsetAperturesOnEdge.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalOffsetAperturesOnEdge : GH_SAMComponent
+    public class SAMAnalyticalOffsetAperturesOnEdge : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,22 +39,34 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_panel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("distance_", "distance_", "Distance", GH_ParamAccess.item, 0.1);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "distance_", NickName = "distance_", Description = "Distance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0.1);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "SAM Analytical Panels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,8 +77,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel) || panel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -74,11 +90,19 @@ namespace SAM.Analytical.Grasshopper
             panel = Create.Panel(panel);
 
             double distance = 0.1;
-            dataAccess.GetData(1, ref distance);
+            index = Params.IndexOfInputParam("distance_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref distance);
+            }
 
             panel.OffsetAperturesOnEdge(distance);
 
-            dataAccess.SetData(0, new GooPanel(panel));
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooPanel(panel));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalOverlapPanels.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalOverlapPanels.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalOverlapPanels : GH_SAMComponent
+    public class SAMAnalyticalOverlapPanels : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,22 +41,34 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "SAM Analytical Panels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,8 +79,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
             bool run = false;
-            if (!dataAccess.GetData(1, ref run))
+            index = Params.IndexOfInputParam("_run");
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -77,7 +92,8 @@ namespace SAM.Analytical.Grasshopper
                 return;
 
             List<Panel> panels = new List<Panel>();
-            if (!dataAccess.GetDataList(0, panels) || panels == null)
+            index = Params.IndexOfInputParam("_panels");
+            if (index == -1 || !dataAccess.GetDataList(index, panels) || panels == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -99,7 +115,12 @@ namespace SAM.Analytical.Grasshopper
                     count++;
                 }
             }
-            dataAccess.SetDataTree(0, dataTree_GooPanel);
+
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataTree(index, dataTree_GooPanel);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPanelDistance.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPanelDistance.cs
@@ -6,10 +6,11 @@ using Rhino.Geometry;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalPanelDistance : GH_SAMComponent
+    public class SAMAnalyticalPanelDistance : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,19 +40,32 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_SAMPanel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddPointParameter("_point", "_point", "Point", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_SAMPanel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Point() { Name = "_point", NickName = "_point", Description = "Point", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddNumberParameter("Distance", "Distance", "Distance", GH_ParamAccess.item);
-            outputParamManager.AddNumberParameter("DistanceToEdges", "DistanceToEdges", "DistanceToEdges", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Distance", NickName = "Distance", Description = "Distance", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "DistanceToEdges", NickName = "DistanceToEdges", Description = "DistanceToEdges", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,15 +76,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel) || panel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             Point3d point3d = new Point3d();
-            if (!dataAccess.GetData(1, ref point3d))
+            index = Params.IndexOfInputParam("_point");
+            if (index == -1 || !dataAccess.GetData(index, ref point3d))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -78,8 +96,17 @@ namespace SAM.Analytical.Grasshopper
 
             Geometry.Spatial.Point3D point3D = Geometry.Rhino.Convert.ToSAM(point3d);
 
-            dataAccess.SetData(0, panel.Distance(point3D));
-            dataAccess.SetData(1, panel.DistanceToEdges(point3D));
+            index = Params.IndexOfOutputParam("Distance");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, panel.Distance(point3D));
+            }
+
+            index = Params.IndexOfOutputParam("DistanceToEdges");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, panel.DistanceToEdges(point3D));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPanelLocation.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPanelLocation.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalPanelLocation : GH_SAMComponent
+    public class SAMAnalyticalPanelLocation : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,21 +39,33 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_panel", "SAM Analytical Panel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddPointParameter("Origin", "Origin", "Origin Point", GH_ParamAccess.item);
-            outputParamManager.AddNumberParameter("Tilt", "Tilt", "Tilt of SAM Analytical Panel", GH_ParamAccess.item);
-            outputParamManager.AddNumberParameter("Azimuth", "Azimuth", "Azimuth of SAM Analytical Panel", GH_ParamAccess.item);
-            outputParamManager.AddVectorParameter("Normal", "Normal", "Normal of SAM Analytical Panel", GH_ParamAccess.item);
-            outputParamManager.AddPointParameter("InternalPoint", "InternalPoint", "InternalPoint of SAM Analytical Panel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Point() { Name = "Origin", NickName = "Origin", Description = "Origin Point", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Tilt", NickName = "Tilt", Description = "Tilt of SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "Azimuth", NickName = "Azimuth", Description = "Azimuth of SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Vector() { Name = "Normal", NickName = "Normal", Description = "Normal of SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Point() { Name = "InternalPoint", NickName = "InternalPoint", Description = "InternalPoint of SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,8 +76,9 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel) || panel == null)
+            if (index == -1 || !dataAccess.GetData(index, ref panel) || panel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -77,11 +91,35 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            dataAccess.SetData(0, Geometry.Rhino.Convert.ToRhino(plane.Origin));
-            dataAccess.SetData(1, panel.Tilt());
-            dataAccess.SetData(2, panel.Azimuth());
-            dataAccess.SetData(3, Geometry.Rhino.Convert.ToRhino(plane.Normal));
-            dataAccess.SetData(4, Geometry.Rhino.Convert.ToRhino(panel.GetInternalPoint3D()));
+            int index_Origin = Params.IndexOfOutputParam("Origin");
+            if (index_Origin != -1)
+            {
+                dataAccess.SetData(index_Origin, Geometry.Rhino.Convert.ToRhino(plane.Origin));
+            }
+
+            int index_Tilt = Params.IndexOfOutputParam("Tilt");
+            if (index_Tilt != -1)
+            {
+                dataAccess.SetData(index_Tilt, panel.Tilt());
+            }
+
+            int index_Azimuth = Params.IndexOfOutputParam("Azimuth");
+            if (index_Azimuth != -1)
+            {
+                dataAccess.SetData(index_Azimuth, panel.Azimuth());
+            }
+
+            int index_Normal = Params.IndexOfOutputParam("Normal");
+            if (index_Normal != -1)
+            {
+                dataAccess.SetData(index_Normal, Geometry.Rhino.Convert.ToRhino(plane.Normal));
+            }
+
+            int index_InternalPoint = Params.IndexOfOutputParam("InternalPoint");
+            if (index_InternalPoint != -1)
+            {
+                dataAccess.SetData(index_InternalPoint, Geometry.Rhino.Convert.ToRhino(panel.GetInternalPoint3D()));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPanelTypeByText.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPanelTypeByText.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalPanelTypeByText : GH_SAMComponent
+    public class SAMAnalyticalPanelTypeByText : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,17 +39,27 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddTextParameter("_text", "_text", "Text", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_text", NickName = "_text", Description = "Text", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddTextParameter("PanelType", "PanelType", "SAM Analytical PanelType", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "PanelType", NickName = "PanelType", Description = "SAM Analytical PanelType", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -59,8 +70,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_text");
             string text = null;
-            if (!dataAccess.GetData(0, ref text) || string.IsNullOrEmpty(text))
+            if (index == -1 || !dataAccess.GetData(index, ref text) || string.IsNullOrEmpty(text))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -103,7 +117,11 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetData(0, panelType.ToString());
+            index = Params.IndexOfOutputParam("PanelType");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, panelType.ToString());
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPlanarBoundary3D.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPlanarBoundary3D.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalPlanarBoundary3D : GH_SAMComponent
+    public class SAMAnalyticalPlanarBoundary3D : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,17 +39,27 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<Core.SAMObject>(), "_SAMAnalytical", "_SAMAnalytical", "SAM Analytical Object", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<Core.SAMObject>() { Name = "_SAMAnalytical", NickName = "_SAMAnalytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPlanarBoundary3DParam(), "PlanarBoundary3D", "PlanarBoundary3D", "SAM Analytical PlanarBoundary3D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPlanarBoundary3DParam() { Name = "PlanarBoundary3D", NickName = "PlanarBoundary3D", Description = "SAM Analytical PlanarBoundary3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -59,14 +70,21 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_SAMAnalytical");
             Core.SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || !(sAMObject is Panel))
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || !(sAMObject is Panel))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            dataAccess.SetData(0, new GooPlanarBoundary3D(((Panel)sAMObject).PlanarBoundary3D));
+            index = Params.IndexOfOutputParam("PlanarBoundary3D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooPlanarBoundary3D(((Panel)sAMObject).PlanarBoundary3D));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPlaneIntersection.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalPlaneIntersection.cs
@@ -13,7 +13,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalPlaneIntersection : GH_SAMComponent
+    public class SAMAnalyticalPlaneIntersection : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -23,7 +23,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -43,19 +43,36 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<Core.SAMObject>(), "_SAMAnalytical", "_SAMAnalytical", "SAM Analytical Object ie.Panel, Face3d", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_elevation", "_elevation", "Elevation", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<Core.SAMObject>() { Name = "_SAMAnalytical", NickName = "_SAMAnalytical", Description = "SAM Analytical Object ie.Panel, Face3d", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_elevation", NickName = "_elevation", Description = "Elevation", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "Edge3Ds", "Edge3Ds", "SAM.Geometry Edge3Ds", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "Edge3Ds", NickName = "Edge3Ds", Description = "SAM.Geometry Edge3Ds", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -66,8 +83,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(2, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -75,15 +95,17 @@ namespace SAM.Analytical.Grasshopper
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_SAMAnalytical");
             Core.SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || !(sAMObject is Panel))
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || !(sAMObject is Panel))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_elevation");
             GH_ObjectWrapper objectWrapper_Elevation = null;
-            if (!dataAccess.GetData(1, ref objectWrapper_Elevation))
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper_Elevation))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -115,7 +137,13 @@ namespace SAM.Analytical.Grasshopper
 
             IEnumerable<ICurve3D> edge3Ds = panel.GetEdge3Ds(elevation);
             if (edge3Ds != null && edge3Ds.Count() > 0)
-                dataAccess.SetDataList(0, edge3Ds.ToList().ConvertAll(x => new GooSAMGeometry(x)));
+            {
+                index = Params.IndexOfOutputParam("Edge3Ds");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, edge3Ds.ToList().ConvertAll(x => new GooSAMGeometry(x)));
+                }
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemove.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemove.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalRemove : GH_SAMComponent
+    public class SAMAnalyticalRemove : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.2";
+        public override string LatestComponentVersion => "1.0.3";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,23 +40,32 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_objects", "_objects", "SAM Objects", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_objects", NickName = "_objects", Description = "SAM Objects", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalObjectParam(), "analyticalObject", "analyticalObject", "SAM Analytical Object", GH_ParamAccess.item);
-            outputParamManager.AddTextParameter("guids", "guids", "Guids of Removed Elements", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "analyticalObject", NickName = "analyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "guids", NickName = "guids", Description = "Guids of Removed Elements", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,15 +76,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analyticalObject");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || sAMObject == null)
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || sAMObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_objects");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(1, sAMObjects) || sAMObjects == null)
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects) || sAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -94,8 +107,17 @@ namespace SAM.Analytical.Grasshopper
                             guids.Add(aperture.Guid);
                 }
 
-                dataAccess.SetData(0, result);
-                dataAccess.SetDataList(1, guids);
+                index = Params.IndexOfOutputParam("analyticalObject");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, result);
+                }
+
+                index = Params.IndexOfOutputParam("guids");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, guids);
+                }
                 return;
             }
             else if (sAMObject is AnalyticalModel)
@@ -104,8 +126,17 @@ namespace SAM.Analytical.Grasshopper
 
                 List<Guid> guids = analyticalModel.Remove(sAMObjects);
 
-                dataAccess.SetData(0, analyticalModel);
-                dataAccess.SetDataList(1, guids);
+                index = Params.IndexOfOutputParam("analyticalObject");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, analyticalModel);
+                }
+
+                index = Params.IndexOfOutputParam("guids");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, guids);
+                }
                 return;
             }
             else if (sAMObject is AdjacencyCluster)
@@ -114,8 +145,17 @@ namespace SAM.Analytical.Grasshopper
 
                 List<Guid> guids = adjacencyCluster.Remove(sAMObjects);
 
-                dataAccess.SetData(0, adjacencyCluster);
-                dataAccess.SetDataList(1, guids);
+                index = Params.IndexOfOutputParam("analyticalObject");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, adjacencyCluster);
+                }
+
+                index = Params.IndexOfOutputParam("guids");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, guids);
+                }
                 return;
             }
         }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemoveFromConstructionManager.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemoveFromConstructionManager.cs
@@ -105,7 +105,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<Construction> constructions = null;
 
-            index = Params.IndexOfInputParam("_constructions");
+            index = Params.IndexOfInputParam("constructions_");
             analyticalObjects = new List<IAnalyticalObject>();
             if (index != -1 && dataAccess.GetDataList(index, analyticalObjects) && analyticalObjects != null)
             {
@@ -129,7 +129,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<ApertureConstruction> apertureConstructions = null;
 
-            index = Params.IndexOfInputParam("_apertureConstructions");
+            index = Params.IndexOfInputParam("apertureConstructions_");
             analyticalObjects = new List<IAnalyticalObject>();
             if (index != -1 && dataAccess.GetDataList(index, analyticalObjects) && analyticalObjects != null)
             {
@@ -153,7 +153,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<IMaterial> materials = null;
 
-            index = Params.IndexOfInputParam("_materials");
+            index = Params.IndexOfInputParam("materials_");
             List<ISAMObject> sAMObjects = new List<ISAMObject>();
             if (index != -1 && dataAccess.GetDataList(index, sAMObjects) && sAMObjects != null)
             {

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemoveInternalEdges.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemoveInternalEdges.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalRemoveInternalEdges : GH_SAMComponent
+    public class SAMAnalyticalRemoveInternalEdges : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,32 +41,49 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Object", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Object", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
 
+            index = Params.IndexOfInputParam("_analytical");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject))
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject))
                 return;
+
+            int index_Output = Params.IndexOfOutputParam("_analytical");
 
             if (sAMObject is Panel)
             {
                 Panel panel = Create.Panel((Panel)sAMObject);
                 panel = Create.Panel(panel.Guid, panel, new Face3D(panel.GetFace3D().GetExternalEdge3D()), null, false);
 
-                dataAccess.SetData(0, panel);
+                if (index_Output != -1)
+                {
+                    dataAccess.SetData(index_Output, panel);
+                }
                 return;
             }
 
@@ -98,9 +115,12 @@ namespace SAM.Analytical.Grasshopper
                     adjacencyCluster.AddObject(panel);
             }
 
+            if (index_Output == -1)
+                return;
+
             if (analyticalModel == null && adjacencyCluster == null)
             {
-                dataAccess.SetData(0, sAMObject);
+                dataAccess.SetData(index_Output, sAMObject);
                 return;
             }
 
@@ -108,16 +128,16 @@ namespace SAM.Analytical.Grasshopper
             {
                 if (adjacencyCluster == null)
                 {
-                    dataAccess.SetData(0, sAMObject);
+                    dataAccess.SetData(index_Output, sAMObject);
                     return;
                 }
 
-                dataAccess.SetData(0, new AnalyticalModel(analyticalModel, adjacencyCluster));
+                dataAccess.SetData(index_Output, new AnalyticalModel(analyticalModel, adjacencyCluster));
                 return;
             }
 
             if (adjacencyCluster != null)
-                dataAccess.SetData(0, adjacencyCluster);
+                dataAccess.SetData(index_Output, adjacencyCluster);
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemoveOverlapApertures.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRemoveOverlapApertures.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalRemoveOverlapApertures : GH_SAMComponent
+    public class SAMAnalyticalRemoveOverlapApertures : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,24 +41,40 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analyticalObject", "_analyticalObject", "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analyticalObject", NickName = "_analyticalObject", Description = "SAM Analytical Object such as AdjacencyCluster, Panel or AnalyticalModel", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddNumberParameter("_tolerance_", "_tolerance_", "Tolerance", GH_ParamAccess.item, Tolerance.Distance);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "analyticalObject", "analyticalObject", "SAM Analytical Object", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureParam(), "removedApertures", "removedApertures", "RemovedApertures", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "analyticalObject", NickName = "analyticalObject", Description = "SAM Analytical Object", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooApertureParam() { Name = "removedApertures", NickName = "removedApertures", Description = "RemovedApertures", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -69,8 +85,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(2, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -78,15 +97,17 @@ namespace SAM.Analytical.Grasshopper
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_tolerance_");
             double tolerance = Tolerance.Distance;
-            if (!dataAccess.GetData(1, ref tolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_analyticalObject");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects) || sAMObjects == null)
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects) || sAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -149,8 +170,17 @@ namespace SAM.Analytical.Grasshopper
             if (analyticalModels != null)
                 result.AddRange(analyticalModels.Cast<SAMObject>());
 
-            dataAccess.SetDataList(0, result);
-            dataAccess.SetDataList(1, removedApertures?.ConvertAll(x => new GooAperture(x)));
+            index = Params.IndexOfOutputParam("analyticalObject");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result);
+            }
+
+            index = Params.IndexOfOutputParam("removedApertures");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, removedApertures?.ConvertAll(x => new GooAperture(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRenameConstruction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalRenameConstruction.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalRenameConstruction : GH_SAMComponent
+    public class SAMAnalyticalRenameConstruction : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,20 +39,35 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooConstructionParam(), "_construction", "_construction", "SAM Analytical Contruction", GH_ParamAccess.list);
-            inputParamManager.AddTextParameter("_csv", "_csv", "csv", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_sourceColumn", "_sourceColumn", "Source Column Name", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_destinationColumn", "_destinationColumn", "Destination Column Name", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "_construction", NickName = "_construction", Description = "SAM Analytical Contruction", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_csv", NickName = "_csv", Description = "csv", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_sourceColumn", NickName = "_sourceColumn", Description = "Source Column Name", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_destinationColumn", NickName = "_destinationColumn", Description = "Destination Column Name", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooConstructionParam(), "Construction", "Construction", "SAM Analytical Construction", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "Construction", NickName = "Construction", Description = "SAM Analytical Construction", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,29 +78,35 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_construction");
             List<Construction> constructions = new List<Construction>();
-            if (!dataAccess.GetDataList(0, constructions))
+            if (index == -1 || !dataAccess.GetDataList(index, constructions))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_csv");
             string csvOrPath = null;
-            if (!dataAccess.GetData(1, ref csvOrPath) || string.IsNullOrWhiteSpace(csvOrPath))
+            if (index == -1 || !dataAccess.GetData(index, ref csvOrPath) || string.IsNullOrWhiteSpace(csvOrPath))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_sourceColumn");
             string sourceColumn = null;
-            if (!dataAccess.GetData(2, ref sourceColumn) || string.IsNullOrWhiteSpace(sourceColumn))
+            if (index == -1 || !dataAccess.GetData(index, ref sourceColumn) || string.IsNullOrWhiteSpace(sourceColumn))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_destinationColumn");
             string destinationColumn = null;
-            if (!dataAccess.GetData(3, ref destinationColumn) || string.IsNullOrWhiteSpace(destinationColumn))
+            if (index == -1 || !dataAccess.GetData(index, ref destinationColumn) || string.IsNullOrWhiteSpace(destinationColumn))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -128,7 +149,6 @@ namespace SAM.Analytical.Grasshopper
                 string name = construction.Name;
                 if (name == null)
                 {
-                    //result.Add(construction);
                     continue;
                 }
 
@@ -153,7 +173,6 @@ namespace SAM.Analytical.Grasshopper
 
                 if (name_destination == null)
                 {
-                    //result.Add(construction);
                     continue;
                 }
                 else
@@ -162,7 +181,11 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooConstruction(x)));
+            index = Params.IndexOfOutputParam("Construction");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooConstruction(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetAdiabatic.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetAdiabatic.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSetAdiabatic : GH_SAMComponent
+    public class SAMAnalyticalSetAdiabatic : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,19 +40,36 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_analytical", "_analytical", "SAM Analytical Object such as AdjacencyCluster or AnalyticalModel", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooPanelParam() { Optional = true }, "panels_", "panels_", "SAM Analytical Panels", GH_ParamAccess.list);
-            inputParamManager.AddBooleanParameter("_adiabatic_", "_adiabatic", "Is Adiabatic", GH_ParamAccess.item, true);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Object such as AdjacencyCluster or AnalyticalModel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "panels_", NickName = "panels_", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_adiabatic_", NickName = "_adiabatic", Description = "Is Adiabatic", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalObjectParam(), "analytical", "analytical", "SAM Analytical Object", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "analytical", NickName = "analytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,8 +80,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analytical");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject))
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -82,11 +102,16 @@ namespace SAM.Analytical.Grasshopper
 
 
             List<Panel> panels = new List<Panel>();
-            dataAccess.GetDataList(1, panels);
+            index = Params.IndexOfInputParam("panels_");
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, panels);
+            }
             if (panels != null && panels.Count != 0)
             {
+                index = Params.IndexOfInputParam("_adiabatic_");
                 bool adiabatic = true;
-                if (!dataAccess.GetData(2, ref adiabatic))
+                if (index == -1 || !dataAccess.GetData(index, ref adiabatic))
                 {
                     AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                     return;
@@ -121,7 +146,11 @@ namespace SAM.Analytical.Grasshopper
                 sAMObject = adjacencyCluster;
             }
 
-            dataAccess.SetData(0, sAMObject);
+            index = Params.IndexOfOutputParam("analytical");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, sAMObject);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetAirflow.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetAirflow.cs
@@ -154,7 +154,7 @@ namespace SAM.Analytical.Grasshopper
                 dataAccess.GetData(index, ref airflow_LpS);
 
             List<Space> spaces = new List<Space>();
-            index = Params.IndexOfInputParam("_spaces");
+            index = Params.IndexOfInputParam("_spaces_");
             if (index != -1)
                 dataAccess.GetDataList(index, spaces);
 

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetApertureConstruction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetApertureConstruction.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSetApertureConstruction : GH_SAMComponent
+    public class SAMAnalyticalSetApertureConstruction : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,20 +40,34 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_adjacencyCluster", "_adjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooApertureParam(), "_apertures", "_apertures", "SAM Analytical Apertures", GH_ParamAccess.list);
-            inputParamManager.AddParameter(new GooApertureConstructionParam(), "_apertureConstruction", "_apertureConstruction", "SAM Analytical ApertureConstruction", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooApertureParam() { Name = "_apertures", NickName = "_apertures", Description = "SAM Analytical Apertures", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooApertureConstructionParam() { Name = "_apertureConstruction", NickName = "_apertureConstruction", Description = "SAM Analytical ApertureConstruction", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "AdjacencyCluster", "AdjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
-            outputParamManager.AddParameter(new GooApertureParam(), "Apertures", "Apertures", "SAM Analytical Apertures", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "AdjacencyCluster", NickName = "AdjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooApertureParam() { Name = "Apertures", NickName = "Apertures", Description = "SAM Analytical Apertures", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,23 +78,28 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_adjacencyCluster");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject))
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
 
+            index = Params.IndexOfInputParam("_apertures");
             List<Aperture> apertures = new List<Aperture>();
-            if (!dataAccess.GetDataList(1, apertures))
+            if (index == -1 || !dataAccess.GetDataList(index, apertures))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_apertureConstruction");
             ApertureConstruction apertureConstruction = null;
-            if (!dataAccess.GetData(2, ref apertureConstruction))
+            if (index == -1 || !dataAccess.GetData(index, ref apertureConstruction))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -138,12 +157,20 @@ namespace SAM.Analytical.Grasshopper
                     adjacencyCluster_Result.AddObject(panel);
             }
 
-            if (analyticalModel != null)
-                dataAccess.SetData(0, new AnalyticalModel(analyticalModel, adjacencyCluster_Result));
-            else if (adjacencyCluster != null)
-                dataAccess.SetData(0, adjacencyCluster_Result);
+            index = Params.IndexOfOutputParam("AdjacencyCluster");
+            if (index != -1)
+            {
+                if (analyticalModel != null)
+                    dataAccess.SetData(index, new AnalyticalModel(analyticalModel, adjacencyCluster_Result));
+                else if (adjacencyCluster != null)
+                    dataAccess.SetData(index, adjacencyCluster_Result);
+            }
 
-            dataAccess.SetDataList(1, apertures_Result.ConvertAll(x => new GooAperture(x)));
+            index = Params.IndexOfOutputParam("Apertures");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, apertures_Result.ConvertAll(x => new GooAperture(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetConstructionByCsv.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetConstructionByCsv.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSetConstructionByCsv : GH_SAMComponent
+    public class SAMAnalyticalSetConstructionByCsv : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,25 +39,37 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            index = inputParamManager.AddParameter(new GooConstructionParam(), "constructions_", "constructions_", "SAM Analytical Contructions", GH_ParamAccess.list);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            inputParamManager.AddTextParameter("_csv", "_csv", "csv", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_sourceColumn", "_sourceColumn", "Source Column Name", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_destinationColumn", "_destinationColumn", "Destination Column Name", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooConstructionParam() { Name = "constructions_", NickName = "constructions_", Description = "SAM Analytical Contructions", Access = GH_ParamAccess.list, Optional = true }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_csv", NickName = "_csv", Description = "csv", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_sourceColumn", NickName = "_sourceColumn", Description = "Source Column Name", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_destinationColumn", NickName = "_destinationColumn", Description = "Destination Column Name", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panel", "Panel", "SAM Analytical Panel", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panel", NickName = "Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -68,34 +80,44 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_panels");
             List<Panel> panels = new List<Panel>();
-            if (!dataAccess.GetDataList(0, panels))
+            if (index == -1 || !dataAccess.GetDataList(index, panels))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("constructions_");
             List<Construction> constructions = new List<Construction>();
-            dataAccess.GetDataList(1, constructions);
+            if (index != -1)
+            {
+                dataAccess.GetDataList(index, constructions);
+            }
             if (constructions == null)
                 constructions = new List<Construction>();
 
+            index = Params.IndexOfInputParam("_csv");
             string csvOrPath = null;
-            if (!dataAccess.GetData(2, ref csvOrPath) || string.IsNullOrWhiteSpace(csvOrPath))
+            if (index == -1 || !dataAccess.GetData(index, ref csvOrPath) || string.IsNullOrWhiteSpace(csvOrPath))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_sourceColumn");
             string sourceColumn = null;
-            if (!dataAccess.GetData(3, ref sourceColumn) || string.IsNullOrWhiteSpace(sourceColumn))
+            if (index == -1 || !dataAccess.GetData(index, ref sourceColumn) || string.IsNullOrWhiteSpace(sourceColumn))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_destinationColumn");
             string destinationColumn = null;
-            if (!dataAccess.GetData(4, ref destinationColumn) || string.IsNullOrWhiteSpace(destinationColumn))
+            if (index == -1 || !dataAccess.GetData(index, ref destinationColumn) || string.IsNullOrWhiteSpace(destinationColumn))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -142,7 +164,6 @@ namespace SAM.Analytical.Grasshopper
                 string name = construction.Name;
                 if (name == null)
                 {
-                    //result.Add(construction);
                     continue;
                 }
 
@@ -167,7 +188,6 @@ namespace SAM.Analytical.Grasshopper
 
                 if (string.IsNullOrWhiteSpace(name_destination))
                 {
-                    //result.Add(construction);
                     continue;
                 }
                 else
@@ -180,7 +200,11 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("Panel");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetConstructionLayersByPanelType.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetConstructionLayersByPanelType.cs
@@ -6,10 +6,11 @@ using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSetConstructionLayersByPanelType : GH_SAMComponent
+    public class SAMAnalyticalSetConstructionLayersByPanelType : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,31 +40,40 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooAnalyticalModelParam(), "_analyticalModel", "_analyticalModel", "SAM Analytical Model", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooAnalyticalModelParam() { Name = "_analyticalModel", NickName = "_analyticalModel", Description = "SAM Analytical Model", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooConstructionLibraryParam(), "_constructionLibrary_", "_constructionLibrary_", "SAM Analytical Contruction Library", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "_constructionLibrary_", NickName = "_constructionLibrary_", Description = "SAM Analytical Contruction Library", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooApertureConstructionLibraryParam(), "_apertureConstructionLibrary_", "_apertureConstructionLibrary_", "SAM Analytical Aperture Contruction Library", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooApertureConstructionLibraryParam() { Name = "_apertureConstructionLibrary_", NickName = "_apertureConstructionLibrary_", Description = "SAM Analytical Aperture Contruction Library", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooMaterialLibraryParam(), "_materialLibrary_", "_materialLibrary_", "SAM Material Library", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "_materialLibrary_", NickName = "_materialLibrary_", Description = "SAM Material Library", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddBooleanParameter("_emptyOnly_", "_emptyOnly_", "Only Null or Constructions without ConctructionLayers", GH_ParamAccess.item, true);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_emptyOnly_", NickName = "_emptyOnly_", Description = "Only Null or Constructions without ConctructionLayers", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalModelParam(), "AnalyticalModel", "AnalyticalModel", "SAM Analytical Model", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalModelParam() { Name = "AnalyticalModel", NickName = "AnalyticalModel", Description = "SAM Analytical Model", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -74,37 +84,60 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analyticalModel");
             AnalyticalModel analyticalModel = null;
-            if (!dataAccess.GetData(0, ref analyticalModel))
+            if (index == -1 || !dataAccess.GetData(index, ref analyticalModel))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_constructionLibrary_");
             ConstructionLibrary constructionLibrary = null;
-            dataAccess.GetData(1, ref constructionLibrary);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref constructionLibrary);
+            }
 
             if (constructionLibrary == null)
                 constructionLibrary = ActiveSetting.Setting.GetValue<ConstructionLibrary>(AnalyticalSettingParameter.DefaultConstructionLibrary);
 
+            index = Params.IndexOfInputParam("_apertureConstructionLibrary_");
             ApertureConstructionLibrary apertureConstructionLibrary = null;
-            dataAccess.GetData(2, ref apertureConstructionLibrary);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref apertureConstructionLibrary);
+            }
 
             if (apertureConstructionLibrary == null)
                 apertureConstructionLibrary = ActiveSetting.Setting.GetValue<ApertureConstructionLibrary>(AnalyticalSettingParameter.DefaultApertureConstructionLibrary);
 
+            index = Params.IndexOfInputParam("_materialLibrary_");
             MaterialLibrary materialLibrary = null;
-            dataAccess.GetData(3, ref apertureConstructionLibrary);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref materialLibrary);
+            }
 
             if (materialLibrary == null)
                 materialLibrary = ActiveSetting.Setting.GetValue<MaterialLibrary>(AnalyticalSettingParameter.DefaultMaterialLibrary);
 
+            index = Params.IndexOfInputParam("_emptyOnly_");
             bool emptyOnly = true;
-            dataAccess.GetData(4, ref emptyOnly);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref emptyOnly);
+            }
 
             AnalyticalModel analyticalModel_Result = analyticalModel?.UpdateConstructionLayersByPanelType(constructionLibrary, apertureConstructionLibrary, materialLibrary, emptyOnly);
 
-            dataAccess.SetData(0, new GooAnalyticalModel(analyticalModel_Result));
+            index = Params.IndexOfOutputParam("AnalyticalModel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAnalyticalModel(analyticalModel_Result));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetDefaultApertureConstruction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetDefaultApertureConstruction.cs
@@ -74,7 +74,7 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            index = Params.IndexOfInputParam("apertures_");
+            index = Params.IndexOfInputParam("_apertures_");
             List<Aperture> apertures = new List<Aperture>();
             if (index != -1)
                 dataAccess.GetDataList(index, apertures);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetDefaultApertureConstructionLayers.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetDefaultApertureConstructionLayers.cs
@@ -74,7 +74,7 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
-            index = Params.IndexOfInputParam("apertures_");
+            index = Params.IndexOfInputParam("_apertures_");
             List<Aperture> apertures = new List<Aperture>();
             if (index != -1)
                 dataAccess.GetDataList(index, apertures);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetOccupancyGains.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetOccupancyGains.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSetOccupancyGains : GH_SAMComponent
+    public class SAMAnalyticalSetOccupancyGains : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,20 +40,31 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analyticals", "_analyticals", "SAM Analytical Space or InternalCondition", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooDegreeOfActivityParam(), "_degreeOfActivity", "_degreeOfActivity", "SAM Analytical DegreeOfActivity", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analyticals", NickName = "_analyticals", Description = "SAM Analytical Space or InternalCondition", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
+                result.Add(new GH_SAMParam(new GooDegreeOfActivityParam() { Name = "_degreeOfActivity", NickName = "_degreeOfActivity", Description = "SAM Analytical DegreeOfActivity", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "Analyticals", "Analyticals", "SAM Analytical Model, Panels or Adjacency Cluster", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "Analyticals", NickName = "Analyticals", Description = "SAM Analytical Model, Panels or Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,15 +75,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analyticals");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects))
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_degreeOfActivity");
             DegreeOfActivity degreeOfActivity = null;
-            if (!dataAccess.GetData(1, ref degreeOfActivity))
+            if (index == -1 || !dataAccess.GetData(index, ref degreeOfActivity))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -94,7 +109,11 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetDataList(0, sAMObjects.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
+            index = Params.IndexOfOutputParam("Analyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, sAMObjects.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetPanelType.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSetPanelType.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSetPanelType : GH_SAMComponent
+    public class SAMAnalyticalSetPanelType : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,20 +40,40 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_panel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_panelType", "_panelType", "SAM Analytical Panel Type", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_setDefaultConstruction_", "_setDefaultConstruction_", "Set Default Construction", GH_ParamAccess.item, false);
-            inputParamManager.AddBooleanParameter("_setDefaultApertureConstruction_", "_setDefaultApertureConstruction_", "Set Default Aperture Construction", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_panelType", NickName = "_panelType", Description = "SAM Analytical Panel Type", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_setDefaultConstruction_", NickName = "_setDefaultConstruction_", Description = "Set Default Construction", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_setDefaultApertureConstruction_", NickName = "_setDefaultApertureConstruction_", Description = "Set Default Aperture Construction", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panel", "Panel", "SAM Analytical Panel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panel", NickName = "Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,29 +84,35 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel) || panel == null)
+            if (index == -1 || !dataAccess.GetData(index, ref panel) || panel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_panelType");
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(1, ref objectWrapper))
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_setDefaultConstruction_");
             bool setDefaultConstruction = false;
-            if (!dataAccess.GetData(2, ref setDefaultConstruction))
+            if (index == -1 || !dataAccess.GetData(index, ref setDefaultConstruction))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_setDefaultApertureConstruction_");
             bool setDefaultApertureConstruction = false;
-            if (!dataAccess.GetData(3, ref setDefaultApertureConstruction))
+            if (index == -1 || !dataAccess.GetData(index, ref setDefaultApertureConstruction))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -125,7 +151,11 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetData(0, new GooPanel(panel_New));
+            index = Params.IndexOfOutputParam("Panel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooPanel(panel_New));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapByElevations.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapByElevations.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSnapByElevations : GH_SAMComponent
+    public class SAMAnalyticalSnapByElevations : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.2";
+        public override string LatestComponentVersion => "1.0.3";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,24 +40,40 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
 
-            inputParamManager.AddGenericParameter("_elevations", "_elevations", "elevations", GH_ParamAccess.list);
-            inputParamManager.AddNumberParameter("_minTolerance_", "_minTolerance_", "Minimal Tolerance", GH_ParamAccess.item, Core.Tolerance.MicroDistance);
-            inputParamManager.AddNumberParameter("_maxTolerance_", "_maxTolerance_", "Maximal Tolerance", GH_ParamAccess.item, Core.Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_elevations", NickName = "_elevations", Description = "elevations", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_minTolerance_", NickName = "_minTolerance_", Description = "Minimal Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Core.Tolerance.MicroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_maxTolerance_", NickName = "_maxTolerance_", Description = "Maximal Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Core.Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "SAM Analytical Panels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -68,14 +84,17 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panels");
             List<Panel> panels = new List<Panel>();
-            if (!dataAccess.GetDataList(0, panels))
+            if (index == -1 || !dataAccess.GetDataList(index, panels))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            int index = Params.IndexOfInputParam("_elevations");
+            index = Params.IndexOfInputParam("_elevations");
             List<GH_ObjectWrapper> objectWrappers_Elevation = new List<GH_ObjectWrapper>();
             if (index == -1 || !dataAccess.GetDataList(index, objectWrappers_Elevation) || objectWrappers_Elevation == null || objectWrappers_Elevation.Count == 0)
             {
@@ -117,22 +136,29 @@ namespace SAM.Analytical.Grasshopper
                 elevations.Add(elevation);
             }
 
+            index = Params.IndexOfInputParam("_minTolerance_");
             double minTolerance = double.NaN;
-            if (!dataAccess.GetData(2, ref minTolerance) || double.IsNaN(minTolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref minTolerance) || double.IsNaN(minTolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_maxTolerance_");
             double maxTolerance = double.NaN;
-            if (!dataAccess.GetData(3, ref maxTolerance) || double.IsNaN(maxTolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref maxTolerance) || double.IsNaN(maxTolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<Panel> result = Analytical.Query.SnapByElevations(panels, elevations, 5, maxTolerance, minTolerance);
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooPanel(x)));
+
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapByLines.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapByLines.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSnapByLines : GH_SAMComponent
+    public class SAMAnalyticalSnapByLines : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// ` Provides an Icon for the component.
@@ -41,19 +41,36 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_Panel", "_Panel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddLineParameter("_lines", "_lines", "Lines", GH_ParamAccess.list);
-            inputParamManager.AddNumberParameter("_maxDistance_", "_maxDistance_", "Max Distance", GH_ParamAccess.item, 1);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_Panel", NickName = "_Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Line() { Name = "_lines", NickName = "_lines", Description = "Lines", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_maxDistance_", NickName = "_maxDistance_", Description = "Max Distance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(1);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "_Panel", "_Panel", "SAM Analytical Panel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_Panel", NickName = "_Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,15 +81,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_Panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_lines");
             List<Line> lines = new List<Line>();
-            if (!dataAccess.GetDataList(1, lines) || lines == null)
+            if (index == -1 || !dataAccess.GetDataList(index, lines) || lines == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -88,8 +109,9 @@ namespace SAM.Analytical.Grasshopper
                     planes.Add(plane_Segment3D);
             }
 
+            index = Params.IndexOfInputParam("_maxDistance_");
             double maxDistance = double.NaN;
-            if (!dataAccess.GetData(2, ref maxDistance) || double.IsNaN(maxDistance))
+            if (index == -1 || !dataAccess.GetData(index, ref maxDistance) || double.IsNaN(maxDistance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -98,7 +120,11 @@ namespace SAM.Analytical.Grasshopper
             Panel result = Create.Panel(panel);
             result.Snap(planes, maxDistance);
 
-            dataAccess.SetData(0, new GooPanel(result));
+            index = Params.IndexOfOutputParam("_Panel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooPanel(result));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapByOffset.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapByOffset.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSnapByOffset : GH_SAMComponent
+    public class SAMAnalyticalSnapByOffset : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,19 +39,35 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            inputParamManager.AddNumberParameter("_offset_", "Offs", "Snap offset", GH_ParamAccess.item, 0.2);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_offset_", NickName = "Offs", Description = "Snap offset", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(0.2);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new Geometry.Grasshopper.GooSAMGeometryParam(), "Point3Ds", "Point3Ds", "Snap Point3Ds", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new Geometry.Grasshopper.GooSAMGeometryParam() { Name = "Point3Ds", NickName = "Point3Ds", Description = "Snap Point3Ds", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,15 +78,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panels");
             List<Panel> panels = new List<Panel>();
-            if (!dataAccess.GetDataList(0, panels))
+            if (index == -1 || !dataAccess.GetDataList(index, panels))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_offset_");
             double offset = double.NaN;
-            if (!dataAccess.GetData(1, ref offset) || double.IsNaN(offset))
+            if (index == -1 || !dataAccess.GetData(index, ref offset) || double.IsNaN(offset))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -81,8 +101,17 @@ namespace SAM.Analytical.Grasshopper
             panels = panels.ConvertAll(x => Create.Panel(x));
             panels.ForEach(x => x.Snap(point3Ds, offset));
 
-            dataAccess.SetDataList(0, panels.ConvertAll(x => new GooPanel(x)));
-            dataAccess.SetDataList(1, point3Ds.ConvertAll(x => new Geometry.Grasshopper.GooSAMGeometry(x)));
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels.ConvertAll(x => new GooPanel(x)));
+            }
+
+            index = Params.IndexOfOutputParam("Point3Ds");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, point3Ds.ConvertAll(x => new Geometry.Grasshopper.GooSAMGeometry(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapByPoints.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapByPoints.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSnapByPoints : GH_SAMComponent
+    public class SAMAnalyticalSnapByPoints : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// ` Provides an Icon for the component.
@@ -40,21 +40,36 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
-            inputParamManager.AddParameter(new GooPanelParam(), "_Panel", "_Panel", "SAM Analytical Panel", GH_ParamAccess.item);
-            index = inputParamManager.AddParameter(new Geometry.Grasshopper.GooSAMGeometryParam(), "_points", "_points", "List of Points", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
-            inputParamManager.AddNumberParameter("_maxDistance_", "_maxDistance_", "Max Distance to snap points default 1m", GH_ParamAccess.item, 1);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_Panel", NickName = "_Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new Geometry.Grasshopper.GooSAMGeometryParam() { Name = "_points", NickName = "_points", Description = "List of Points", Access = GH_ParamAccess.list, DataMapping = GH_DataMapping.Flatten }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_maxDistance_", NickName = "_maxDistance_", Description = "Max Distance to snap points default 1m", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(1);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "_Panel", "_Panel", "SAM Analytical Panel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_Panel", NickName = "_Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,24 +80,27 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_Panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_points");
             List<Geometry.ISAMGeometry> geometries = new List<Geometry.ISAMGeometry>();
-
-            List<object> objects = new List<object>();
-            if (!dataAccess.GetDataList(1, geometries) || geometries == null)
+            if (index == -1 || !dataAccess.GetDataList(index, geometries) || geometries == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_maxDistance_");
             double maxDistance = double.NaN;
-            if (!dataAccess.GetData(2, ref maxDistance) || double.IsNaN(maxDistance))
+            if (index == -1 || !dataAccess.GetData(index, ref maxDistance) || double.IsNaN(maxDistance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -94,7 +112,11 @@ namespace SAM.Analytical.Grasshopper
             Panel result = Create.Panel(panel);
             result.Snap(point3Ds, maxDistance);
 
-            dataAccess.SetData(0, new GooPanel(result));
+            index = Params.IndexOfOutputParam("_Panel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooPanel(result));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapPoints.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSnapPoints.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSnapPoints : GH_SAMComponent
+    public class SAMAnalyticalSnapPoints : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// ` Provides an Icon for the component.
@@ -41,19 +41,39 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_Panel", "_Panel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddPointParameter("_origin_", "_origin_", "Origin Point", GH_ParamAccess.item, new Point3d(0, 0, 0));
-            inputParamManager.AddNumberParameter("_offset_", "_offset_", "offset", GH_ParamAccess.item, 1);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_Panel", NickName = "_Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Point param_Point;
+                param_Point = new global::Grasshopper.Kernel.Parameters.Param_Point() { Name = "_origin_", NickName = "_origin_", Description = "Origin Point", Access = GH_ParamAccess.item };
+                param_Point.SetPersistentData(new Point3d(0, 0, 0));
+                result.Add(new GH_SAMParam(param_Point, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_offset_", NickName = "_offset_", Description = "offset", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(1);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddPointParameter("_Points", "_Points", "Points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Point() { Name = "_Points", NickName = "_Points", Description = "Points", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,22 +84,27 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_Panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_origin_");
             Point3d origin = new Point3d(0, 0, 0);
-            if (!dataAccess.GetData(1, ref origin))
+            if (index == -1 || !dataAccess.GetData(index, ref origin))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_offset_");
             double offset = 1;
-            if (!dataAccess.GetData(2, ref offset))
+            if (index == -1 || !dataAccess.GetData(index, ref offset))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -132,7 +157,11 @@ namespace SAM.Analytical.Grasshopper
                 point2Ds.Add(point2D.GetMoved(new Geometry.Planar.Vector2D(-offset, offset)));
             }
 
-            dataAccess.SetDataList(0, point2Ds.ConvertAll(x => Geometry.Rhino.Convert.ToRhino(plane.Convert(x))));
+            index = Params.IndexOfOutputParam("_Points");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, point2Ds.ConvertAll(x => Geometry.Rhino.Convert.ToRhino(plane.Convert(x))));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSplitByInternalEdges.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSplitByInternalEdges.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSplitByInternalEdges : GH_SAMComponent
+    public class SAMAnalyticalSplitByInternalEdges : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,17 +39,29 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_panel", "SAM Analytical PAnel", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_panel", Description = "SAM Analytical PAnel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "SAM Analytical Panels", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,8 +72,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -71,7 +86,11 @@ namespace SAM.Analytical.Grasshopper
             if (panels == null)
                 panels = new List<Panel>() { panel };
 
-            dataAccess.SetDataList(0, panels.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSplitPanelByElevations.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSplitPanelByElevations.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSplitPanelByElevations : GH_SAMComponent
+    public class SAMAnalyticalSplitPanelByElevations : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.2";
+        public override string LatestComponentVersion => "1.0.3";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -42,20 +42,33 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_panel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_elevations", "_elevations", "Elevations or Planes", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_elevations", NickName = "_elevations", Description = "Elevations or Planes", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panels", "Panels", "Panels", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooPanelParam(), "UpperPanels", "UpperPanels", "Panels above given Elevation", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooPanelParam(), "LowerPanels", "LowerPanels", "Panels below given Elevation", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panels", NickName = "Panels", Description = "Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "UpperPanels", NickName = "UpperPanels", Description = "Panels above given Elevation", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "LowerPanels", NickName = "LowerPanels", Description = "Panels below given Elevation", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -66,15 +79,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
-            if (!dataAccess.GetDataList(1, objectWrappers) || objectWrappers == null)
+            index = Params.IndexOfInputParam("_elevations");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrappers) || objectWrappers == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -153,9 +170,23 @@ namespace SAM.Analytical.Grasshopper
                     result_Lower.Add(panel_Temp);
             }
 
-            dataAccess.SetDataList(0, result?.ConvertAll(x => new GooPanel(x)));
-            dataAccess.SetDataList(1, result_Upper?.ConvertAll(x => new GooPanel(x)));
-            dataAccess.SetDataList(2, result_Lower?.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("Panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result?.ConvertAll(x => new GooPanel(x)));
+            }
+
+            index = Params.IndexOfOutputParam("UpperPanels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result_Upper?.ConvertAll(x => new GooPanel(x)));
+            }
+
+            index = Params.IndexOfOutputParam("LowerPanels");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result_Lower?.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSplitPanelsByElevations.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalSplitPanelsByElevations.cs
@@ -15,7 +15,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalSplitPanelsByElevations : GH_SAMComponent
+    public class SAMAnalyticalSplitPanelsByElevations : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -25,7 +25,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -45,20 +45,37 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panels", "_panels", "SAM Analytical Panels", GH_ParamAccess.list);
-            inputParamManager.AddGenericParameter("_elevations", "_elevations", "Elevations or Planes", GH_ParamAccess.list);
-            inputParamManager.AddNumberParameter("threshold_", "threshold_", "Threshold", GH_ParamAccess.item, 0);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panels", NickName = "_panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_elevations", NickName = "_elevations", Description = "Elevations or Planes", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "threshold_", NickName = "threshold_", Description = "Threshold", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(0.0);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddIntervalParameter("intervals", "intervals", "Elevations intervals", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooPanelParam(), "panels", "panels", "SAM Analytical Panels", GH_ParamAccess.tree);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Interval() { Name = "intervals", NickName = "intervals", Description = "Elevations intervals", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "panels", NickName = "panels", Description = "SAM Analytical Panels", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -69,15 +86,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_panels");
             List<Panel> panels = new List<Panel>();
-            if (!dataAccess.GetDataList(0, panels))
+            if (index == -1 || !dataAccess.GetDataList(index, panels))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
-            if (!dataAccess.GetDataList(1, objectWrappers) || objectWrappers == null)
+            index = Params.IndexOfInputParam("_elevations");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrappers) || objectWrappers == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -138,9 +159,13 @@ namespace SAM.Analytical.Grasshopper
             }
 
             double threshold = double.NaN;
-            if (!dataAccess.GetData(2, ref threshold))
+            index = Params.IndexOfInputParam("threshold_");
+            if (index != -1)
             {
-                threshold = double.NaN;
+                if (!dataAccess.GetData(index, ref threshold))
+                {
+                    threshold = double.NaN;
+                }
             }
 
             if (double.IsNaN(threshold))
@@ -205,8 +230,17 @@ namespace SAM.Analytical.Grasshopper
                 tuples[i].Item3?.ForEach(x => dataTree_Panel.Add(new GooPanel(x), path));
             }
 
-            dataAccess.SetDataList(0, intervals.ConvertAll(x => new GH_Interval(x)));
-            dataAccess.SetDataTree(1, dataTree_Panel);
+            index = Params.IndexOfOutputParam("intervals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, intervals.ConvertAll(x => new GH_Interval(x)));
+            }
+
+            index = Params.IndexOfOutputParam("panels");
+            if (index != -1)
+            {
+                dataAccess.SetDataTree(index, dataTree_Panel);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalTransfom.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalTransfom.cs
@@ -8,10 +8,11 @@ using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper;
 using SAM.Geometry.Spatial;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalTransform : GH_SAMComponent
+    public class SAMAnalyticalTransform : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +22,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,18 +42,31 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooTransform3DParam(), "_transform", "_transform", "Transform can be SAM or GH", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooTransform3DParam() { Name = "_transform", NickName = "_transform", Description = "Transform can be SAM or GH", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("Analytical", "Analytical", "SAM Analytical Object such as Panel, Aperture etc.", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Analytical", NickName = "Analytical", Description = "SAM Analytical Object such as Panel, Aperture etc.", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,15 +77,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_transform");
             Transform3D transform3D = null;
-            if (!dataAccess.GetData(1, ref transform3D))
+            if (index == -1 || !dataAccess.GetData(index, ref transform3D))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_analytical");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject))
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -108,7 +126,11 @@ namespace SAM.Analytical.Grasshopper
                 sAMObject = analyticalModel;
             }
 
-            dataAccess.SetData(0, sAMObject);
+            index = Params.IndexOfOutputParam("Analytical");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, sAMObject);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateApertureConstructionsByName.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateApertureConstructionsByName.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateApertureConstructionsByName : GH_SAMComponent
+    public class SAMAnalyticalUpdateApertureConstructionsByName : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,23 +40,32 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Model ot Adjacency Cluster", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Model ot Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooApertureConstructionLibraryParam(), "apertureConstructionLibrary_", "apertureConstructionLibrary_", "SAM Analytical Aperture ConstructionLibrary", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooApertureConstructionLibraryParam() { Name = "apertureConstructionLibrary_", NickName = "apertureConstructionLibrary_", Description = "SAM Analytical Aperture ConstructionLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "Analyticals", "Analyticals", "SAM Analytical Model, Panels or Adjacency Cluster", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureConstructionLibraryParam(), "ApertureConstructionLibrary", "ApertureConstructionLibrary", "SAM Analytical ApertureConstructionLibrary", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "Analyticals", NickName = "Analyticals", Description = "SAM Analytical Model, Panels or Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooApertureConstructionLibraryParam() { Name = "ApertureConstructionLibrary", NickName = "ApertureConstructionLibrary", Description = "SAM Analytical ApertureConstructionLibrary", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,15 +76,22 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_analytical");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects))
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             ApertureConstructionLibrary apertureConstructionLibrary = null;
-            dataAccess.GetData(1, ref apertureConstructionLibrary);
+            index = Params.IndexOfInputParam("apertureConstructionLibrary_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref apertureConstructionLibrary);
+            }
             if (apertureConstructionLibrary == null)
                 apertureConstructionLibrary = ActiveSetting.Setting.GetValue<ApertureConstructionLibrary>(AnalyticalSettingParameter.DefaultApertureConstructionLibrary);
 
@@ -130,8 +146,17 @@ namespace SAM.Analytical.Grasshopper
                 constructionLibraries.Add(apertureConstructionLibrary_Temp);
             }
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
-            dataAccess.SetDataList(1, constructionLibraries.ConvertAll(x => new GooApertureConstructionLibrary(x)));
+            index = Params.IndexOfOutputParam("Analyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
+            }
+
+            index = Params.IndexOfOutputParam("ApertureConstructionLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, constructionLibraries.ConvertAll(x => new GooApertureConstructionLibrary(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateApertureConstructionsByPanelType.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateApertureConstructionsByPanelType.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateApertureConstructionsByPanelType : GH_SAMComponent
+    public class SAMAnalyticalUpdateApertureConstructionsByPanelType : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,23 +40,32 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Model ot Adjacency Cluster", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Model ot Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooApertureConstructionLibraryParam(), "apertureConstructionLibrary_", "apertureConstructionLibrary_", "SAM Analytical Aperture ConstructionLibrary", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooApertureConstructionLibraryParam() { Name = "apertureConstructionLibrary_", NickName = "apertureConstructionLibrary_", Description = "SAM Analytical Aperture ConstructionLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "Analyticals", "Analyticals", "SAM Analytical Model, Panels or Adjacency Cluster", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureConstructionLibraryParam(), "ApertureConstructionLibrary", "ApertureConstructionLibrary", "SAM Analytical ApertureConstructionLibrary", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "Analyticals", NickName = "Analyticals", Description = "SAM Analytical Model, Panels or Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooApertureConstructionLibraryParam() { Name = "ApertureConstructionLibrary", NickName = "ApertureConstructionLibrary", Description = "SAM Analytical ApertureConstructionLibrary", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,15 +76,22 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_analytical");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects))
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             ApertureConstructionLibrary apertureConstructionLibrary = null;
-            dataAccess.GetData(1, ref apertureConstructionLibrary);
+            index = Params.IndexOfInputParam("apertureConstructionLibrary_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref apertureConstructionLibrary);
+            }
             if (apertureConstructionLibrary == null)
                 apertureConstructionLibrary = ActiveSetting.Setting.GetValue<ApertureConstructionLibrary>(AnalyticalSettingParameter.DefaultApertureConstructionLibrary);
 
@@ -130,8 +146,17 @@ namespace SAM.Analytical.Grasshopper
                 constructionLibraries.Add(apertureConstructionLibrary_Temp);
             }
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
-            dataAccess.SetDataList(1, constructionLibraries.ConvertAll(x => new GooApertureConstructionLibrary(x)));
+            index = Params.IndexOfOutputParam("Analyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
+            }
+
+            index = Params.IndexOfOutputParam("ApertureConstructionLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, constructionLibraries.ConvertAll(x => new GooApertureConstructionLibrary(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateConstructionManager.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateConstructionManager.cs
@@ -105,7 +105,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<Construction> constructions = null;
 
-            index = Params.IndexOfInputParam("_constructions");
+            index = Params.IndexOfInputParam("constructions_");
             analyticalObjects = new List<IAnalyticalObject>();
             if (index != -1 && dataAccess.GetDataList(index, analyticalObjects) && analyticalObjects != null)
             {
@@ -129,7 +129,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<ApertureConstruction> apertureConstructions = null;
 
-            index = Params.IndexOfInputParam("_apertureConstructions");
+            index = Params.IndexOfInputParam("apertureConstructions_");
             analyticalObjects = new List<IAnalyticalObject>();
             if (index != -1 && dataAccess.GetDataList(index, analyticalObjects) && analyticalObjects != null)
             {
@@ -153,7 +153,7 @@ namespace SAM.Analytical.Grasshopper
 
             List<IMaterial> materials = null;
 
-            index = Params.IndexOfInputParam("_materials");
+            index = Params.IndexOfInputParam("materials_");
             List<ISAMObject> sAMObjects = new List<ISAMObject>();
             if (index != -1 && dataAccess.GetDataList(index, sAMObjects) && sAMObjects != null)
             {

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateConstructionsByMap.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateConstructionsByMap.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateConstructionsByMap : GH_SAMComponent
+    public class SAMAnalyticalUpdateConstructionsByMap : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.3";
+        public override string LatestComponentVersion => "1.0.4";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,27 +40,48 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Model ot Adjacency Cluster", GH_ParamAccess.list);
-            inputParamManager.AddTextParameter("_csvOrPath", "_csvOrPath", "Map File Path or csv text", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_sourceColumnName_", "_sourceColumnName_", "Column Name for Source Names of Constructions", GH_ParamAccess.item, "Name");
-            inputParamManager.AddTextParameter("_templateColumnName_", "_templateColumnName_", "Column Name for Template Names of Constructions", GH_ParamAccess.item, "template Family");
-            inputParamManager.AddTextParameter("_destinationColumnName_", "_destinationColumnName_", "Column Name for Destination Names of Constructions", GH_ParamAccess.item, "New Name Family");
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Model ot Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooConstructionLibraryParam(), "constructionLibrary_", "constructionLibrary_", "SAM Analytical ConstructionLibrary", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_csvOrPath", NickName = "_csvOrPath", Description = "Map File Path or csv text", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_sourceColumnName_", NickName = "_sourceColumnName_", Description = "Column Name for Source Names of Constructions", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("Name");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_templateColumnName_", NickName = "_templateColumnName_", Description = "Column Name for Template Names of Constructions", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("template Family");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_destinationColumnName_", NickName = "_destinationColumnName_", Description = "Column Name for Destination Names of Constructions", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("New Name Family");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "constructionLibrary_", NickName = "constructionLibrary_", Description = "SAM Analytical ConstructionLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "Analyticals", "Analyticals", "SAM Analytical Model, Panels or Adjacency Cluster", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooConstructionLibraryParam(), "ConstructionLibrary", "ConstructionLibrary", "SAM Analytical ConstructionLibrary", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "Analyticals", NickName = "Analyticals", Description = "SAM Analytical Model, Panels or Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "ConstructionLibrary", NickName = "ConstructionLibrary", Description = "SAM Analytical ConstructionLibrary", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -71,43 +92,54 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analytical");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects))
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_csvOrPath");
             string csvOrPath = null;
-            if (!dataAccess.GetData(1, ref csvOrPath) || csvOrPath == null)
+            if (index == -1 || !dataAccess.GetData(index, ref csvOrPath) || csvOrPath == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_sourceColumnName_");
             string sourceColumnName = null;
-            if (!dataAccess.GetData(2, ref sourceColumnName) || string.IsNullOrWhiteSpace(sourceColumnName))
+            if (index == -1 || !dataAccess.GetData(index, ref sourceColumnName) || string.IsNullOrWhiteSpace(sourceColumnName))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_templateColumnName_");
             string templateColumnName = null;
-            if (!dataAccess.GetData(3, ref templateColumnName) || string.IsNullOrWhiteSpace(templateColumnName))
+            if (index == -1 || !dataAccess.GetData(index, ref templateColumnName) || string.IsNullOrWhiteSpace(templateColumnName))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_destinationColumnName_");
             string destinationColumnName = null;
-            if (!dataAccess.GetData(4, ref destinationColumnName) || string.IsNullOrWhiteSpace(destinationColumnName))
+            if (index == -1 || !dataAccess.GetData(index, ref destinationColumnName) || string.IsNullOrWhiteSpace(destinationColumnName))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("constructionLibrary_");
             ConstructionLibrary constructionLibrary = null;
-            dataAccess.GetData(5, ref constructionLibrary);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref constructionLibrary);
+            }
             if (constructionLibrary == null)
                 constructionLibrary = ActiveSetting.Setting.GetValue<ConstructionLibrary>(AnalyticalSettingParameter.DefaultConstructionLibrary);
 
@@ -185,8 +217,17 @@ namespace SAM.Analytical.Grasshopper
                 constructionLibraries.Add(constructionLibrary_Temp);
             }
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
-            dataAccess.SetDataList(1, constructionLibraries.ConvertAll(x => new GooConstructionLibrary(x)));
+            index = Params.IndexOfOutputParam("Analyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
+            }
+
+            index = Params.IndexOfOutputParam("ConstructionLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, constructionLibraries.ConvertAll(x => new GooConstructionLibrary(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateConstructionsByName.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateConstructionsByName.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateConstructionsByName : GH_SAMComponent
+    public class SAMAnalyticalUpdateConstructionsByName : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,23 +40,32 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Model ot Adjacency Cluster", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Model ot Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooConstructionLibraryParam(), "constructionLibrary_", "constructionLibrary_", "SAM Analytical ConstructionLibrary", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "constructionLibrary_", NickName = "constructionLibrary_", Description = "SAM Analytical ConstructionLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "Analyticals", "Analyticals", "SAM Analytical Model, Panels or Adjacency Cluster", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooConstructionLibraryParam(), "ConstructionLibrary", "ConstructionLibrary", "SAM Analytical ConstructionLibrary", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "Analyticals", NickName = "Analyticals", Description = "SAM Analytical Model, Panels or Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "ConstructionLibrary", NickName = "ConstructionLibrary", Description = "SAM Analytical ConstructionLibrary", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,15 +76,22 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analytical");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects))
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("constructionLibrary_");
             ConstructionLibrary constructionLibrary = null;
-            dataAccess.GetData(1, ref constructionLibrary);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref constructionLibrary);
+            }
             if (constructionLibrary == null)
                 constructionLibrary = ActiveSetting.Setting.GetValue<ConstructionLibrary>(AnalyticalSettingParameter.DefaultConstructionLibrary);
 
@@ -130,8 +146,17 @@ namespace SAM.Analytical.Grasshopper
                 constructionLibraries.Add(constructionLibrary_Temp);
             }
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
-            dataAccess.SetDataList(1, constructionLibraries.ConvertAll(x => new GooConstructionLibrary(x)));
+            index = Params.IndexOfOutputParam("Analyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
+            }
+
+            index = Params.IndexOfOutputParam("ConstructionLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, constructionLibraries.ConvertAll(x => new GooConstructionLibrary(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateGeometry.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateGeometry.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateGeometry : GH_SAMComponent
+    public class SAMAnalyticalUpdateGeometry : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,41 +40,77 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooPanelParam(), "_panel", "_panel", "SAM Analytical Panel", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_geometry", "_geometry", "Geometry", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_copyApertures_", "_copyApertures_", "Copy apertures if possible", GH_ParamAccess.item, true);
-            inputParamManager.AddBooleanParameter("_includeInternalEdges_", "_includeInternalEdges_", "Include internal Edges if exist", GH_ParamAccess.item, true);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddBooleanParameter("simplify_", "simplify_", "Simplify", GH_ParamAccess.item, true);
-            inputParamManager.AddNumberParameter("minArea_", "minArea_", "Minimal Acceptable area of Aperture", GH_ParamAccess.item, Core.Tolerance.MacroDistance);
-            inputParamManager.AddNumberParameter("tolerance_", "tolerance_", "Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "_panel", NickName = "_panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_geometry", NickName = "_geometry", Description = "Geometry", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_copyApertures_", NickName = "_copyApertures_", Description = "Copy apertures if possible", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_includeInternalEdges_", NickName = "_includeInternalEdges_", Description = "Include internal Edges if exist", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "simplify_", NickName = "simplify_", Description = "Simplify", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "minArea_", NickName = "minArea_", Description = "Minimal Acceptable area of Aperture", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Core.Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "tolerance_", NickName = "tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooPanelParam(), "Panel", "Panel", "SAM Analytical Panel", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooPanelParam() { Name = "Panel", NickName = "Panel", Description = "SAM Analytical Panel", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_panel");
             Panel panel = null;
-            if (!dataAccess.GetData(0, ref panel))
+            if (index == -1 || !dataAccess.GetData(index, ref panel))
                 return;
 
+            index = Params.IndexOfInputParam("_geometry");
             object @object = null;
-            if (!dataAccess.GetData(1, ref @object))
+            if (index == -1 || !dataAccess.GetData(index, ref @object))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("simplify_");
             bool simplify = true;
-            if (!dataAccess.GetData(4, ref simplify))
+            if (index == -1 || !dataAccess.GetData(index, ref simplify))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -87,29 +123,33 @@ namespace SAM.Analytical.Grasshopper
                 return;
             }
 
+            index = Params.IndexOfInputParam("minArea_");
             double minArea = double.NaN;
-            if (!dataAccess.GetData(5, ref minArea))
+            if (index == -1 || !dataAccess.GetData(index, ref minArea))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("tolerance_");
             double tolerance = double.NaN;
-            if (!dataAccess.GetData(6, ref tolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_copyApertures_");
             bool copyApertures = true;
-            if (!dataAccess.GetData(2, ref copyApertures))
+            if (index == -1 || !dataAccess.GetData(index, ref copyApertures))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_includeInternalEdges_");
             bool includeInternalEdges = true;
-            if (!dataAccess.GetData(3, ref includeInternalEdges))
+            if (index == -1 || !dataAccess.GetData(index, ref includeInternalEdges))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -148,7 +188,11 @@ namespace SAM.Analytical.Grasshopper
                 }
             }
 
-            dataAccess.SetDataList(0, panels.ConvertAll(x => new GooPanel(x)));
+            index = Params.IndexOfOutputParam("Panel");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, panels.ConvertAll(x => new GooPanel(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateLibraries.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateLibraries.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateLibraries : GH_SAMComponent
+    public class SAMAnalyticalUpdateLibraries : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,24 +41,35 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            index = inputParamManager.AddParameter(new GooAnalyticalModelParam(), "_analyticalModel", "_analyticalModel", "SAM Analytical Model", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooAnalyticalModelParam() { Name = "_analyticalModel", NickName = "_analyticalModel", Description = "SAM Analytical Model", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new global::Grasshopper.Kernel.Parameters.Param_GenericObject(), "_libraries", "_libraries", "SAM Libraries (MaterialLibraries or/and ProfileLibraries)", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_libraries", NickName = "_libraries", Description = "SAM Libraries (MaterialLibraries or/and ProfileLibraries)", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddBooleanParameter("_missingOnly", "_missingOnly", "Copy only missing objects from library", GH_ParamAccess.item, true);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_missingOnly", NickName = "_missingOnly", Description = "Copy only missing objects from library", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAnalyticalModelParam(), "analyticalModel", "analyticalModel", "SAM Analytical Model", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAnalyticalModelParam() { Name = "analyticalModel", NickName = "analyticalModel", Description = "SAM Analytical Model", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -69,15 +80,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analyticalModel");
             AnalyticalModel analyticalModel = null;
-            if (!dataAccess.GetData(0, ref analyticalModel) || analyticalModel == null)
+            if (index == -1 || !dataAccess.GetData(index, ref analyticalModel) || analyticalModel == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_libraries");
             List<IJSAMObject> jSAMObjects = new List<IJSAMObject>();
-            if (!dataAccess.GetDataList(1, jSAMObjects) || jSAMObjects == null)
+            if (index == -1 || !dataAccess.GetDataList(index, jSAMObjects) || jSAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -85,10 +100,14 @@ namespace SAM.Analytical.Grasshopper
 
             List<ISAMLibrary> sAMLibraries = jSAMObjects.FindAll(x => x is ISAMLibrary).ConvertAll(x => (ISAMLibrary)x);
 
+            index = Params.IndexOfInputParam("_missingOnly");
             bool missingOnly = true;
-            if (!dataAccess.GetData(2, ref missingOnly))
+            if (index != -1)
             {
+                if (!dataAccess.GetData(index, ref missingOnly))
+                {
 
+                }
             }
 
             foreach (ISAMLibrary sAMLibrary in sAMLibraries)
@@ -126,7 +145,11 @@ namespace SAM.Analytical.Grasshopper
 
 
 
-            dataAccess.SetData(0, new GooAnalyticalModel(analyticalModel));
+            index = Params.IndexOfOutputParam("analyticalModel");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAnalyticalModel(analyticalModel));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateName.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateName.cs
@@ -6,10 +6,11 @@ using SAM.Analytical.Grasshopper.Properties;
 using SAM.Core;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateName : GH_SAMComponent
+    public class SAMAnalyticalUpdateName : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,19 +40,31 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Object", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_name", "_name", "Name", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name", NickName = "_name", Description = "Name", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "Analytical", "Analytical", "SAM Analytical Object", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "Analytical", NickName = "Analytical", Description = "SAM Analytical Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,15 +75,19 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_analytical");
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject))
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_name");
             string name = null;
-            if (!dataAccess.GetData(1, ref name) || name == null)
+            if (index == -1 || !dataAccess.GetData(index, ref name) || name == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -87,7 +104,11 @@ namespace SAM.Analytical.Grasshopper
                 sAMObject = new InternalCondition(name, internalCondition);
             }
 
-            dataAccess.SetData(0, sAMObject);
+            index = Params.IndexOfOutputParam("Analytical");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, sAMObject);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateNormals.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateNormals.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateNormals : GH_SAMComponent
+    public class SAMAnalyticalUpdateNormals : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,23 +39,35 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAdjacencyClusterParam(), "_adjacencyCluster", "_adjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            GooSpaceParam gooSpaceParam = new GooSpaceParam();
-            gooSpaceParam.Optional = true;
-            inputParamManager.AddParameter(gooSpaceParam, "space_", "space_", "SAM Analytical Space", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            inputParamManager.AddBooleanParameter("_includeApertures_", "_includeApertures_", "Include Apertures", GH_ParamAccess.item, false);
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "space_", NickName = "space_", Description = "SAM Analytical Space", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_includeApertures_", NickName = "_includeApertures_", Description = "Include Apertures", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAdjacencyClusterParam(), "AdjacencyCluster", "AdjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "AdjacencyCluster", NickName = "AdjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -66,18 +78,26 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_adjacencyCluster");
             AdjacencyCluster adjacencyCluster = null;
-            if (!dataAccess.GetData(0, ref adjacencyCluster) || adjacencyCluster == null)
+            if (index == -1 || !dataAccess.GetData(index, ref adjacencyCluster) || adjacencyCluster == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("space_");
             Space space = null;
-            dataAccess.GetData(1, ref space);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref space);
+            }
 
+            index = Params.IndexOfInputParam("_includeApertures_");
             bool includeApertures = false;
-            if (!dataAccess.GetData(2, ref includeApertures))
+            if (index == -1 || !dataAccess.GetData(index, ref includeApertures))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -96,7 +116,11 @@ namespace SAM.Analytical.Grasshopper
                     panels.ForEach(x => adjacencyCluster_New.AddObject(x));
             }
 
-            dataAccess.SetData(0, new GooAdjacencyCluster(adjacencyCluster_New));
+            index = Params.IndexOfOutputParam("AdjacencyCluster");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAdjacencyCluster(adjacencyCluster_New));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateObjects.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateObjects.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateObjects : GH_SAMComponent
+    public class SAMAnalyticalUpdateObjects : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,19 +40,35 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooAdjacencyClusterParam(), "_adjacencyCluster", "_adjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooAnalyticalObjectParam(), "_objects", "_objects", "SAM Objects", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "_adjacencyCluster", NickName = "_adjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooAnalyticalObjectParam() { Name = "_objects", NickName = "_objects", Description = "SAM Objects", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAdjacencyClusterParam(), "AdjacencyCluster", "AdjacencyCluster", "SAM Analytical AdjacencyCluster", GH_ParamAccess.item);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Successgully Added?", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooAdjacencyClusterParam() { Name = "AdjacencyCluster", NickName = "AdjacencyCluster", Description = "SAM Analytical AdjacencyCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Successgully Added?", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,16 +79,20 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             AdjacencyCluster adjacencyCluster = null;
 
-            if (!dataAccess.GetData(0, ref adjacencyCluster))
+            index = Params.IndexOfInputParam("_adjacencyCluster");
+            if (index == -1 || !dataAccess.GetData(index, ref adjacencyCluster))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<IAnalyticalObject> analyticalObjects = new List<IAnalyticalObject>();
-            if (!dataAccess.GetDataList(1, analyticalObjects))
+            index = Params.IndexOfInputParam("_objects");
+            if (index == -1 || !dataAccess.GetDataList(index, analyticalObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -92,8 +112,17 @@ namespace SAM.Analytical.Grasshopper
                 successfuls.Add(adjacencyCluster_Result.AddObject(analyticalObject));
             }
 
-            dataAccess.SetData(0, adjacencyCluster_Result);
-            dataAccess.SetDataList(1, successfuls);
+            index = Params.IndexOfOutputParam("AdjacencyCluster");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, adjacencyCluster_Result);
+            }
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, successfuls);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateSpace.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateSpace.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateSpaces : GH_SAMComponent
+    public class SAMAnalyticalUpdateSpaces : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.2";
+        public override string LatestComponentVersion => "1.0.3";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,18 +40,33 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Model ot Adjacency Cluster", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooSpaceParam(), "_spaces", "_spaces", "SAM Analytical Spaces", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Model ot Adjacency Cluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_spaces", NickName = "_spaces", Description = "SAM Analytical Spaces", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "Analytical", "Analytical", "SAM Analytical Model or Adjacency Cluster", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "Analytical", NickName = "Analytical", Description = "SAM Analytical Model or Adjacency Cluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,8 +77,11 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<Space> spaces = new List<Space>();
-            if (!dataAccess.GetDataList(1, spaces))
+            index = Params.IndexOfInputParam("_spaces");
+            if (index == -1 || !dataAccess.GetDataList(index, spaces))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -71,7 +89,8 @@ namespace SAM.Analytical.Grasshopper
 
 
             SAMObject sAMObject = null;
-            if (!dataAccess.GetData(0, ref sAMObject) || sAMObject == null)
+            index = Params.IndexOfInputParam("_analytical");
+            if (index == -1 || !dataAccess.GetData(index, ref sAMObject) || sAMObject == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -93,15 +112,19 @@ namespace SAM.Analytical.Grasshopper
             // a ~35 s loop to a few seconds.
             adjacencyCluster.UpdateSpaces(spaces);
 
-            if (sAMObject is AnalyticalModel)
+            index = Params.IndexOfOutputParam("Analytical");
+            if (index != -1)
             {
-                AnalyticalModel analyticalModel = ((AnalyticalModel)sAMObject);
-                analyticalModel = new AnalyticalModel(analyticalModel, adjacencyCluster);
-                dataAccess.SetData(0, new GooJSAMObject<SAMObject>(analyticalModel));
-            }
-            else
-            {
-                dataAccess.SetData(0, new GooJSAMObject<SAMObject>(adjacencyCluster));
+                if (sAMObject is AnalyticalModel)
+                {
+                    AnalyticalModel analyticalModel = ((AnalyticalModel)sAMObject);
+                    analyticalModel = new AnalyticalModel(analyticalModel, adjacencyCluster);
+                    dataAccess.SetData(index, new GooJSAMObject<SAMObject>(analyticalModel));
+                }
+                else
+                {
+                    dataAccess.SetData(index, new GooJSAMObject<SAMObject>(adjacencyCluster));
+                }
             }
         }
     }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateSpaceByLocationAndName.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateSpaceByLocationAndName.cs
@@ -9,10 +9,11 @@ using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper;
 using SAM.Geometry.Spatial;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateSpaceByLocationAndName : GH_SAMComponent
+    public class SAMAnalyticalUpdateSpaceByLocationAndName : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +23,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -42,25 +43,39 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooSpaceParam(), "_space", "_space", "SAM Analytcial Space", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "_space", NickName = "_space", Description = "SAM Analytcial Space", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("_location_", "_location_", "Location", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_GenericObject param_GenericObject;
 
-            index = inputParamManager.AddGenericParameter("_name_", "_name_", "Name", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                param_GenericObject = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_location_", NickName = "_location_", Description = "Location", Access = GH_ParamAccess.item, Optional = true };
+                result.Add(new GH_SAMParam(param_GenericObject, ParamVisibility.Binding));
+
+                param_GenericObject = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_name_", NickName = "_name_", Description = "Name", Access = GH_ParamAccess.item, Optional = true };
+                result.Add(new GH_SAMParam(param_GenericObject, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSpaceParam(), "Space", "Space", "SAM Analytical Space", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooSpaceParam() { Name = "Space", NickName = "Space", Description = "SAM Analytical Space", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -71,19 +86,27 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             Space space = null;
-            if (!dataAccess.GetData(0, ref space))
+            index = Params.IndexOfInputParam("_space");
+            if (index == -1 || !dataAccess.GetData(index, ref space))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             string name = null;
-            dataAccess.GetData(2, ref name);
+            index = Params.IndexOfInputParam("_name_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref name);
+            }
 
             Point3D location = null;
             GH_ObjectWrapper objectWrapper = null;
-            if (dataAccess.GetData(1, ref objectWrapper))
+            index = Params.IndexOfInputParam("_location_");
+            if (index != -1 && dataAccess.GetData(index, ref objectWrapper))
             {
                 if (objectWrapper.Value is GH_Point)
                     location = Geometry.Rhino.Convert.ToSAM(((GH_Point)objectWrapper.Value).Value);
@@ -101,7 +124,11 @@ namespace SAM.Analytical.Grasshopper
 
             Space space_Result = new Space(space, name, location);
 
-            dataAccess.SetData(0, new GooSpace(space_Result));
+            index = Params.IndexOfOutputParam("Space");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooSpace(space_Result));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateTypesByMap.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateTypesByMap.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateTypesByMap : GH_SAMComponent
+    public class SAMAnalyticalUpdateTypesByMap : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,31 +40,55 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Model ot Adjacency Cluster", GH_ParamAccess.list);
-            inputParamManager.AddTextParameter("_csvOrPath", "_csvOrPath", "Map File Path or csv text", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_sourceColumnName_", "_sourceColumnName_", "Column Name for Source Names of Constructions", GH_ParamAccess.item, "Name");
-            inputParamManager.AddTextParameter("_templateColumnName_", "_templateColumnName_", "Column Name for Template Names of Constructions", GH_ParamAccess.item, "template Family");
-            inputParamManager.AddTextParameter("_destinationColumnName_", "_destinationColumnName_", "Column Name for Destination Names of Constructions", GH_ParamAccess.item, "New Name Family");
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Model ot Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooConstructionLibraryParam(), "constructionLibrary_", "constructionLibrary_", "SAM Analytical ConstructionLibrary", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_csvOrPath", NickName = "_csvOrPath", Description = "Map File Path or csv text", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooApertureConstructionLibraryParam(), "apertureConstructionLibrary_", "apertureConstructionLibrary_", "SAM Analytical ApertureConstructionLibrary", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_sourceColumnName_", NickName = "_sourceColumnName_", Description = "Column Name for Source Names of Constructions", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("Name");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_templateColumnName_", NickName = "_templateColumnName_", Description = "Column Name for Template Names of Constructions", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("template Family");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_destinationColumnName_", NickName = "_destinationColumnName_", Description = "Column Name for Destination Names of Constructions", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("New Name Family");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "constructionLibrary_", NickName = "constructionLibrary_", Description = "SAM Analytical ConstructionLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooApertureConstructionLibraryParam() { Name = "apertureConstructionLibrary_", NickName = "apertureConstructionLibrary_", Description = "SAM Analytical ApertureConstructionLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "Analyticals", "Analyticals", "SAM Analytical Model, Panels or Adjacency Cluster", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooConstructionLibraryParam(), "ConstructionLibrary", "ConstructionLibrary", "SAM Analytical ConstructionLibrary", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureConstructionLibraryParam(), "ApertureConstructionLibrary", "ApertureConstructionLibrary", "SAM Analytical ApertureConstructionLibrary", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "Analyticals", NickName = "Analyticals", Description = "SAM Analytical Model, Panels or Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "ConstructionLibrary", NickName = "ConstructionLibrary", Description = "SAM Analytical ConstructionLibrary", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooApertureConstructionLibraryParam() { Name = "ApertureConstructionLibrary", NickName = "ApertureConstructionLibrary", Description = "SAM Analytical ApertureConstructionLibrary", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -75,48 +99,63 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects))
+            index = Params.IndexOfInputParam("_analytical");
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             string csvOrPath = null;
-            if (!dataAccess.GetData(1, ref csvOrPath) || csvOrPath == null)
+            index = Params.IndexOfInputParam("_csvOrPath");
+            if (index == -1 || !dataAccess.GetData(index, ref csvOrPath) || csvOrPath == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             string sourceColumnName = null;
-            if (!dataAccess.GetData(2, ref sourceColumnName) || string.IsNullOrWhiteSpace(sourceColumnName))
+            index = Params.IndexOfInputParam("_sourceColumnName_");
+            if (index == -1 || !dataAccess.GetData(index, ref sourceColumnName) || string.IsNullOrWhiteSpace(sourceColumnName))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             string templateColumnName = null;
-            if (!dataAccess.GetData(3, ref templateColumnName) || string.IsNullOrWhiteSpace(templateColumnName))
+            index = Params.IndexOfInputParam("_templateColumnName_");
+            if (index == -1 || !dataAccess.GetData(index, ref templateColumnName) || string.IsNullOrWhiteSpace(templateColumnName))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             string destinationColumnName = null;
-            if (!dataAccess.GetData(4, ref destinationColumnName) || string.IsNullOrWhiteSpace(destinationColumnName))
+            index = Params.IndexOfInputParam("_destinationColumnName_");
+            if (index == -1 || !dataAccess.GetData(index, ref destinationColumnName) || string.IsNullOrWhiteSpace(destinationColumnName))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             ConstructionLibrary constructionLibrary = null;
-            dataAccess.GetData(5, ref constructionLibrary);
+            index = Params.IndexOfInputParam("constructionLibrary_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref constructionLibrary);
+            }
             if (constructionLibrary == null)
                 constructionLibrary = ActiveSetting.Setting.GetValue<ConstructionLibrary>(AnalyticalSettingParameter.DefaultConstructionLibrary);
 
             ApertureConstructionLibrary apertureConstructionLibrary = null;
-            dataAccess.GetData(6, ref apertureConstructionLibrary);
+            index = Params.IndexOfInputParam("apertureConstructionLibrary_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref apertureConstructionLibrary);
+            }
             if (apertureConstructionLibrary == null)
                 apertureConstructionLibrary = ActiveSetting.Setting.GetValue<ApertureConstructionLibrary>(AnalyticalSettingParameter.DefaultApertureConstructionLibrary);
 
@@ -227,9 +266,23 @@ namespace SAM.Analytical.Grasshopper
                 apertureConstructionLibraries.Add(apertureConstructionLibrary_Temp);
             }
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
-            dataAccess.SetDataList(1, constructionLibraries.ConvertAll(x => new GooConstructionLibrary(x)));
-            dataAccess.SetDataList(2, apertureConstructionLibraries.ConvertAll(x => new GooApertureConstructionLibrary(x)));
+            index = Params.IndexOfOutputParam("Analyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
+            }
+
+            index = Params.IndexOfOutputParam("ConstructionLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, constructionLibraries.ConvertAll(x => new GooConstructionLibrary(x)));
+            }
+
+            index = Params.IndexOfOutputParam("ApertureConstructionLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, apertureConstructionLibraries.ConvertAll(x => new GooApertureConstructionLibrary(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateTypesByName.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalUpdateTypesByName.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Analytical.Grasshopper
 {
-    public class SAMAnalyticalUpdateTypesByName : GH_SAMComponent
+    public class SAMAnalyticalUpdateTypesByName : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,27 +40,39 @@ namespace SAM.Analytical.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_analytical", "_analytical", "SAM Analytical Model ot Adjacency Cluster", GH_ParamAccess.list);
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_analytical", NickName = "_analytical", Description = "SAM Analytical Model ot Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooConstructionLibraryParam(), "constructionLibrary_", "constructionLibrary_", "SAM Analytical ConstructionLibrary", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "constructionLibrary_", NickName = "constructionLibrary_", Description = "SAM Analytical ConstructionLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddParameter(new GooApertureConstructionLibraryParam(), "apertureConstructionLibrary_", "apertureConstructionLibrary_", "SAM Analytical ApertureConstructionLibrary", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                result.Add(new GH_SAMParam(new GooApertureConstructionLibraryParam() { Name = "apertureConstructionLibrary_", NickName = "apertureConstructionLibrary_", Description = "SAM Analytical ApertureConstructionLibrary", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "Analyticals", "Analyticals", "SAM Analytical Model, Panels or Adjacency Cluster", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooConstructionLibraryParam(), "ConstructionLibrary", "ConstructionLibrary", "SAM Analytical ConstructionLibrary", GH_ParamAccess.list);
-            outputParamManager.AddParameter(new GooApertureConstructionLibraryParam(), "ApertureConstructionLibrary", "ApertureConstructionLibrary", "SAM Analytical ApertureConstructionLibrary", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "Analyticals", NickName = "Analyticals", Description = "SAM Analytical Model, Panels or Adjacency Cluster", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooConstructionLibraryParam() { Name = "ConstructionLibrary", NickName = "ConstructionLibrary", Description = "SAM Analytical ConstructionLibrary", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooApertureConstructionLibraryParam() { Name = "ApertureConstructionLibrary", NickName = "ApertureConstructionLibrary", Description = "SAM Analytical ApertureConstructionLibrary", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -71,20 +83,31 @@ namespace SAM.Analytical.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(0, sAMObjects))
+            index = Params.IndexOfInputParam("_analytical");
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             ConstructionLibrary constructionLibrary = null;
-            dataAccess.GetData(1, ref constructionLibrary);
+            index = Params.IndexOfInputParam("constructionLibrary_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref constructionLibrary);
+            }
             if (constructionLibrary == null)
                 constructionLibrary = ActiveSetting.Setting.GetValue<ConstructionLibrary>(AnalyticalSettingParameter.DefaultConstructionLibrary); ;
 
             ApertureConstructionLibrary apertureConstructionLibrary = null;
-            dataAccess.GetData(2, ref apertureConstructionLibrary);
+            index = Params.IndexOfInputParam("apertureConstructionLibrary_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref apertureConstructionLibrary);
+            }
             if (apertureConstructionLibrary == null)
                 apertureConstructionLibrary = ActiveSetting.Setting.GetValue<ApertureConstructionLibrary>(AnalyticalSettingParameter.DefaultApertureConstructionLibrary);
 
@@ -166,9 +189,23 @@ namespace SAM.Analytical.Grasshopper
                 apertureConstructionLibraries.Add(apertureConstructionLibrary_Temp);
             }
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
-            dataAccess.SetDataList(1, constructionLibraries.ConvertAll(x => new GooConstructionLibrary(x)));
-            dataAccess.SetDataList(2, apertureConstructionLibraries.ConvertAll(x => new GooApertureConstructionLibrary(x)));
+            index = Params.IndexOfOutputParam("Analyticals");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooJSAMObject<SAMObject>(x)));
+            }
+
+            index = Params.IndexOfOutputParam("ConstructionLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, constructionLibraries.ConvertAll(x => new GooConstructionLibrary(x)));
+            }
+
+            index = Params.IndexOfOutputParam("ApertureConstructionLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, apertureConstructionLibraries.ConvertAll(x => new GooApertureConstructionLibrary(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Architectural.Grasshopper/Component/SAMArchitecturalCreateLevel.cs
+++ b/Grasshopper/SAM.Architectural.Grasshopper/Component/SAMArchitecturalCreateLevel.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Architectural.Grasshopper.Properties;
 using SAM.Core.Grasshopper;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Architectural.Grasshopper
 {
-    public class SAMArchitecturalCreateLevel : GH_SAMComponent
+    public class SAMArchitecturalCreateLevel : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Architectural.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,18 +39,28 @@ namespace SAM.Architectural.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddTextParameter("_name", "name", "Name", GH_ParamAccess.item);
-            inputParamManager.AddNumberParameter("_elevation", "elevation", "Elevation", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name", NickName = "name", Description = "Name", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_elevation", NickName = "elevation", Description = "Elevation", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooLevelParam(), "Level", "Level", "SAM Architectural Level", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooLevelParam() { Name = "Level", NickName = "Level", Description = "SAM Architectural Level", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,21 +71,29 @@ namespace SAM.Architectural.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_name");
             string name = null;
-            if (!dataAccess.GetData(0, ref name) || string.IsNullOrEmpty(name))
+            if (index == -1 || !dataAccess.GetData(index, ref name) || string.IsNullOrEmpty(name))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_elevation");
             double elevation = double.NaN;
-            if (!dataAccess.GetData(1, ref elevation) || double.IsNaN(elevation))
+            if (index == -1 || !dataAccess.GetData(index, ref elevation) || double.IsNaN(elevation))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            dataAccess.SetData(0, new GooLevel(new Level(name, elevation)));
+            index = Params.IndexOfOutputParam("Level");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooLevel(new Level(name, elevation)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Classes/GH_SAMComponent.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Classes/GH_SAMComponent.cs
@@ -52,6 +52,16 @@ namespace SAM.Core.Grasshopper
 
         public abstract string LatestComponentVersion { get; }
 
+        public virtual string MinCompatibleVersion => LatestComponentVersion;
+
+        public ObsoleteSeverity ObsoleteSeverity
+        {
+            get
+            {
+                return Query.GetObsoleteSeverity(this);
+            }
+        }
+
         public override void AddedToDocument(GH_Document document)
         {
             base.AddedToDocument(document);

--- a/Grasshopper/SAM.Core.Grasshopper/Classes/ParamConnection.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Classes/ParamConnection.cs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System.Collections.Generic;
+
+namespace SAM.Core.Grasshopper
+{
+    public class ParamConnection
+    {
+        public GH_ParameterSide Side;
+        public string ParamName;
+        public List<IGH_Param> ConnectedParams = new List<IGH_Param>();
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreARGBToUint.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreARGBToUint.cs
@@ -4,10 +4,11 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreARGBToUint : GH_SAMComponent
+    public class SAMCoreARGBToUint : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -17,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -37,20 +38,39 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddIntegerParameter("a_", "a_", "Alpha", GH_ParamAccess.item, 255);
-            inputParamManager.AddIntegerParameter("_r", "_r", "Red", GH_ParamAccess.item);
-            inputParamManager.AddIntegerParameter("_g", "_g", "Green", GH_ParamAccess.item);
-            inputParamManager.AddIntegerParameter("_b", "_b", "Blue", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                global::Grasshopper.Kernel.Parameters.Param_Integer param_Integer;
+
+                param_Integer = new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "a_", NickName = "a_", Description = "Alpha", Access = GH_ParamAccess.item, Optional = true };
+                param_Integer.SetPersistentData(255);
+                result.Add(new GH_SAMParam(param_Integer, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "_r", NickName = "_r", Description = "Red", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "_g", NickName = "_g", Description = "Green", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "_b", NickName = "_b", Description = "Blue", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddIntegerParameter("Uint", "Uint", "Uint", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "Uint", NickName = "Uint", Description = "Uint", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -61,31 +81,35 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("a_");
             int a = 255;
-            if (!dataAccess.GetData(0, ref a))
+            if (index == -1 || !dataAccess.GetData(index, ref a))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_r");
             int r = int.MinValue;
-            if (!dataAccess.GetData(1, ref r))
+            if (index == -1 || !dataAccess.GetData(index, ref r))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-
+            index = Params.IndexOfInputParam("_g");
             int g = int.MinValue;
-            if (!dataAccess.GetData(2, ref g))
+            if (index == -1 || !dataAccess.GetData(index, ref g))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-
+            index = Params.IndexOfInputParam("_b");
             int b = int.MinValue;
-            if (!dataAccess.GetData(3, ref b))
+            if (index == -1 || !dataAccess.GetData(index, ref b))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -97,7 +121,11 @@ namespace SAM.Core.Grasshopper
             else
                 @uint = Core.Convert.ToUint(System.Convert.ToByte(a), System.Convert.ToByte(r), System.Convert.ToByte(g), System.Convert.ToByte(b));
 
-            dataAccess.SetData(0, System.Convert.ToInt32(@uint));
+            index = Params.IndexOfOutputParam("Uint");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, System.Convert.ToInt32(@uint));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreAddMaterials.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreAddMaterials.cs
@@ -8,14 +8,14 @@ using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreAddMaterials : GH_SAMComponent
+    public class SAMCoreAddMaterials : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
         /// </summary>
         public override Guid ComponentGuid => new Guid("9e82ec78-e5fb-4843-b334-f62fa2fd9b6f");
 
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -35,20 +35,32 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooMaterialLibraryParam(), "_materialLibrary", "_materialLibrary", "SAM Material Library", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooMaterialParam(), "_materials", "_materials", "SAM Materials", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "_materialLibrary", NickName = "_materialLibrary", Description = "SAM Material Library", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooMaterialParam() { Name = "_materials", NickName = "_materials", Description = "SAM Materials", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooMaterialLibraryParam(), "MaterialLibrary", "MaterialLibrary", "SAM MaterialLibrary", GH_ParamAccess.item);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.list);
-
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "MaterialLibrary", NickName = "MaterialLibrary", Description = "SAM MaterialLibrary", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -59,15 +71,19 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_materialLibrary");
             MaterialLibrary materialLibrary = null;
-            if (!dataAccess.GetData(0, ref materialLibrary) || materialLibrary == null)
+            if (index == -1 || !dataAccess.GetData(index, ref materialLibrary) || materialLibrary == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<IMaterial> materials = new List<IMaterial>();
-            if (!dataAccess.GetDataList(1, materials))
+            index = Params.IndexOfInputParam("_materials");
+            if (index == -1 || !dataAccess.GetDataList(index, materials))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -82,8 +98,17 @@ namespace SAM.Core.Grasshopper
                 successfuls.Add(successful);
             }
 
-            dataAccess.SetData(0, new GooMaterialLibrary(materialLibrary));
-            dataAccess.SetDataList(1, successfuls);
+            index = Params.IndexOfOutputParam("MaterialLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooMaterialLibrary(materialLibrary));
+            }
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, successfuls);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreColorToUint.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreColorToUint.cs
@@ -4,11 +4,12 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreColorToUint : GH_SAMComponent
+    public class SAMCoreColorToUint : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,18 +39,34 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddColourParameter("_color", "_color", "_Color", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_includeAlpha_", "_IncludeAplha_", "Include Alpha", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Colour() { Name = "_color", NickName = "_color", Description = "_Color", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_includeAlpha_", NickName = "_IncludeAplha_", Description = "Include Alpha", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddIntegerParameter("Uint", "Uint", "Uint", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "Uint", NickName = "Uint", Description = "Uint", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,15 +77,19 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_color");
             Color color = Color.Empty;
-            if (!dataAccess.GetData(0, ref color))
+            if (index == -1 || !dataAccess.GetData(index, ref color))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_includeAlpha_");
             bool includeAlpha = false;
-            if (!dataAccess.GetData(1, ref includeAlpha))
+            if (index == -1 || !dataAccess.GetData(index, ref includeAlpha))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -76,7 +97,11 @@ namespace SAM.Core.Grasshopper
 
             uint @uint = Core.Convert.ToUint(color, includeAlpha);
 
-            dataAccess.SetData(0, System.Convert.ToInt32(@uint));
+            index = Params.IndexOfOutputParam("Uint");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, System.Convert.ToInt32(@uint));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCopyMaterials.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCopyMaterials.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreCopyMaterials : GH_SAMComponent
+    public class SAMCoreCopyMaterials : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,20 +38,36 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooMaterialLibraryParam(), "materialLibrary_", "materialLibrary_", "Destination SAM MaterialLibrary", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooMaterialLibraryParam(), "materialLibraries_", "materialLibraries_", "Source SAM MaterialLibraries", GH_ParamAccess.list);
-            inputParamManager.AddBooleanParameter("_overwrite_", "_overwrite_", "Overwrite existing materials in destination SAM MaterialLibrary", GH_ParamAccess.item, true);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "materialLibrary_", NickName = "materialLibrary_", Description = "Destination SAM MaterialLibrary", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "materialLibraries_", NickName = "materialLibraries_", Description = "Source SAM MaterialLibraries", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_overwrite_", NickName = "_overwrite_", Description = "Overwrite existing materials in destination SAM MaterialLibrary", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooMaterialLibraryParam(), "MaterialLibrary", "MaterialLibrary", "SAM MaterialLibrary", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "MaterialLibrary", NickName = "MaterialLibrary", Description = "SAM MaterialLibrary", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,15 +78,19 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("materialLibrary_");
             MaterialLibrary materialLibrary = null;
-            if (!dataAccess.GetData(0, ref materialLibrary) || materialLibrary == null)
+            if (index == -1 || !dataAccess.GetData(index, ref materialLibrary) || materialLibrary == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<MaterialLibrary> materialLibraries = new List<MaterialLibrary>();
-            if (!dataAccess.GetDataList(1, materialLibraries))
+            index = Params.IndexOfInputParam("materialLibraries_");
+            if (index == -1 || !dataAccess.GetDataList(index, materialLibraries))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -80,12 +100,17 @@ namespace SAM.Core.Grasshopper
 
             if (materialLibraries == null || materialLibraries.Count == 0)
             {
-                dataAccess.SetData(0, new GooMaterialLibrary(materialLibrary));
+                index = Params.IndexOfOutputParam("MaterialLibrary");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, new GooMaterialLibrary(materialLibrary));
+                }
                 return;
             }
 
+            index = Params.IndexOfInputParam("_overwrite_");
             bool overwrite = true;
-            if (!dataAccess.GetData(2, ref overwrite))
+            if (index == -1 || !dataAccess.GetData(index, ref overwrite))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -115,7 +140,11 @@ namespace SAM.Core.Grasshopper
                 }
             }
 
-            dataAccess.SetData(0, new GooMaterialLibrary(materialLibrary));
+            index = Params.IndexOfOutputParam("MaterialLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooMaterialLibrary(materialLibrary));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateAddress.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateAddress.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreCreateAddress : GH_SAMComponent
+    public class SAMCoreCreateAddress : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,23 +39,47 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            Address address = Core.Query.DefaultAddress();
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddTextParameter("_street_", "_street_", "Street", GH_ParamAccess.item, address.Street);
-            inputParamManager.AddTextParameter("_city_", "_city_", "City", GH_ParamAccess.item, address.City);
-            inputParamManager.AddTextParameter("_postalCode_", "_postalCode_", "Postal Code", GH_ParamAccess.item, address.PostalCode);
-            inputParamManager.AddTextParameter("_countryCode_", "_countryCode_", "Country Code", GH_ParamAccess.item, address.CountryCode.ToString());
+                Address address = Core.Query.DefaultAddress();
+
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_street_", NickName = "_street_", Description = "Street", Access = GH_ParamAccess.item, Optional = true };
+                param_String.SetPersistentData(address.Street);
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_city_", NickName = "_city_", Description = "City", Access = GH_ParamAccess.item, Optional = true };
+                param_String.SetPersistentData(address.City);
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_postalCode_", NickName = "_postalCode_", Description = "Postal Code", Access = GH_ParamAccess.item, Optional = true };
+                param_String.SetPersistentData(address.PostalCode);
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_countryCode_", NickName = "_countryCode_", Description = "Country Code", Access = GH_ParamAccess.item, Optional = true };
+                param_String.SetPersistentData(address.CountryCode.ToString());
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooAddressParam(), "address", "address", "SAM Core Address", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooAddressParam() { Name = "address", NickName = "address", Description = "SAM Core Address", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,22 +90,27 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_street_");
             string street = string.Empty;
-            if (!dataAccess.GetData(0, ref street))
+            if (index == -1 || !dataAccess.GetData(index, ref street))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_city_");
             string city = string.Empty;
-            if (!dataAccess.GetData(1, ref city))
+            if (index == -1 || !dataAccess.GetData(index, ref city))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_postalCode_");
             string postalCode = string.Empty;
-            if (!dataAccess.GetData(2, ref postalCode))
+            if (index == -1 || !dataAccess.GetData(index, ref postalCode))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -88,8 +118,9 @@ namespace SAM.Core.Grasshopper
 
             CountryCode countryCode = CountryCode.Undefined;
 
+            index = Params.IndexOfInputParam("_countryCode_");
             GH_ObjectWrapper objectWrapper = null;
-            dataAccess.GetData(3, ref objectWrapper);
+            dataAccess.GetData(index, ref objectWrapper);
             if (objectWrapper != null)
             {
                 if (objectWrapper.Value is GH_String)
@@ -98,7 +129,11 @@ namespace SAM.Core.Grasshopper
                     countryCode = Core.Query.Enum<CountryCode>(objectWrapper.Value.ToString());
             }
 
-            dataAccess.SetData(0, new GooAddress(new Address(street, city, postalCode, countryCode)));
+            index = Params.IndexOfOutputParam("address");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooAddress(new Address(street, city, postalCode, countryCode)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateGasMaterial_Obsolete.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateGasMaterial_Obsolete.cs
@@ -4,11 +4,12 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper.Obsolete
 {
     [Obsolete("Obsolete since 2020-09-30")]
-    public class SAMCoreCreateGasMaterial : GH_SAMComponent
+    public class SAMCoreCreateGasMaterial : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Core.Grasshopper.Obsolete
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         public override GH_Exposure Exposure => GH_Exposure.hidden;
 
@@ -40,18 +41,29 @@ namespace SAM.Core.Grasshopper.Obsolete
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddTextParameter("_name", "_name", "Name", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name", NickName = "_name", Description = "Name", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooMaterialParam(), "Material", "Material", "SAM Material", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooMaterialParam() { Name = "Material", NickName = "Material", Description = "SAM Material", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,14 +74,21 @@ namespace SAM.Core.Grasshopper.Obsolete
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_name");
             string name = null;
-            if (!dataAccess.GetData(0, ref name) || string.IsNullOrWhiteSpace(name))
+            if (index == -1 || !dataAccess.GetData(index, ref name) || string.IsNullOrWhiteSpace(name))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            dataAccess.SetData(0, new GooMaterial(new GasMaterial(name)));
+            index = Params.IndexOfOutputParam("Material");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooMaterial(new GasMaterial(name)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateLocation.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateLocation.cs
@@ -4,10 +4,11 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreCreateLocation : GH_SAMComponent
+    public class SAMCoreCreateLocation : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -17,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -37,23 +38,47 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            Location location = Core.Query.DefaultLocation();
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddTextParameter("_name", "_name", "Name", GH_ParamAccess.item, location.Name);
-            inputParamManager.AddNumberParameter("_elevation", "_elevation", "Elevation", GH_ParamAccess.item, location.Elevation);
-            inputParamManager.AddNumberParameter("_latitude", "_latitude", "Latitude", GH_ParamAccess.item, location.Latitude);
-            inputParamManager.AddNumberParameter("_longitude", "_longitude", "Longitude", GH_ParamAccess.item, location.Longitude);
+                Location location = Core.Query.DefaultLocation();
+
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name", NickName = "_name", Description = "Name", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData(location.Name);
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_elevation", NickName = "_elevation", Description = "Elevation", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(location.Elevation);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_latitude", NickName = "_latitude", Description = "Latitude", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(location.Latitude);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_longitude", NickName = "_longitude", Description = "Longitude", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(location.Longitude);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooLocationParam(), "Location", "Location", "SAM Location", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooLocationParam() { Name = "Location", NickName = "Location", Description = "SAM Location", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,35 +89,45 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_name");
             string name = string.Empty;
-            if (!dataAccess.GetData(0, ref name))
+            if (index == -1 || !dataAccess.GetData(index, ref name))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_elevation");
             double elevation = double.NaN;
-            if (!dataAccess.GetData(1, ref elevation))
+            if (index == -1 || !dataAccess.GetData(index, ref elevation))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_latitude");
             double latitude = double.NaN;
-            if (!dataAccess.GetData(2, ref latitude))
+            if (index == -1 || !dataAccess.GetData(index, ref latitude))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_longitude");
             double longitude = double.NaN;
-            if (!dataAccess.GetData(3, ref longitude))
+            if (index == -1 || !dataAccess.GetData(index, ref longitude))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            dataAccess.SetData(0, new GooLocation(new Location(name, longitude, latitude, elevation)));
+            index = Params.IndexOfOutputParam("Location");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooLocation(new Location(name, longitude, latitude, elevation)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateMaterialLibrary.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateMaterialLibrary.cs
@@ -4,10 +4,11 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreCreateMaterialLibrary : GH_SAMComponent
+    public class SAMCoreCreateMaterialLibrary : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -17,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -37,18 +38,32 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddTextParameter("_name_", "_name_", "Name", GH_ParamAccess.item, "Default Material Library");
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name_", NickName = "_name_", Description = "Name", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("Default Material Library");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooMaterialLibraryParam(), "MaterialLibrary", "MaterialLibrary", "SAM MaterialLibrary", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "MaterialLibrary", NickName = "MaterialLibrary", Description = "SAM MaterialLibrary", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -59,14 +74,19 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_name_");
             string name = null;
-            if (!dataAccess.GetData(0, ref name) || name == null)
+            if (index == -1 || !dataAccess.GetData(index, ref name) || name == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            dataAccess.SetData(0, new GooMaterialLibrary(new MaterialLibrary(name)));
+            index = Params.IndexOfOutputParam("MaterialLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooMaterialLibrary(new MaterialLibrary(name)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateOpaqueMaterial_Obsolete.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateOpaqueMaterial_Obsolete.cs
@@ -4,11 +4,12 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper.Obsolete
 {
     [Obsolete("Obsolete since 2020-09-30")]
-    public class SAMCoreCreateOpaqueMaterial : GH_SAMComponent
+    public class SAMCoreCreateOpaqueMaterial : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Core.Grasshopper.Obsolete
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         public override GH_Exposure Exposure => GH_Exposure.hidden;
 
@@ -40,18 +41,27 @@ namespace SAM.Core.Grasshopper.Obsolete
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddTextParameter("_name", "_name", "Name", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name", NickName = "_name", Description = "Name", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooMaterialParam(), "Material", "Material", "SAM Material", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooMaterialParam() { Name = "Material", NickName = "Material", Description = "SAM Material", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,14 +72,19 @@ namespace SAM.Core.Grasshopper.Obsolete
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_name");
             string name = null;
-            if (!dataAccess.GetData(0, ref name) || string.IsNullOrWhiteSpace(name))
+            if (index == -1 || !dataAccess.GetData(index, ref name) || string.IsNullOrWhiteSpace(name))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            dataAccess.SetData(0, new GooMaterial(new OpaqueMaterial(name)));
+            index = Params.IndexOfOutputParam("Material");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooMaterial(new OpaqueMaterial(name)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateTransparentMaterial_Obsolete.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreCreateTransparentMaterial_Obsolete.cs
@@ -4,11 +4,12 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper.Obsolete
 {
     [Obsolete("Obsolete since 2020-09-30")]
-    public class SAMCoreCreateTransparentMaterial : GH_SAMComponent
+    public class SAMCoreCreateTransparentMaterial : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Core.Grasshopper.Obsolete
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         public override GH_Exposure Exposure => GH_Exposure.hidden;
 
@@ -40,18 +41,27 @@ namespace SAM.Core.Grasshopper.Obsolete
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddTextParameter("_name", "_name", "Name", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name", NickName = "_name", Description = "Name", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooMaterialParam(), "Material", "Material", "SAM Material", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooMaterialParam() { Name = "Material", NickName = "Material", Description = "SAM Material", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,14 +72,19 @@ namespace SAM.Core.Grasshopper.Obsolete
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_name");
             string name = null;
-            if (!dataAccess.GetData(0, ref name) || string.IsNullOrWhiteSpace(name))
+            if (index == -1 || !dataAccess.GetData(index, ref name) || string.IsNullOrWhiteSpace(name))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
-            dataAccess.SetData(0, new GooMaterial(new TransparentMaterial(name)));
+            index = Params.IndexOfOutputParam("Material");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooMaterial(new TransparentMaterial(name)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreFilter.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreFilter.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreFilter : GH_SAMComponent
+    public class SAMCoreFilter : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,14 +19,12 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
         /// </summary>
         protected override System.Drawing.Bitmap Icon => Resources.SAM_Filter3;
-
-        private GH_OutputParamManager outputParamManager;
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -41,27 +39,39 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddGenericParameter("_objects", "_objects", "Objects", GH_ParamAccess.list);
-            inputParamManager.AddTextParameter("_name", "_name", "Name", GH_ParamAccess.item, "Name");
-            inputParamManager.AddGenericParameter("_value", "_value", "Value to Filter elements", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_objects", NickName = "_objects", Description = "Objects", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("_comparisonType_", "_comparisonType_", "SAM ComparisonType (TextComparisonType or NumberComparisonType)", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name", NickName = "_name", Description = "Name", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData("Name");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_value", NickName = "_value", Description = "Value to Filter elements", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_comparisonType_", NickName = "_comparisonType_", Description = "SAM ComparisonType (TextComparisonType or NumberComparisonType)", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            this.outputParamManager = outputParamManager;
-            outputParamManager.AddGenericParameter("In", "In", "Objects In", GH_ParamAccess.list);
-            outputParamManager.AddGenericParameter("Out", "Out", "Objects Out", GH_ParamAccess.list);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "In", NickName = "In", Description = "Objects In", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Out", NickName = "Out", Description = "Objects Out", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -72,15 +82,19 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_name");
             string name = null;
-            if (!dataAccess.GetData(1, ref name) || string.IsNullOrWhiteSpace(name))
+            if (index == -1 || !dataAccess.GetData(index, ref name) || string.IsNullOrWhiteSpace(name))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_objects");
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
-            if (!dataAccess.GetDataList(0, objectWrappers))
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrappers))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -107,14 +121,9 @@ namespace SAM.Core.Grasshopper
                     objects.Add(@object);
             }
 
-            //if (@objects == null || @objects.Count == 0)
-            //{
-            //    AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-            //    return;
-            //}
-
+            index = Params.IndexOfInputParam("_value");
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(2, ref objectWrapper) || objectWrapper == null)
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -125,8 +134,13 @@ namespace SAM.Core.Grasshopper
                 value = (objectWrapper.Value as dynamic).Value;
 
 
+            index = Params.IndexOfInputParam("_comparisonType_");
             objectWrapper = null;
-            dataAccess.GetData(3, ref objectWrapper);
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref objectWrapper);
+            }
+
             object object_ComparisonType = null;
             if (objectWrapper?.Value == null)
             {
@@ -182,8 +196,17 @@ namespace SAM.Core.Grasshopper
                 }
             }
 
-            dataAccess.SetDataList(0, result_in);
-            dataAccess.SetDataList(1, result_out);
+            index = Params.IndexOfOutputParam("In");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result_in);
+            }
+
+            index = Params.IndexOfOutputParam("Out");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result_out);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreFilterByType.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreFilterByType.cs
@@ -24,6 +24,16 @@ namespace SAM.Core.Grasshopper
         /// </summary>
         public string LatestComponentVersion => "1.0.0";
 
+        public string MinCompatibleVersion => LatestComponentVersion;
+
+        public ObsoleteSeverity ObsoleteSeverity
+        {
+            get
+            {
+                return Core.Grasshopper.Query.GetObsoleteSeverity(this);
+            }
+        }
+
         public override GH_Exposure Exposure => GH_Exposure.tertiary;
 
         /// <summary>

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreFromFile.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreFromFile.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreFromFile : GH_SAMComponent
+    public class SAMCoreFromFile : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,19 +38,35 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_path", "_path", "file path", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_path", NickName = "_path", Description = "file path", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("SAMObjects", "SAMObjects", "SAM Objects", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "SAMObjects", NickName = "SAMObjects", Description = "SAM Objects", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -61,30 +77,54 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(1, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_path");
             string path = null;
-            if (!dataAccess.GetData(0, ref path))
+            if (index == -1 || !dataAccess.GetData(index, ref path))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Invalid path");
-                dataAccess.SetData(0, null);
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("SAMObjects");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(path))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Null or Empty value for Json");
-                dataAccess.SetData(0, null);
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("SAMObjects");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
@@ -92,17 +132,33 @@ namespace SAM.Core.Grasshopper
             if (jSAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Could not parse Json to SAM");
-                dataAccess.SetData(0, null);
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("SAMObjects");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
-            if (jSAMObjects.Count == 1)
-                dataAccess.SetData(0, jSAMObjects[0]);
-            else
-                dataAccess.SetDataList(0, jSAMObjects);
+            index = Params.IndexOfOutputParam("SAMObjects");
+            if (index != -1)
+            {
+                if (jSAMObjects.Count == 1)
+                    dataAccess.SetData(index, jSAMObjects[0]);
+                else
+                    dataAccess.SetDataList(index, jSAMObjects);
+            }
 
-            dataAccess.SetData(1, true);
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreFromJson.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreFromJson.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreFromJson : GH_SAMComponent
+    public class SAMCoreFromJson : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,19 +38,35 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_pathJSON", "_pathJSON", "JSON file path including extension .json or .JSON", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_pathJSON", NickName = "_pathJSON", Description = "JSON file path including extension .json or .JSON", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("SAMObjects", "SAMObjects", "SAM Objects", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "SAMObjects", NickName = "SAMObjects", Description = "SAM Objects", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -61,30 +77,52 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+            int index_Successful = Params.IndexOfOutputParam("Successful");
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(1, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                if (index_Successful != -1)
+                {
+                    dataAccess.SetData(index_Successful, false);
+                }
                 return;
             }
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_pathJSON");
             string pathOrJson = null;
-            if (!dataAccess.GetData(0, ref pathOrJson))
+            if (index == -1 || !dataAccess.GetData(index, ref pathOrJson))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Null or Empty value for Json");
-                dataAccess.SetData(0, null);
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("SAMObjects");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
+                if (index_Successful != -1)
+                {
+                    dataAccess.SetData(index_Successful, false);
+                }
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(pathOrJson))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Null or Empty value for Json");
-                dataAccess.SetData(0, null);
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("SAMObjects");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
+                if (index_Successful != -1)
+                {
+                    dataAccess.SetData(index_Successful, false);
+                }
                 return;
             }
 
@@ -92,17 +130,31 @@ namespace SAM.Core.Grasshopper
             if (jSAMObjects == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Could not parse Json to SAM");
-                dataAccess.SetData(0, null);
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("SAMObjects");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
+                if (index_Successful != -1)
+                {
+                    dataAccess.SetData(index_Successful, false);
+                }
                 return;
             }
 
-            if (jSAMObjects.Count == 1)
-                dataAccess.SetData(0, jSAMObjects[0]);
-            else
-                dataAccess.SetDataList(0, jSAMObjects);
+            index = Params.IndexOfOutputParam("SAMObjects");
+            if (index != -1)
+            {
+                if (jSAMObjects.Count == 1)
+                    dataAccess.SetData(index, jSAMObjects[0]);
+                else
+                    dataAccess.SetDataList(index, jSAMObjects);
+            }
 
-            dataAccess.SetData(1, true);
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreGetNames.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreGetNames.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using Grasshopper.Kernel.Types;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreGetNames : GH_SAMComponent
+    public class SAMCoreGetNames : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,18 +39,27 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_object", "_object", "SAM Object", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_object", NickName = "_object", Description = "SAM Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddTextParameter("Names", "Names", "Property names", GH_ParamAccess.list);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "Names", NickName = "Names", Description = "Property names", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,10 +70,15 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_object");
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper == null)
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null)
             {
-                dataAccess.SetData(0, null);
+                index = Params.IndexOfOutputParam("Names");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Null object provided");
                 return;
             }
@@ -84,12 +99,20 @@ namespace SAM.Core.Grasshopper
 
             if (@object == null)
             {
-                dataAccess.SetData(0, null);
+                index = Params.IndexOfOutputParam("Names");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Null object provided");
                 return;
             }
 
-            dataAccess.SetDataList(0, Core.Query.Names(@object));
+            index = Params.IndexOfOutputParam("Names");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, Core.Query.Names(@object));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreGetValue.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreGetValue.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreGetValue : GH_SAMComponent
+    public class SAMCoreGetValue : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,14 +20,12 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
         /// </summary>
         protected override System.Drawing.Bitmap Icon => Resources.SAM_Get3;
-
-        private GH_OutputParamManager outputParamManager;
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -42,21 +40,34 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_object", "_object", "SAM Object", GH_ParamAccess.item);
-            int index = inputParamManager.AddTextParameter("_name_", "_name_", "Name", GH_ParamAccess.item, "Name");
-            inputParamManager[index].DataMapping = GH_DataMapping.Graft;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_object", NickName = "_object", Description = "SAM Object", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_name_", NickName = "_name_", Description = "Name", Access = GH_ParamAccess.item, DataMapping = GH_DataMapping.Graft };
+                param_String.SetPersistentData("Name");
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            this.outputParamManager = outputParamManager;
-            outputParamManager.AddGenericParameter("Value", "Value", "Property Value", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Value", NickName = "Value", Description = "Property Value", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,17 +78,23 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_name_");
             string name = null;
-            if (!dataAccess.GetData(1, ref name) || string.IsNullOrWhiteSpace(name))
+            if (index == -1 || !dataAccess.GetData(index, ref name) || string.IsNullOrWhiteSpace(name))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_object");
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper == null)
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null)
             {
-                dataAccess.SetData(0, null);
+                index = Params.IndexOfOutputParam("Value");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Null object provided");
                 return;
             }
@@ -98,7 +115,11 @@ namespace SAM.Core.Grasshopper
 
             if (@object == null)
             {
-                dataAccess.SetData(0, null);
+                index = Params.IndexOfOutputParam("Value");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, null);
+                }
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Null object provided");
                 return;
             }
@@ -144,10 +165,14 @@ namespace SAM.Core.Grasshopper
                 value = new GooJSAMObject<SAMObject>((SAMObject)value);
             }
 
-            if (value is IEnumerable && !(value is string))
-                dataAccess.SetDataList(0, (IEnumerable)value);
-            else
-                dataAccess.SetData(0, value);
+            index = Params.IndexOfOutputParam("Value");
+            if (index != -1)
+            {
+                if (value is IEnumerable && !(value is string))
+                    dataAccess.SetDataList(index, (IEnumerable)value);
+                else
+                    dataAccess.SetData(index, value);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreInspect.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreInspect.cs
@@ -26,6 +26,16 @@ namespace SAM.Core.Grasshopper
         /// </summary>
         public string LatestComponentVersion => "1.0.0";
 
+        public string MinCompatibleVersion => LatestComponentVersion;
+
+        public ObsoleteSeverity ObsoleteSeverity
+        {
+            get
+            {
+                return Core.Grasshopper.Query.GetObsoleteSeverity(this);
+            }
+        }
+
         public override GH_Exposure Exposure => GH_Exposure.tertiary;
 
         /// <summary>

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreLoadMaterialLibrary.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreLoadMaterialLibrary.cs
@@ -4,11 +4,12 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
     [Obsolete("Obsolete since 2020-09-24")]
-    public class SAMCoreLoadMaterialLibrary : GH_SAMComponent
+    public class SAMCoreLoadMaterialLibrary : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         public override GH_Exposure Exposure => GH_Exposure.hidden;
 
@@ -40,19 +41,28 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            //inputParamManager.AddParameter(new GooMaterialLibraryParam(), "_materialLibrary", "_materialLibrary", "SAM Material Library", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_path", "_path", "Path", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_path", NickName = "_path", Description = "Path", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooMaterialLibraryParam(), "MaterialLibrary", "MaterialLibrary", "SAM MaterialLibrary", GH_ParamAccess.item);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "MaterialLibrary", NickName = "MaterialLibrary", Description = "SAM MaterialLibrary", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,8 +73,9 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_path");
             string path = null;
-            if (!dataAccess.GetData(0, ref path) || string.IsNullOrWhiteSpace(path))
+            if (index == -1 || !dataAccess.GetData(index, ref path) || string.IsNullOrWhiteSpace(path))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -74,8 +85,17 @@ namespace SAM.Core.Grasshopper
 
             bool successful = materialLibrary != null;
 
-            dataAccess.SetData(0, new GooMaterialLibrary(materialLibrary));
-            dataAccess.SetData(1, successful);
+            index = Params.IndexOfOutputParam("MaterialLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooMaterialLibrary(materialLibrary));
+            }
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, successful);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreLogToFile.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreLogToFile.cs
@@ -4,10 +4,11 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreLogToFile : GH_SAMComponent
+    public class SAMCoreLogToFile : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -17,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -37,19 +38,29 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooLogParam(), "_log", "_log", "SAM Log", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_path", "_path", "Save Log File Path", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooLogParam() { Name = "_log", NickName = "_log", Description = "SAM Log", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_path", NickName = "_path", Description = "Save Log File Path", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooLogParam(), "Log", "Log", "SAM Log", GH_ParamAccess.item);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly saved?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooLogParam() { Name = "Log", NickName = "Log", Description = "SAM Log", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly saved?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,18 +71,30 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            dataAccess.SetData(0, null);
-            dataAccess.SetData(1, false);
+            int index;
+            int index_Log = Params.IndexOfOutputParam("Log");
+            int index_Successful = Params.IndexOfOutputParam("Successful");
 
+            if (index_Log != -1)
+            {
+                dataAccess.SetData(index_Log, null);
+            }
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, false);
+            }
+
+            index = Params.IndexOfInputParam("_log");
             Log log = null;
-            if (!dataAccess.GetData(0, ref log) || log == null)
+            if (index == -1 || !dataAccess.GetData(index, ref log) || log == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_path");
             string path = null;
-            if (!dataAccess.GetData(1, ref path) || string.IsNullOrWhiteSpace(path))
+            if (index == -1 || !dataAccess.GetData(index, ref path) || string.IsNullOrWhiteSpace(path))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -79,8 +102,14 @@ namespace SAM.Core.Grasshopper
 
             if (log.Write(path))
             {
-                dataAccess.SetData(0, log);
-                dataAccess.SetData(1, true);
+                if (index_Log != -1)
+                {
+                    dataAccess.SetData(index_Log, log);
+                }
+                if (index_Successful != -1)
+                {
+                    dataAccess.SetData(index_Successful, true);
+                }
             }
         }
     }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreRelationClusterAddObjects.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreRelationClusterAddObjects.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 namespace SAM.Core.Grasshopper
 {
     [Obsolete("Obsolete since 2021-10-15")]
-    public class SAMCoreRelationClusterAddObjects : GH_SAMComponent
+    public class SAMCoreRelationClusterAddObjects : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         public override GH_Exposure Exposure => GH_Exposure.tertiary | GH_Exposure.hidden;
 
@@ -41,18 +41,28 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooRelationClusterParam(), "_relationCluster", "_relationCluster", "SAM RelationCluster", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_objects", "_objects", "SAM Objects", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooRelationClusterParam() { Name = "_relationCluster", NickName = "_relationCluster", Description = "SAM RelationCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_objects", NickName = "_objects", Description = "SAM Objects", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooRelationClusterParam(), "RelationCluster", "RelationCluster", "SAM RelationCluster", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooRelationClusterParam() { Name = "RelationCluster", NickName = "RelationCluster", Description = "SAM RelationCluster", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,14 +75,16 @@ namespace SAM.Core.Grasshopper
         {
             IRelationCluster relationCluster = null;
 
-            if (!dataAccess.GetData(0, ref relationCluster))
+            int index = Params.IndexOfInputParam("_relationCluster");
+            if (index == -1 || !dataAccess.GetData(index, ref relationCluster))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_objects");
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(1, sAMObjects))
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -85,8 +97,11 @@ namespace SAM.Core.Grasshopper
                 (relationCluster_Result as dynamic).AddObject(sAMObject);
             }
 
-
-            dataAccess.SetData(0, relationCluster_Result);
+            index = Params.IndexOfOutputParam("RelationCluster");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, relationCluster_Result);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreSAMLibraryAddObjects.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreSAMLibraryAddObjects.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreSAMLibraryAddObjects : GH_SAMComponent
+    public class SAMCoreSAMLibraryAddObjects : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,18 +38,31 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooJSAMObjectParam<ISAMLibrary>(), "_sAMLibrary", "_sAMLibrary", "SAM Core Library", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooJSAMObjectParam<SAMObject>(), "_objects", "_objects", "SAM Objects", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<ISAMLibrary>() { Name = "_sAMLibrary", NickName = "_sAMLibrary", Description = "SAM Core Library", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<SAMObject>() { Name = "_objects", NickName = "_objects", Description = "SAM Objects", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooJSAMObjectParam<ISAMLibrary>(), "SAMLibrary", "SAMLibrary", "SAM Core Library", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<ISAMLibrary>() { Name = "SAMLibrary", NickName = "SAMLibrary", Description = "SAM Core Library", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,16 +73,19 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            ISAMLibrary sAMLibrary = null;
+            int index = -1;
 
-            if (!dataAccess.GetData(0, ref sAMLibrary))
+            ISAMLibrary sAMLibrary = null;
+            index = Params.IndexOfInputParam("_sAMLibrary");
+            if (index == -1 || !dataAccess.GetData(index, ref sAMLibrary))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<SAMObject> sAMObjects = new List<SAMObject>();
-            if (!dataAccess.GetDataList(1, sAMObjects))
+            index = Params.IndexOfInputParam("_objects");
+            if (index == -1 || !dataAccess.GetDataList(index, sAMObjects))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -84,7 +100,11 @@ namespace SAM.Core.Grasshopper
 
 
 
-            dataAccess.SetData(0, sAMLibrary_Result);
+            index = Params.IndexOfOutputParam("SAMLibrary");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, sAMLibrary_Result);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreSaveMaterialLibrary.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreSaveMaterialLibrary.cs
@@ -4,11 +4,12 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
     [Obsolete("Obsolete since 2020-09-24")]
-    public class SAMCoreSaveMaterialLibrary : GH_SAMComponent
+    public class SAMCoreSaveMaterialLibrary : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         public override GH_Exposure Exposure => GH_Exposure.hidden;
 
@@ -40,20 +41,37 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooMaterialLibraryParam(), "_materialLibrary", "_materialLibrary", "SAM Material Library", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_path", "_path", "Path", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "_materialLibrary", NickName = "_materialLibrary", Description = "SAM Material Library", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_path", NickName = "_path", Description = "Path", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooMaterialLibraryParam(), "MaterialLibrary", "MaterialLibrary", "SAM MaterialLibrary", GH_ParamAccess.item);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooMaterialLibraryParam() { Name = "MaterialLibrary", NickName = "MaterialLibrary", Description = "SAM MaterialLibrary", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,10 +82,17 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            dataAccess.SetData(1, false);
+            int index_Successful = Params.IndexOfOutputParam("Successful");
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, false);
+            }
+
+            int index = -1;
 
             bool run = false;
-            if (!dataAccess.GetData(2, ref run))
+            index = Params.IndexOfInputParam("_run");
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -76,14 +101,16 @@ namespace SAM.Core.Grasshopper
                 return;
 
             MaterialLibrary materialLibrary = null;
-            if (!dataAccess.GetData(0, ref materialLibrary) || materialLibrary == null)
+            index = Params.IndexOfInputParam("_materialLibrary");
+            if (index == -1 || !dataAccess.GetData(index, ref materialLibrary) || materialLibrary == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             string path = null;
-            if (!dataAccess.GetData(1, ref path) || string.IsNullOrWhiteSpace(path))
+            index = Params.IndexOfInputParam("_path");
+            if (index == -1 || !dataAccess.GetData(index, ref path) || string.IsNullOrWhiteSpace(path))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -91,8 +118,16 @@ namespace SAM.Core.Grasshopper
 
             bool successful = materialLibrary.Write(path);
 
-            dataAccess.SetData(0, new GooMaterialLibrary(materialLibrary));
-            dataAccess.SetData(1, successful);
+            int index_MaterialLibrary = Params.IndexOfOutputParam("MaterialLibrary");
+            if (index_MaterialLibrary != -1)
+            {
+                dataAccess.SetData(index_MaterialLibrary, new GooMaterialLibrary(materialLibrary));
+            }
+
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, successful);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreSetValue.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreSetValue.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreSetValue : GH_SAMComponent
+    public class SAMCoreSetValue : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,14 +20,12 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
         /// </summary>
         protected override System.Drawing.Bitmap Icon => Resources.SAM_Get3;
-
-        private GH_OutputParamManager outputParamManager;
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -42,27 +40,40 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            global::Grasshopper.Kernel.Parameters.Param_GenericObject genericObject = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_sAMObject", NickName = "_sAMObject", Description = "SAM Object", Access = GH_ParamAccess.item };
-            genericObject.DataMapping = GH_DataMapping.Graft;
-            inputParamManager.AddParameter(genericObject, "_sAMObject", "_sAMObject", "SAM Object\nConnect item or list", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            int index = inputParamManager.AddTextParameter("_parameter", "_parameter", "Parameter", GH_ParamAccess.item);
-            inputParamManager[index].DataMapping = GH_DataMapping.Graft;
+                global::Grasshopper.Kernel.Parameters.Param_GenericObject param_GenericObject;
+                param_GenericObject = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_sAMObject", NickName = "_sAMObject", Description = "SAM Object\nConnect item or list", Access = GH_ParamAccess.item };
+                param_GenericObject.DataMapping = GH_DataMapping.Graft;
+                result.Add(new GH_SAMParam(param_GenericObject, ParamVisibility.Binding));
 
-            inputParamManager.AddGenericParameter("_value", "_value", "Value \nConnect item or list", GH_ParamAccess.item);
+                global::Grasshopper.Kernel.Parameters.Param_String param_String;
+                param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_parameter", NickName = "_parameter", Description = "Parameter", Access = GH_ParamAccess.item };
+                param_String.DataMapping = GH_DataMapping.Graft;
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_value", NickName = "_value", Description = "Value \nConnect item or list", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            this.outputParamManager = outputParamManager;
-            outputParamManager.AddParameter(new GooJSAMObjectParam<ParameterizedSAMObject>(), "SAMObject", "SAMObject", "SAMObject", GH_ParamAccess.item);
-            //outputParamManager.AddGenericParameter("Points", "Pts", "Snap points", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooJSAMObjectParam<ParameterizedSAMObject>() { Name = "SAMObject", NickName = "SAMObject", Description = "SAMObject", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -73,8 +84,11 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper == null || !(objectWrapper.Value is ParameterizedSAMObject))
+            index = Params.IndexOfInputParam("_sAMObject");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null || !(objectWrapper.Value is ParameterizedSAMObject))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -83,7 +97,8 @@ namespace SAM.Core.Grasshopper
             ParameterizedSAMObject parameterizedSAMObject = objectWrapper.Value as ParameterizedSAMObject;
 
             string name = null;
-            if (!dataAccess.GetData(1, ref name) || string.IsNullOrWhiteSpace(name))
+            index = Params.IndexOfInputParam("_parameter");
+            if (index == -1 || !dataAccess.GetData(index, ref name) || string.IsNullOrWhiteSpace(name))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -92,9 +107,14 @@ namespace SAM.Core.Grasshopper
             List<Enum> enums = ActiveManager.GetParameterEnums(parameterizedSAMObject, name);
 
             objectWrapper = null;
-            if (!dataAccess.GetData(2, ref objectWrapper) || objectWrapper == null)
+            index = Params.IndexOfInputParam("_value");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null)
             {
-                dataAccess.SetData(0, null);
+                int index_Result = Params.IndexOfOutputParam("SAMObject");
+                if (index_Result != -1)
+                {
+                    dataAccess.SetData(index_Result, null);
+                }
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, "Null object provided");
                 return;
             }
@@ -194,8 +214,17 @@ namespace SAM.Core.Grasshopper
                 }
             }
 
-            dataAccess.SetData(0, parameterizedSAMObject);
-            dataAccess.SetData(1, result);
+            int index_SAMObject = Params.IndexOfOutputParam("SAMObject");
+            if (index_SAMObject != -1)
+            {
+                dataAccess.SetData(index_SAMObject, parameterizedSAMObject);
+            }
+
+            int index_Successful = Params.IndexOfOutputParam("Successful");
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, result);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreToCsv.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreToCsv.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreToCsv : GH_SAMComponent
+    public class SAMCoreToCsv : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,32 +39,46 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            string path = null;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            int index = -1;
+                global::Grasshopper.Kernel.Parameters.Param_GenericObject param_GenericObject;
+                param_GenericObject = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_SAMObjects", NickName = "_SAMObjects", Description = "any SAM Objects", Access = GH_ParamAccess.list };
+                param_GenericObject.DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(param_GenericObject, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("_SAMObjects", "_SAMObjects", "any SAM Objects", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_parameterNames", NickName = "_parameterNames", Description = "Csv file path", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
 
-            inputParamManager.AddTextParameter("_parameterNames", "_parameterNames", "Csv file path", GH_ParamAccess.list);
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_includeHeader_", NickName = "_includeHeader_", Description = "Include Header in csv", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
 
-            index = inputParamManager.AddBooleanParameter("_includeHeader_", "_includeHeader_", "Include Header in csv", GH_ParamAccess.item, true);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "path_", NickName = "path_", Description = "Csv file path", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddTextParameter("path_", "path_", "Csv file path", GH_ParamAccess.item, path);
-            inputParamManager[index].Optional = true;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run, set to True to export JSON to given path", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
 
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run, set to True to export JSON to given path", GH_ParamAccess.item, false);
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddTextParameter("Csv", "Csv", "Csv", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "Csv", NickName = "Csv", Description = "Csv", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -75,41 +89,53 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index_Successful = Params.IndexOfOutputParam("Successful");
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, false);
+            }
+
+            int index = -1;
+
             bool run = false;
-            if (!dataAccess.GetData(4, ref run))
+            index = Params.IndexOfInputParam("_run");
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
             if (!run)
                 return;
 
             string path = null;
-            dataAccess.GetData(3, ref path);
+            index = Params.IndexOfInputParam("path_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref path);
+            }
 
             bool includeHeader = true;
-            if (!dataAccess.GetData(2, ref includeHeader))
+            index = Params.IndexOfInputParam("_includeHeader_");
+            if (index == -1 || !dataAccess.GetData(index, ref includeHeader))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
             List<string> propertyNames = new List<string>();
-            if (!dataAccess.GetDataList(1, propertyNames))
+            index = Params.IndexOfInputParam("_parameterNames");
+            if (index == -1 || !dataAccess.GetDataList(index, propertyNames))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
             List<GH_ObjectWrapper> objectWrapperList = new List<GH_ObjectWrapper>();
 
-            if (!dataAccess.GetDataList(0, objectWrapperList) || objectWrapperList == null)
+            index = Params.IndexOfInputParam("_SAMObjects");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -132,8 +158,16 @@ namespace SAM.Core.Grasshopper
             if (!string.IsNullOrWhiteSpace(path))
                 System.IO.File.WriteAllText(path, csv);
 
-            dataAccess.SetData(0, csv);
-            dataAccess.SetData(1, true);
+            int index_Csv = Params.IndexOfOutputParam("Csv");
+            if (index_Csv != -1)
+            {
+                dataAccess.SetData(index_Csv, csv);
+            }
+
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreToFile.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreToFile.cs
@@ -11,7 +11,7 @@ using System.Reflection;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreToFile : GH_SAMComponent
+    public class SAMCoreToFile : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,27 +41,39 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            string path = null;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            int index = -1;
+                global::Grasshopper.Kernel.Parameters.Param_GenericObject param_GenericObject;
+                param_GenericObject = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_SAMObjects", NickName = "_SAMObjects", Description = "any SAM Objects", Access = GH_ParamAccess.list };
+                param_GenericObject.DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(param_GenericObject, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("_SAMObjects", "_SAMObjects", "any SAM Objects", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "path_", NickName = "path_", Description = "File path including extension", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddTextParameter("path_", "path_", "File path including extension", GH_ParamAccess.item, path);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run, set to True to export to given path", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
 
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run, set to True to export to given path", GH_ParamAccess.item, false);
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -72,25 +84,37 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index_Successful = Params.IndexOfOutputParam("Successful");
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, false);
+            }
+
+            int index = -1;
+
             bool run = false;
-            if (!dataAccess.GetData(2, ref run))
+            index = Params.IndexOfInputParam("_run");
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(0, false);
                 return;
             }
             if (!run)
                 return;
 
             string path = null;
-            dataAccess.GetData(1, ref path);
+            index = Params.IndexOfInputParam("path_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref path);
+            }
 
             List<GH_ObjectWrapper> objectWrapperList = new List<GH_ObjectWrapper>();
 
-            if (!dataAccess.GetDataList(0, objectWrapperList) || objectWrapperList == null)
+            index = Params.IndexOfInputParam("_SAMObjects");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(0, false);
                 return;
             }
 
@@ -105,7 +129,11 @@ namespace SAM.Core.Grasshopper
             }
 
             bool result = Core.Convert.ToFile(jSAMObjects, path);
-            dataAccess.SetData(0, result);
+
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, result);
+            }
         }
 
         private static IJSAMObject ToJSAMObject(object @object)

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreToJson.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreToJson.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreToJson : GH_SAMComponent
+    public class SAMCoreToJson : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +19,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,28 +39,40 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            string path = null;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            int index = -1;
+                global::Grasshopper.Kernel.Parameters.Param_GenericObject param_GenericObject;
+                param_GenericObject = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_SAMObjects", NickName = "_SAMObjects", Description = "any SAM Objects", Access = GH_ParamAccess.list };
+                param_GenericObject.DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(param_GenericObject, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("_SAMObjects", "_SAMObjects", "any SAM Objects", GH_ParamAccess.list);
-            inputParamManager[index].DataMapping = GH_DataMapping.Flatten;
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "path_", NickName = "path_", Description = "JSON file path including extension .json", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddTextParameter("path_", "path_", "JSON file path including extension .json", GH_ParamAccess.item, path);
-            inputParamManager[index].Optional = true;
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run, set to True to export JSON to given path", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
 
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run, set to True to export JSON to given path", GH_ParamAccess.item, false);
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddTextParameter("String", "String", "String", GH_ParamAccess.item);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "String", NickName = "String", Description = "String", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -71,25 +83,37 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index_Successful = Params.IndexOfOutputParam("Successful");
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, false);
+            }
+
+            int index = -1;
+
             bool run = false;
-            if (!dataAccess.GetData(2, ref run))
+            index = Params.IndexOfInputParam("_run");
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
             if (!run)
                 return;
 
             string path = null;
-            dataAccess.GetData(1, ref path);
+            index = Params.IndexOfInputParam("path_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref path);
+            }
 
             List<GH_ObjectWrapper> objectWrapperList = new List<GH_ObjectWrapper>();
 
-            if (!dataAccess.GetDataList(0, objectWrapperList) || objectWrapperList == null)
+            index = Params.IndexOfInputParam("_SAMObjects");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -115,8 +139,16 @@ namespace SAM.Core.Grasshopper
             if (!string.IsNullOrWhiteSpace(path))
                 System.IO.File.WriteAllText(path, @string);
 
-            dataAccess.SetData(0, @string);
-            dataAccess.SetData(1, true);
+            int index_String = Params.IndexOfOutputParam("String");
+            if (index_String != -1)
+            {
+                dataAccess.SetData(index_String, @string);
+            }
+
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreToList.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreToList.cs
@@ -5,10 +5,11 @@ using Grasshopper;
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreToList : GH_SAMComponent
+    public class SAMCoreToList : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -38,18 +39,33 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddTextParameter("_text", "_text", "Text as single string", GH_ParamAccess.item);
-            inputParamManager.AddTextParameter("_separator", "_separator", "Separator", GH_ParamAccess.item, Core.Query.Separator(DelimitedFileType.Csv).ToString());
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_text", NickName = "_text", Description = "Text as single string", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_String param_String = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_separator", NickName = "_separator", Description = "Separator", Access = GH_ParamAccess.item };
+                param_String.SetPersistentData(Core.Query.Separator(DelimitedFileType.Csv).ToString());
+                result.Add(new GH_SAMParam(param_String, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddTextParameter("List", "List", "List", GH_ParamAccess.tree);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "List", NickName = "List", Description = "List", Access = GH_ParamAccess.tree }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,18 +80,25 @@ namespace SAM.Core.Grasshopper
 
             char separator = Core.Query.Separator(DelimitedFileType.Csv);
 
-            string separatorString = null;
-            if (dataAccess.GetData(1, ref separatorString) && !string.IsNullOrEmpty(separatorString))
-                separator = separatorString[0];
+            int index = Params.IndexOfInputParam("_separator");
+            if (index != -1)
+            {
+                string separatorString = null;
+                if (dataAccess.GetData(index, ref separatorString) && !string.IsNullOrEmpty(separatorString))
+                    separator = separatorString[0];
+            }
 
+            index = Params.IndexOfInputParam("_text");
             string text = null;
-            if (dataAccess.GetData(0, ref text))
+            if (index != -1 && dataAccess.GetData(index, ref text))
                 result = Query.DataTree(text, separator);
 
             if (result == null)
                 result = new DataTree<string>();
 
-            dataAccess.SetDataTree(0, result);
+            index = Params.IndexOfOutputParam("List");
+            if (index != -1)
+                dataAccess.SetDataTree(index, result);
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreUintToARGB.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreUintToARGB.cs
@@ -4,10 +4,11 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreUintToARGB : GH_SAMComponent
+    public class SAMCoreUintToARGB : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -17,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -37,22 +38,34 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddIntegerParameter("_uint", "_uint", "Unit or Integer", GH_ParamAccess.item);
-            int index = inputParamManager.AddIntegerParameter("alpha_", "alpha_", "Alpha", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "_uint", NickName = "_uint", Description = "Unit or Integer", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "alpha_", NickName = "alpha_", Description = "Alpha", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddIntegerParameter("A", "A", "Alpha", GH_ParamAccess.item);
-            outputParamManager.AddIntegerParameter("R", "R", "Red", GH_ParamAccess.item);
-            outputParamManager.AddIntegerParameter("G", "G", "Green", GH_ParamAccess.item);
-            outputParamManager.AddIntegerParameter("B", "B", "Blue", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "A", NickName = "A", Description = "Alpha", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "R", NickName = "R", Description = "Red", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "G", NickName = "G", Description = "Green", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "B", NickName = "B", Description = "Blue", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,15 +76,17 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_uint");
             int @int = int.MinValue;
-            if (!dataAccess.GetData(0, ref @int))
+            if (index == -1 || !dataAccess.GetData(index, ref @int))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             int alpha = int.MinValue;
-            if (!dataAccess.GetData(1, ref alpha))
+            index = Params.IndexOfInputParam("alpha_");
+            if (index != -1 && !dataAccess.GetData(index, ref alpha))
                 alpha = int.MinValue;
 
             System.Drawing.Color color;
@@ -80,10 +95,18 @@ namespace SAM.Core.Grasshopper
             else
                 color = Core.Convert.ToColor(@int, System.Convert.ToByte(alpha));
 
-            dataAccess.SetData(0, System.Convert.ToInt32(color.A));
-            dataAccess.SetData(1, System.Convert.ToInt32(color.R));
-            dataAccess.SetData(2, System.Convert.ToInt32(color.G));
-            dataAccess.SetData(3, System.Convert.ToInt32(color.B));
+            index = Params.IndexOfOutputParam("A");
+            if (index != -1)
+                dataAccess.SetData(index, System.Convert.ToInt32(color.A));
+            index = Params.IndexOfOutputParam("R");
+            if (index != -1)
+                dataAccess.SetData(index, System.Convert.ToInt32(color.R));
+            index = Params.IndexOfOutputParam("G");
+            if (index != -1)
+                dataAccess.SetData(index, System.Convert.ToInt32(color.G));
+            index = Params.IndexOfOutputParam("B");
+            if (index != -1)
+                dataAccess.SetData(index, System.Convert.ToInt32(color.B));
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreUintToColor.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreUintToColor.cs
@@ -4,10 +4,11 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMCoreUintToColor : GH_SAMComponent
+    public class SAMCoreUintToColor : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -17,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -37,19 +38,31 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddIntegerParameter("_uint", "_uint", "Unit or Integer", GH_ParamAccess.item);
-            int index = inputParamManager.AddIntegerParameter("alpha_", "alpha_", "Alpha", GH_ParamAccess.item);
-            inputParamManager[index].Optional = true;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "_uint", NickName = "_uint", Description = "Unit or Integer", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "alpha_", NickName = "alpha_", Description = "Alpha", Access = GH_ParamAccess.item, Optional = true }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddColourParameter("Color", "Color", "Color", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Colour() { Name = "Color", NickName = "Color", Description = "Color", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,15 +73,17 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_uint");
             int @int = int.MinValue;
-            if (!dataAccess.GetData(0, ref @int))
+            if (index == -1 || !dataAccess.GetData(index, ref @int))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             int alpha = int.MinValue;
-            if (!dataAccess.GetData(1, ref alpha))
+            index = Params.IndexOfInputParam("alpha_");
+            if (index != -1 && !dataAccess.GetData(index, ref alpha))
                 alpha = int.MinValue;
 
             System.Drawing.Color color;
@@ -77,7 +92,9 @@ namespace SAM.Core.Grasshopper
             else
                 color = Core.Convert.ToColor(@int, System.Convert.ToByte(alpha));
 
-            dataAccess.SetData(0, color);
+            index = Params.IndexOfOutputParam("Color");
+            if (index != -1)
+                dataAccess.SetData(index, color);
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreUpdate.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreUpdate.cs
@@ -11,21 +11,10 @@ namespace SAM.Core.Grasshopper
 {
     public class SAMCoreUpdate : GH_SAMVariableOutputParameterComponent
     {
-        /// <summary>
-        /// Gets the unique ID for this component. Do not change this ID after release.
-        /// </summary>
         public override Guid ComponentGuid => new Guid("a89bfee3-3a3c-4d29-9c7a-64073724eddc");
 
-        /// <summary>
-        /// The latest version of this component
-        /// </summary>
         public override string LatestComponentVersion => "1.0.0";
 
-        List<GH_SAMComponent> gH_SAMComponents = null;
-
-        /// <summary>
-        /// Provides an Icon for the component.
-        /// </summary>
         protected override System.Drawing.Bitmap Icon => Resources.SAM_Small;
 
         public override GH_Exposure Exposure => GH_Exposure.primary;
@@ -35,6 +24,15 @@ namespace SAM.Core.Grasshopper
             get
             {
                 List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                global::Grasshopper.Kernel.Parameters.Param_String param_Components;
+                param_Components = new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_components", NickName = "_components", Description = "Component names, nicknames, or GUID strings (optional). If empty, scans entire document.", Access = GH_ParamAccess.list, Optional = true };
+                result.Add(new GH_SAMParam(param_Components, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_DryRun;
+                param_DryRun = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_dryRun", NickName = "_dryRun", Description = "Preview mode — reports changes without applying them", Access = GH_ParamAccess.item, Optional = true };
+                param_DryRun.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_DryRun, ParamVisibility.Binding));
 
                 global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
                 param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run Update", Access = GH_ParamAccess.item, Optional = false };
@@ -56,15 +54,6 @@ namespace SAM.Core.Grasshopper
             }
         }
 
-        public override void CreateAttributes()
-        {
-            base.CreateAttributes();
-            //m_attributes = new CustomAttributes(this);
-        }
-
-        /// <summary>
-        /// Updates PanelTypes for AdjacencyCluster
-        /// </summary>
         public SAMCoreUpdate()
           : base("SAMCore.Update", "SAMCore.Update",
               "Updates Grasshopper components to the latest version",
@@ -86,30 +75,58 @@ namespace SAM.Core.Grasshopper
         {
             int index = -1;
 
-            bool run = false;
-            index = Params.IndexOfInputParam("_run");
-            if (index == -1 || !dataAccess.GetData(index, ref run))
+            bool dryRun = false;
+            index = Params.IndexOfInputParam("_dryRun");
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                dataAccess.GetData(index, ref dryRun);
             }
 
-            if (!run)
+            bool run = false;
+            index = Params.IndexOfInputParam("_run");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref run);
+            }
+
+            if (!dryRun && !run)
             {
                 return;
             }
 
             GH_Document gH_Document = OnPingDocument();
+            if (gH_Document == null)
+            {
+                return;
+            }
 
-            //List<GH_SAMComponent> gH_SAMComponents = Modify.UpdateComponents(gH_Document, out Log log);
-            gH_SAMComponents = Modify.UpdateComponents(gH_Document, out Log log);
+            List<GH_SAMComponent> targetComponents = ResolveTargetComponents(dataAccess, gH_Document);
 
+            Log log;
+            List<GH_SAMComponent> result;
 
-            //gH_Document.SolutionEnd += GH_Document_SolutionEnd;
-
-            //OnPingDocument().Modified();
-
-            //ExpireSolution(true);
+            if (dryRun)
+            {
+                if (targetComponents != null && targetComponents.Count > 0)
+                {
+                    result = Modify.PreviewUpdateComponents(targetComponents, out log);
+                }
+                else
+                {
+                    result = Modify.PreviewUpdateComponents(gH_Document, out log);
+                }
+            }
+            else
+            {
+                if (targetComponents != null && targetComponents.Count > 0)
+                {
+                    result = Modify.UpdateComponents(targetComponents, out log);
+                }
+                else
+                {
+                    result = Modify.UpdateComponents(gH_Document, out log);
+                }
+            }
 
             index = Params.IndexOfOutputParam("log");
             if (index != -1)
@@ -120,21 +137,80 @@ namespace SAM.Core.Grasshopper
             index = Params.IndexOfOutputParam("succeeded");
             if (index != -1)
             {
-                dataAccess.SetData(index, gH_SAMComponents != null && gH_SAMComponents.Count != 0);
+                dataAccess.SetData(index, !dryRun && result != null && result.Count != 0);
             }
         }
 
-        //private void GH_Document_SolutionEnd(object sender, GH_SolutionEventArgs e)
-        //{
-        //    if (gH_SAMComponents != null)
-        //    {
-        //        foreach (GH_SAMComponent gH_SAMComponent in gH_SAMComponents)
-        //        {
-        //            gH_SAMComponent.ExpireSolution(true);
-        //        }
-        //    }
+        private List<GH_SAMComponent> ResolveTargetComponents(IGH_DataAccess dataAccess, GH_Document gH_Document)
+        {
+            int index = Params.IndexOfInputParam("_components");
+            if (index == -1)
+            {
+                return null;
+            }
 
-        //    gH_SAMComponents = null;
-        //}
+            List<string> names = new List<string>();
+            if (!dataAccess.GetDataList(index, names) || names.Count == 0)
+            {
+                return null;
+            }
+
+            if (gH_Document == null)
+            {
+                return null;
+            }
+
+            List<GH_SAMComponent> result = new List<GH_SAMComponent>();
+            IList<IGH_DocumentObject> allObjects = gH_Document.Objects;
+            if (allObjects == null)
+            {
+                return null;
+            }
+
+            foreach (string search in names)
+            {
+                if (string.IsNullOrWhiteSpace(search))
+                {
+                    continue;
+                }
+
+                string trimmed = search.Trim();
+
+                if (Guid.TryParse(trimmed, out Guid guid))
+                {
+                    foreach (IGH_DocumentObject obj in allObjects)
+                    {
+                        if (obj is GH_SAMComponent samComp && samComp.InstanceGuid == guid)
+                        {
+                            if (!result.Contains(samComp))
+                            {
+                                result.Add(samComp);
+                            }
+                            break;
+                        }
+                    }
+                    continue;
+                }
+
+                foreach (IGH_DocumentObject obj in allObjects)
+                {
+                    if (obj is GH_SAMComponent samComp)
+                    {
+                        if (string.Equals(samComp.Name, trimmed, StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(samComp.NickName, trimmed, StringComparison.OrdinalIgnoreCase) ||
+                            samComp.Name.StartsWith(trimmed, StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!result.Contains(samComp))
+                            {
+                                result.Add(samComp);
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return result.Count > 0 ? result : null;
+        }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMVersion.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMVersion.cs
@@ -4,10 +4,11 @@
 using Grasshopper.Kernel;
 using SAM.Core.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
-    public class SAMVersion : GH_SAMComponent
+    public class SAMVersion : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -17,7 +18,7 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "2.0.0";
+        public override string LatestComponentVersion => "2.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -37,18 +38,27 @@ namespace SAM.Core.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
+            get
+            {
+                return new GH_SAMParam[0];
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddTextParameter("CurrentVersion", "CurrentVersion", "Current Version", GH_ParamAccess.item);
-            outputParamManager.AddTextParameter("LatestVersion", "LatesttVersion", "The Latest Version", GH_ParamAccess.item);
-            outputParamManager.AddBooleanParameter("IsUpdateAvaliable", "IsUpdateAvaliable", "Is new version avaliable?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "CurrentVersion", NickName = "CurrentVersion", Description = "Current Version", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "LatestVersion", NickName = "LatesttVersion", Description = "The Latest Version", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "IsUpdateAvaliable", NickName = "IsUpdateAvaliable", Description = "Is new version avaliable?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -59,23 +69,37 @@ namespace SAM.Core.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            dataAccess.SetData(0, string.Empty);
-            dataAccess.SetData(1, string.Empty);
-            dataAccess.SetData(2, false);
+            int index;
+
+            index = Params.IndexOfOutputParam("CurrentVersion");
+            if (index != -1)
+                dataAccess.SetData(index, string.Empty);
+            index = Params.IndexOfOutputParam("LatestVersion");
+            if (index != -1)
+                dataAccess.SetData(index, string.Empty);
+            index = Params.IndexOfOutputParam("IsUpdateAvaliable");
+            if (index != -1)
+                dataAccess.SetData(index, false);
 
             string currentVersion = Core.Query.CurrentVersion();
             if (string.IsNullOrWhiteSpace(currentVersion))
                 return;
 
-            dataAccess.SetData(0, currentVersion);
+            index = Params.IndexOfOutputParam("CurrentVersion");
+            if (index != -1)
+                dataAccess.SetData(index, currentVersion);
 
             string latestVersion = Core.Query.LatestVersion();
             if (string.IsNullOrWhiteSpace(latestVersion))
                 return;
 
-            dataAccess.SetData(1, latestVersion);
+            index = Params.IndexOfOutputParam("LatestVersion");
+            if (index != -1)
+                dataAccess.SetData(index, latestVersion);
 
-            dataAccess.SetData(2, !currentVersion.Equals(latestVersion));
+            index = Params.IndexOfOutputParam("IsUpdateAvaliable");
+            if (index != -1)
+                dataAccess.SetData(index, !currentVersion.Equals(latestVersion));
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Enums/ObsoleteSeverity.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Enums/ObsoleteSeverity.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+namespace SAM.Core.Grasshopper
+{
+    public enum ObsoleteSeverity
+    {
+        None = 0,
+        Advisory = 1,
+        Standard = 2,
+        Breaking = 3
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Interfaces/IGH_SAMComponent.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Interfaces/IGH_SAMComponent.cs
@@ -10,5 +10,9 @@ namespace SAM.Core.Grasshopper
         string SAMVersion { get; }
 
         string LatestComponentVersion { get; }
+
+        string MinCompatibleVersion { get; }
+
+        ObsoleteSeverity ObsoleteSeverity { get; }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/CaptureConnections.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/CaptureConnections.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System.Collections.Generic;
+
+namespace SAM.Core.Grasshopper
+{
+    public static partial class Modify
+    {
+        public static List<ParamConnection> CaptureConnections(GH_SAMComponent gH_SAMComponent)
+        {
+            List<ParamConnection> result = new List<ParamConnection>();
+
+            if (gH_SAMComponent == null)
+            {
+                return result;
+            }
+
+            List<IGH_Param> outputParams = gH_SAMComponent.Params?.Output;
+            if (outputParams != null)
+            {
+                foreach (IGH_Param param in outputParams)
+                {
+                    if (param == null || param.Recipients == null || param.Recipients.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    result.Add(new ParamConnection
+                    {
+                        Side = GH_ParameterSide.Output,
+                        ParamName = param.Name,
+                        ConnectedParams = new List<IGH_Param>(param.Recipients)
+                    });
+                }
+            }
+
+            List<IGH_Param> inputParams = gH_SAMComponent.Params?.Input;
+            if (inputParams != null)
+            {
+                foreach (IGH_Param param in inputParams)
+                {
+                    if (param == null || param.Sources == null || param.Sources.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    result.Add(new ParamConnection
+                    {
+                        Side = GH_ParameterSide.Input,
+                        ParamName = param.Name,
+                        ConnectedParams = new List<IGH_Param>(param.Sources)
+                    });
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/CopyParameteres.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/CopyParameteres.cs
@@ -2,103 +2,16 @@
 // Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
 
 using Grasshopper.Kernel;
-using System.Collections.Generic;
-using System.Linq;
+using System;
 
 namespace SAM.Core.Grasshopper
 {
     public static partial class Modify
     {
+        [Obsolete("Use CopyParameters instead.", false)]
         public static void CopyParameteres(GH_ParameterSide parameterSide, GH_SAMComponent gH_SAMComponent_From, GH_SAMComponent gH_SAMComponent_To)
         {
-            if (gH_SAMComponent_From == null || gH_SAMComponent_To == null)
-            {
-                return;
-            }
-
-            List<IGH_Param> gH_Params;
-
-            Dictionary<string, IGH_Param> dictionary_Old = new Dictionary<string, IGH_Param>();
-            gH_Params = parameterSide == GH_ParameterSide.Output ? gH_SAMComponent_From.Params.Output : gH_SAMComponent_From.Params.Input;
-            foreach (IGH_Param gH_Param in gH_Params)
-            {
-                dictionary_Old[gH_Param.Name] = gH_Param;
-            }
-
-            Dictionary<string, IGH_Param> dictionary_New = new Dictionary<string, IGH_Param>();
-            gH_Params = parameterSide == GH_ParameterSide.Output ? gH_SAMComponent_To.Params.Output : gH_SAMComponent_To.Params.Input;
-            if (gH_SAMComponent_To is GH_SAMVariableOutputParameterComponent)
-            {
-                GH_SAMVariableOutputParameterComponent gH_SAMVariableOutputParameterComponent = (GH_SAMVariableOutputParameterComponent)gH_SAMComponent_To;
-                for (int i = gH_Params.Count - 1; i >= 0; i--)
-                {
-                    if (gH_SAMVariableOutputParameterComponent.CanInsertParameter(parameterSide, i))
-                    {
-                        gH_Params.Add(gH_SAMVariableOutputParameterComponent.CreateParameter(parameterSide, i));
-                    }
-                }
-            }
-
-            foreach (IGH_Param gH_Param in gH_Params)
-            {
-                dictionary_New[gH_Param.Name] = gH_Param;
-            }
-
-            foreach (KeyValuePair<string, IGH_Param> keyValuePair in dictionary_Old)
-            {
-                IEnumerable<IGH_Param> gH_Params_Connect = parameterSide == GH_ParameterSide.Output ? keyValuePair.Value.Recipients : keyValuePair.Value.Sources;
-                if (gH_Params_Connect == null || gH_Params_Connect.Count() == 0)
-                {
-                    continue;
-                }
-
-                if (!dictionary_New.TryGetValue(keyValuePair.Key, out IGH_Param gH_Param_New))
-                {
-                    continue;
-                }
-
-                foreach (IGH_Param gH_Param in gH_Params_Connect)
-                {
-                    if (parameterSide == GH_ParameterSide.Output)
-                    {
-                        gH_Param.AddSource(gH_Param_New);
-                    }
-                    else
-                    {
-                        gH_Param_New.AddSource(gH_Param);
-                    }
-                }
-            }
-
-
-            if (gH_SAMComponent_To is GH_SAMVariableOutputParameterComponent)
-            {
-                GH_SAMVariableOutputParameterComponent gH_SAMVariableOutputParameterComponent = (GH_SAMVariableOutputParameterComponent)gH_SAMComponent_To;
-
-                GH_ComponentParamServer gH_ComponentParamServer = gH_SAMComponent_To.Params;
-
-                gH_Params = parameterSide == GH_ParameterSide.Output ? gH_ComponentParamServer.Output : gH_ComponentParamServer.Input;
-                for (int i = gH_Params.Count - 1; i >= 0; i--)
-                {
-                    if (dictionary_Old.ContainsKey(gH_Params[i].Name))
-                    {
-                        continue;
-                    }
-
-                    if (gH_SAMVariableOutputParameterComponent.CanRemoveParameter(parameterSide, i))
-                    {
-                        if (parameterSide == GH_ParameterSide.Output)
-                        {
-                            gH_ComponentParamServer.UnregisterOutputParameter(gH_Params[i]);
-                        }
-                        else
-                        {
-                            gH_ComponentParamServer.UnregisterInputParameter(gH_Params[i]);
-                        }
-                    }
-
-                }
-            }
+            CopyParameters(parameterSide, gH_SAMComponent_From, gH_SAMComponent_To);
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/CopyParameters.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/CopyParameters.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SAM.Core.Grasshopper
+{
+    public static partial class Modify
+    {
+        public static void CopyParameters(GH_ParameterSide parameterSide, GH_SAMComponent gH_SAMComponent_From, GH_SAMComponent gH_SAMComponent_To)
+        {
+            if (gH_SAMComponent_From == null || gH_SAMComponent_To == null)
+            {
+                return;
+            }
+
+            List<IGH_Param> gH_Params;
+
+            Dictionary<string, IGH_Param> dictionary_Old = new Dictionary<string, IGH_Param>();
+            gH_Params = parameterSide == GH_ParameterSide.Output ? gH_SAMComponent_From.Params.Output : gH_SAMComponent_From.Params.Input;
+            if (gH_Params != null)
+            {
+                foreach (IGH_Param gH_Param in gH_Params)
+                {
+                    if (gH_Param == null)
+                    {
+                        continue;
+                    }
+                    dictionary_Old[gH_Param.Name] = gH_Param;
+                }
+            }
+
+            Dictionary<string, IGH_Param> dictionary_New = new Dictionary<string, IGH_Param>();
+            gH_Params = parameterSide == GH_ParameterSide.Output ? gH_SAMComponent_To.Params.Output : gH_SAMComponent_To.Params.Input;
+
+            if (gH_SAMComponent_To is GH_SAMVariableOutputParameterComponent gH_SAMVariableOutputParameterComponent && gH_Params != null)
+            {
+                List<IGH_Param> gH_Params_Snapshot = new List<IGH_Param>(gH_Params);
+                for (int i = gH_Params_Snapshot.Count - 1; i >= 0; i--)
+                {
+                    if (gH_SAMVariableOutputParameterComponent.CanInsertParameter(parameterSide, i))
+                    {
+                        gH_Params.Add(gH_SAMVariableOutputParameterComponent.CreateParameter(parameterSide, i));
+                    }
+                }
+            }
+
+            if (gH_Params != null)
+            {
+                foreach (IGH_Param gH_Param in gH_Params)
+                {
+                    if (gH_Param == null)
+                    {
+                        continue;
+                    }
+                    dictionary_New[gH_Param.Name] = gH_Param;
+                }
+            }
+
+            foreach (KeyValuePair<string, IGH_Param> keyValuePair in dictionary_Old)
+            {
+                IEnumerable<IGH_Param> gH_Params_Connect = parameterSide == GH_ParameterSide.Output ? keyValuePair.Value.Recipients : keyValuePair.Value.Sources;
+                if (gH_Params_Connect == null || !gH_Params_Connect.Any())
+                {
+                    continue;
+                }
+
+                if (!dictionary_New.TryGetValue(keyValuePair.Key, out IGH_Param gH_Param_New))
+                {
+                    continue;
+                }
+
+                IGH_Param[] connectedParams = gH_Params_Connect.ToArray();
+
+                foreach (IGH_Param gH_Param in connectedParams)
+                {
+                    if (parameterSide == GH_ParameterSide.Output)
+                    {
+                        gH_Param.AddSource(gH_Param_New);
+                    }
+                    else
+                    {
+                        gH_Param_New.AddSource(gH_Param);
+                    }
+                }
+            }
+
+            if (gH_SAMComponent_To is GH_SAMVariableOutputParameterComponent gH_SAMVariableOutputParameterComponent2)
+            {
+                GH_ComponentParamServer gH_ComponentParamServer = gH_SAMComponent_To.Params;
+
+                gH_Params = parameterSide == GH_ParameterSide.Output ? gH_ComponentParamServer.Output : gH_ComponentParamServer.Input;
+                if (gH_Params != null)
+                {
+                    for (int i = gH_Params.Count - 1; i >= 0; i--)
+                    {
+                        if (gH_Params[i] == null)
+                        {
+                            continue;
+                        }
+
+                        if (dictionary_Old.ContainsKey(gH_Params[i].Name))
+                        {
+                            continue;
+                        }
+
+                        if (gH_SAMVariableOutputParameterComponent2.CanRemoveParameter(parameterSide, i))
+                        {
+                            if (parameterSide == GH_ParameterSide.Output)
+                            {
+                                gH_ComponentParamServer.UnregisterOutputParameter(gH_Params[i]);
+                            }
+                            else
+                            {
+                                gH_ComponentParamServer.UnregisterInputParameter(gH_Params[i]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/CopyPersistentData.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/CopyPersistentData.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System;
+
+namespace SAM.Core.Grasshopper
+{
+    public static partial class Modify
+    {
+        internal static void CopyPersistentData(IGH_Param oldParam, IGH_Param newParam)
+        {
+            if (oldParam == null || newParam == null)
+            {
+                return;
+            }
+
+            if (oldParam.GetType() != newParam.GetType())
+            {
+                return;
+            }
+
+            try
+            {
+                Type type = oldParam.GetType();
+                while (type != null && type != typeof(object))
+                {
+                    if (type.IsGenericType && type.GetGenericTypeDefinition().FullName == "Grasshopper.Kernel.GH_PersistentParam`1")
+                    {
+                        System.Reflection.PropertyInfo persistentDataProp = type.GetProperty("PersistentData");
+                        if (persistentDataProp == null)
+                        {
+                            break;
+                        }
+
+                        object persistentData = persistentDataProp.GetValue(oldParam);
+                        if (persistentData == null)
+                        {
+                            break;
+                        }
+
+                        if (!(persistentData is System.Collections.IEnumerable enumerable))
+                        {
+                            break;
+                        }
+
+                        System.Reflection.MethodInfo addMethod = type.GetMethod("AddPersistentData");
+                        if (addMethod == null)
+                        {
+                            break;
+                        }
+
+                        foreach (object item in enumerable)
+                        {
+                            addMethod.Invoke(newParam, new[] { item });
+                        }
+                        break;
+                    }
+                    type = type.BaseType;
+                }
+            }
+            catch
+            {
+                // Best-effort: persistent data copy is non-critical
+            }
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/CopyPersistentDataFromComponent.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/CopyPersistentDataFromComponent.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System.Collections.Generic;
+
+namespace SAM.Core.Grasshopper
+{
+    public static partial class Modify
+    {
+        internal static void CopyPersistentDataFromComponent(GH_SAMComponent gH_SAMComponent_From, GH_SAMComponent gH_SAMComponent_To)
+        {
+            if (gH_SAMComponent_From == null || gH_SAMComponent_To == null)
+            {
+                return;
+            }
+
+            List<IGH_Param> oldInputs = gH_SAMComponent_From.Params?.Input;
+            List<IGH_Param> newInputs = gH_SAMComponent_To.Params?.Input;
+
+            if (oldInputs == null || newInputs == null)
+            {
+                return;
+            }
+
+            Dictionary<string, IGH_Param> newInputDict = new Dictionary<string, IGH_Param>();
+            foreach (IGH_Param param in newInputs)
+            {
+                if (param != null)
+                {
+                    newInputDict[param.Name] = param;
+                }
+            }
+
+            foreach (IGH_Param oldParam in oldInputs)
+            {
+                if (oldParam == null)
+                {
+                    continue;
+                }
+
+                if (!newInputDict.TryGetValue(oldParam.Name, out IGH_Param newParam))
+                {
+                    continue;
+                }
+
+                CopyPersistentData(oldParam, newParam);
+            }
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/ExpandVariableParameters.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/ExpandVariableParameters.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System;
+using System.Collections.Generic;
+
+namespace SAM.Core.Grasshopper
+{
+    public static partial class Modify
+    {
+        internal static void ExpandVariableParameters(GH_SAMComponent gH_SAMComponent_From, GH_SAMComponent gH_SAMComponent_To)
+        {
+            if (!(gH_SAMComponent_To is GH_SAMVariableOutputParameterComponent variableOutput))
+            {
+                return;
+            }
+
+            try
+            {
+                ExpandSide(GH_ParameterSide.Input, gH_SAMComponent_From, gH_SAMComponent_To, variableOutput);
+                ExpandSide(GH_ParameterSide.Output, gH_SAMComponent_From, gH_SAMComponent_To, variableOutput);
+            }
+            catch
+            {
+                // Best-effort: expansion failure is non-critical
+            }
+        }
+
+        private static void ExpandSide(GH_ParameterSide side, GH_SAMComponent from, GH_SAMComponent to, GH_SAMVariableOutputParameterComponent variableOutput)
+        {
+            List<IGH_Param> fromParams = side == GH_ParameterSide.Output ? from.Params?.Output : from.Params?.Input;
+            List<IGH_Param> toParams = side == GH_ParameterSide.Output ? to.Params?.Output : to.Params?.Input;
+
+            if (fromParams == null || toParams == null || fromParams.Count == 0)
+            {
+                return;
+            }
+
+            HashSet<string> fromParamNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (IGH_Param param in fromParams)
+            {
+                if (param != null)
+                {
+                    fromParamNames.Add(param.Name);
+                }
+            }
+
+            HashSet<string> toParamNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (IGH_Param param in toParams)
+            {
+                if (param != null)
+                {
+                    toParamNames.Add(param.Name);
+                }
+            }
+
+            List<string> missingNames = new List<string>();
+            foreach (string name in fromParamNames)
+            {
+                if (!toParamNames.Contains(name))
+                {
+                    missingNames.Add(name);
+                }
+            }
+
+            if (missingNames.Count == 0)
+            {
+                return;
+            }
+
+            int attempts = 0;
+            int maxAttempts = missingNames.Count * 3;
+            while (missingNames.Count > 0 && attempts < maxAttempts)
+            {
+                attempts++;
+                bool added = false;
+
+                for (int i = toParams.Count - 1; i >= 0; i--)
+                {
+                    if (!variableOutput.CanInsertParameter(side, i))
+                    {
+                        continue;
+                    }
+
+                    IGH_Param newParam = null;
+                    try
+                    {
+                        newParam = variableOutput.CreateParameter(side, i);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
+                    if (newParam == null)
+                    {
+                        continue;
+                    }
+
+                    if (missingNames.Contains(newParam.Name))
+                    {
+                        toParams.Add(newParam);
+                        missingNames.Remove(newParam.Name);
+                        added = true;
+                        break;
+                    }
+                }
+
+                if (!added)
+                {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/RestoreConnections.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/RestoreConnections.cs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System;
+using System.Collections.Generic;
+
+namespace SAM.Core.Grasshopper
+{
+    public static partial class Modify
+    {
+        public static void RestoreConnections(GH_SAMComponent gH_SAMComponent, List<ParamConnection> connections, out Log log)
+        {
+            log = new Log();
+
+            if (gH_SAMComponent == null || connections == null || connections.Count == 0)
+            {
+                return;
+            }
+
+            List<IGH_Param> outputParams = gH_SAMComponent.Params?.Output;
+            List<IGH_Param> inputParams = gH_SAMComponent.Params?.Input;
+
+            Dictionary<string, IGH_Param> newOutputParams = new Dictionary<string, IGH_Param>();
+            Dictionary<string, IGH_Param> newInputParams = new Dictionary<string, IGH_Param>();
+
+            if (outputParams != null)
+            {
+                foreach (IGH_Param param in outputParams)
+                {
+                    if (param != null)
+                    {
+                        newOutputParams[param.Name] = param;
+                    }
+                }
+            }
+
+            if (inputParams != null)
+            {
+                foreach (IGH_Param param in inputParams)
+                {
+                    if (param != null)
+                    {
+                        newInputParams[param.Name] = param;
+                    }
+                }
+            }
+
+            foreach (ParamConnection connection in connections)
+            {
+                Dictionary<string, IGH_Param> targetDict = connection.Side == GH_ParameterSide.Output ? newOutputParams : newInputParams;
+
+                if (!targetDict.TryGetValue(connection.ParamName, out IGH_Param newParam))
+                {
+                    if (connection.ConnectedParams.Count > 0)
+                    {
+                        string sideLabel = connection.Side == GH_ParameterSide.Output ? "output" : "input";
+                        log.Add(new LogRecord("  DROPPED: {0} {1} '{2}' not in new version ({3} {4} lost). Manual reconnect needed.",
+                            LogRecordType.Warning, gH_SAMComponent.Name, sideLabel, connection.ParamName,
+                            connection.ConnectedParams.Count, connection.ConnectedParams.Count == 1 ? "connection" : "connections"));
+
+                        foreach (IGH_Param cp in connection.ConnectedParams)
+                        {
+                            if (cp != null)
+                            {
+                                string dest = "?";
+                                try { dest = cp.Attributes?.ToString() ?? cp.Name; } catch { dest = cp.Name; }
+                                log.Add(new LogRecord("    was connected to: {0}", LogRecordType.Warning, dest));
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                foreach (IGH_Param connectedParam in connection.ConnectedParams)
+                {
+                    if (connectedParam == null)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        if (connection.Side == GH_ParameterSide.Output)
+                        {
+                            connectedParam.AddSource(newParam);
+                        }
+                        else
+                        {
+                            newParam.AddSource(connectedParam);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Add(new LogRecord("  Warning: failed to reconnect '{0}' → '{1}': {2}",
+                            LogRecordType.Warning, connection.ParamName,
+                            connectedParam.Name ?? "(unnamed)", ex.Message));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/UpdateComponent.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/UpdateComponent.cs
@@ -3,6 +3,7 @@
 
 using Grasshopper.Kernel;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Core.Grasshopper
 {
@@ -12,6 +13,12 @@ namespace SAM.Core.Grasshopper
         {
             log = new Log();
 
+            if (gH_SAMComponent == null)
+            {
+                log.Add(new LogRecord("Component is null", LogRecordType.Error));
+                return null;
+            }
+
             GH_Document gH_Document = gH_SAMComponent?.OnPingDocument();
             if (gH_Document == null)
             {
@@ -19,12 +26,34 @@ namespace SAM.Core.Grasshopper
                 return null;
             }
 
-            GH_SAMComponent result = Activator.CreateInstance(gH_SAMComponent.GetType()) as GH_SAMComponent;
+            GH_SAMComponent result = null;
+            try
+            {
+                result = Activator.CreateInstance(gH_SAMComponent.GetType()) as GH_SAMComponent;
+            }
+            catch (Exception ex)
+            {
+                log.Add(new LogRecord("Failed to create new component '{0}': {1}", LogRecordType.Error, gH_SAMComponent.Name, ex.Message));
+                return null;
+            }
+
             if (result == null)
             {
                 log.Add(new LogRecord("Failed to create new component: {0}", LogRecordType.Error, gH_SAMComponent.Name));
                 return null;
             }
+
+            ObsoleteSeverity severity = gH_SAMComponent.ObsoleteSeverity;
+            string severityLabel = severity == ObsoleteSeverity.Breaking ? "[breaking]" :
+                                   severity == ObsoleteSeverity.Advisory ? "[patch]" : "";
+            bool isVariable = result is IGH_VariableParameterComponent;
+            log.Add(new LogRecord("Component {0} updating. Old: {1} New: {2} {3} variable={4}",
+                LogRecordType.Message, gH_SAMComponent.Name, gH_SAMComponent.ComponentVersion,
+                gH_SAMComponent.LatestComponentVersion, severityLabel, isVariable));
+
+            List<ParamConnection> capturedConnections = CaptureConnections(gH_SAMComponent);
+
+            System.Drawing.PointF pivot = gH_SAMComponent.Attributes?.Pivot ?? System.Drawing.PointF.Empty;
 
             bool add = gH_Document.AddObject(result, false);
             if (!add)
@@ -33,16 +62,16 @@ namespace SAM.Core.Grasshopper
                 return null;
             }
 
-            log.Add(new LogRecord("Component {0} updating. Old version: {1} New version: {2}", LogRecordType.Message, gH_SAMComponent.Name, gH_SAMComponent.ComponentVersion, gH_SAMComponent.LatestComponentVersion));
+            RestoreConnections(result, capturedConnections, out Log log_Restore);
+            if (log_Restore != null)
+            {
+                log.AddRange(log_Restore);
+            }
 
-            result.Attributes.Pivot = gH_SAMComponent.Attributes.Pivot;
+            CopyPersistentDataFromComponent(gH_SAMComponent, result);
 
-            CopyParameteres(GH_ParameterSide.Output, gH_SAMComponent, result);
-            CopyParameteres(GH_ParameterSide.Input, gH_SAMComponent, result);
+            result.Attributes.Pivot = pivot;
 
-            //gH_Document.RemoveObject(gH_SAMComponent, false);
-
-            //result.ExpireSolution(true);
             return result;
         }
 

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/UpdateComponents.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/UpdateComponents.cs
@@ -28,9 +28,7 @@ namespace SAM.Core.Grasshopper
             List<GH_SAMComponent> gH_SAMComponents = new List<GH_SAMComponent>();
             foreach (IGH_DocumentObject gH_DocumentObject in gH_DocumentObjects)
             {
-                GH_SAMComponent gH_SAMComponent = gH_DocumentObject as GH_SAMComponent;
-
-                if (!(gH_DocumentObject is GH_SAMComponent))
+                if (!(gH_DocumentObject is GH_SAMComponent gH_SAMComponent))
                 {
                     continue;
                 }
@@ -41,46 +39,346 @@ namespace SAM.Core.Grasshopper
                 }
             }
 
-            if (gH_SAMComponents == null || gH_SAMComponents.Count == 0)
+            if (gH_SAMComponents.Count == 0)
             {
-                return null;
+                log.Add(new LogRecord("No obsolete components found.", LogRecordType.Message));
+                return new List<GH_SAMComponent>();
             }
 
-            return UpdateComponents(gH_SAMComponents, out log);
+            return UpdateComponents(gH_SAMComponents, gH_Document, out log);
         }
 
         public static List<GH_SAMComponent> UpdateComponents(IEnumerable<GH_SAMComponent> gH_SAMComponents, out Log log)
         {
             log = new Log();
-            if (gH_SAMComponents == null || gH_SAMComponents.Count() == 0)
+            if (gH_SAMComponents == null || !gH_SAMComponents.Any())
             {
                 return null;
             }
 
-            List<Tuple<GH_SAMComponent, GH_SAMComponent>> tuples = new List<Tuple<GH_SAMComponent, GH_SAMComponent>>();
-            foreach (GH_SAMComponent gH_SAMComponent in gH_SAMComponents)
+            GH_Document gH_Document = gH_SAMComponents.FirstOrDefault()?.OnPingDocument();
+            if (gH_Document == null)
             {
-                GH_SAMComponent gH_SAMComponent_New = DuplicateComponent(gH_SAMComponent, out Log log_Temp);
-                if (gH_SAMComponent_New == null)
+                log.Add(new LogRecord("Could not access document.", LogRecordType.Error));
+                return null;
+            }
+
+            return UpdateComponents(gH_SAMComponents, gH_Document, out log);
+        }
+
+        private static List<GH_SAMComponent> UpdateComponents(IEnumerable<GH_SAMComponent> gH_SAMComponents, GH_Document gH_Document, out Log log)
+        {
+            log = new Log();
+
+            if (gH_SAMComponents == null || !gH_SAMComponents.Any())
+            {
+                return null;
+            }
+
+            if (gH_Document == null)
+            {
+                log.Add(new LogRecord("Document is null.", LogRecordType.Error));
+                return null;
+            }
+
+            GH_SAMComponent[] components = gH_SAMComponents.ToArray();
+
+            int obsoleteCount = components.Count(c => c != null && c.Obsolete);
+            log.Add(new LogRecord("Update started. Targeting {0} component(s), {1} are obsolete.",
+                LogRecordType.Message, components.Length, obsoleteCount));
+
+            int updated = 0;
+            int failed = 0;
+            int warnings = 0;
+            List<GH_SAMComponent> result = new List<GH_SAMComponent>();
+            List<GH_SAMComponent> oldComponents = new List<GH_SAMComponent>();
+
+            try
+            {
+                gH_Document.UndoUtil.RecordEvent("Update Obsolete Components");
+            }
+            catch
+            {
+                log.Add(new LogRecord("Undo grouping not available — updates will be individually undoable.", LogRecordType.Warning));
+                warnings++;
+            }
+
+            foreach (GH_SAMComponent gH_SAMComponent in components)
+            {
+                if (gH_SAMComponent == null)
                 {
                     continue;
                 }
 
-                tuples.Add(new Tuple<GH_SAMComponent, GH_SAMComponent>(gH_SAMComponent, gH_SAMComponent_New));
-
-                if (log_Temp != null)
+                if (!gH_SAMComponent.Obsolete)
                 {
-                    log.AddRange(log_Temp);
+                    continue;
+                }
+
+                try
+                {
+                    GH_SAMComponent gH_SAMComponent_New = DuplicateComponent(gH_SAMComponent, out Log log_Temp);
+                    if (gH_SAMComponent_New == null)
+                    {
+                        failed++;
+                        if (log_Temp != null)
+                        {
+                            log.AddRange(log_Temp);
+                        }
+                        continue;
+                    }
+
+                    result.Add(gH_SAMComponent_New);
+                    oldComponents.Add(gH_SAMComponent);
+                    updated++;
+
+                    if (log_Temp != null)
+                    {
+                        log.AddRange(log_Temp);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failed++;
+                    log.Add(new LogRecord("  Failed to update {0}: {1}", LogRecordType.Error, gH_SAMComponent.Name, ex.Message));
                 }
             }
 
-            List<GH_SAMComponent> result = new List<GH_SAMComponent>();
-            foreach (Tuple<GH_SAMComponent, GH_SAMComponent> tuple in tuples)
+            foreach (GH_SAMComponent oldComponent in oldComponents)
             {
-                //tuple.Item2.ExpireSolution(false);
-                result.Add(tuple.Item2);
-                tuple.Item1.OnPingDocument().RemoveObject(tuple.Item1, false);
+                gH_Document.RemoveObject(oldComponent, false);
             }
+
+            log.Add(new LogRecord("Update completed: {0} updated, {1} failed, {2} warning(s).",
+                LogRecordType.Message, updated, failed, warnings));
+
+            if (result.Count == 0)
+            {
+                return null;
+            }
+
+            return result;
+        }
+
+        public static List<GH_SAMComponent> PreviewUpdateComponents(GH_Document gH_Document, out Log log)
+        {
+            log = new Log();
+
+            if (gH_Document == null)
+            {
+                return null;
+            }
+
+            IList<IGH_DocumentObject> gH_DocumentObjects = gH_Document.Objects;
+            if (gH_DocumentObjects == null || gH_DocumentObjects.Count == 0)
+            {
+                log.Add(new LogRecord("No components found in document.", LogRecordType.Message));
+                return null;
+            }
+
+            List<GH_SAMComponent> gH_SAMComponents = new List<GH_SAMComponent>();
+            foreach (IGH_DocumentObject gH_DocumentObject in gH_DocumentObjects)
+            {
+                if (!(gH_DocumentObject is GH_SAMComponent gH_SAMComponent))
+                {
+                    continue;
+                }
+
+                if (gH_SAMComponent.Obsolete)
+                {
+                    gH_SAMComponents.Add(gH_SAMComponent);
+                }
+            }
+
+            if (gH_SAMComponents.Count == 0)
+            {
+                log.Add(new LogRecord("No obsolete components found.", LogRecordType.Message));
+                return null;
+            }
+
+            return PreviewUpdateComponents(gH_SAMComponents, gH_Document, out log);
+        }
+
+        public static List<GH_SAMComponent> PreviewUpdateComponents(IEnumerable<GH_SAMComponent> gH_SAMComponents, out Log log)
+        {
+            log = new Log();
+            if (gH_SAMComponents == null || !gH_SAMComponents.Any())
+            {
+                return null;
+            }
+
+            GH_Document gH_Document = gH_SAMComponents.FirstOrDefault()?.OnPingDocument();
+            if (gH_Document == null)
+            {
+                log.Add(new LogRecord("Could not access document.", LogRecordType.Error));
+                return null;
+            }
+
+            return PreviewUpdateComponents(gH_SAMComponents, gH_Document, out log);
+        }
+
+        private static List<GH_SAMComponent> PreviewUpdateComponents(IEnumerable<GH_SAMComponent> gH_SAMComponents, GH_Document gH_Document, out Log log)
+        {
+            log = new Log();
+
+            if (gH_SAMComponents == null || !gH_SAMComponents.Any())
+            {
+                return null;
+            }
+
+            if (gH_Document == null)
+            {
+                log.Add(new LogRecord("Document is null.", LogRecordType.Error));
+                return null;
+            }
+
+            GH_SAMComponent[] components = gH_SAMComponents.ToArray();
+
+            log.Add(new LogRecord("--- DRY RUN --- Would update {0} component(s):", LogRecordType.Message, components.Length));
+
+            int connectionsAtRisk = 0;
+            List<GH_SAMComponent> result = new List<GH_SAMComponent>();
+
+            foreach (GH_SAMComponent gH_SAMComponent in components)
+            {
+                if (gH_SAMComponent == null || !gH_SAMComponent.Obsolete)
+                {
+                    continue;
+                }
+
+                ObsoleteSeverity severity = gH_SAMComponent.ObsoleteSeverity;
+                string severityLabel = severity == ObsoleteSeverity.Breaking ? " [BREAKING]" :
+                                       severity == ObsoleteSeverity.Advisory ? " [patch]" : "";
+
+                log.Add(new LogRecord("  {0}: {1} → {2}{3}",
+                    LogRecordType.Message, gH_SAMComponent.Name, gH_SAMComponent.ComponentVersion,
+                    gH_SAMComponent.LatestComponentVersion, severityLabel));
+
+                result.Add(gH_SAMComponent);
+
+                List<IGH_Param> outputParams = gH_SAMComponent.Params?.Output;
+                List<IGH_Param> inputParams = gH_SAMComponent.Params?.Input;
+
+                if (outputParams != null)
+                {
+                    foreach (IGH_Param param in outputParams)
+                    {
+                        if (param != null && param.Recipients != null && param.Recipients.Count > 0)
+                        {
+                            connectionsAtRisk += param.Recipients.Count;
+                        }
+                    }
+                }
+
+                if (inputParams != null)
+                {
+                    foreach (IGH_Param param in inputParams)
+                    {
+                        if (param != null && param.Sources != null && param.Sources.Count > 0)
+                        {
+                            connectionsAtRisk += param.Sources.Count;
+                        }
+                    }
+                }
+            }
+
+            if (connectionsAtRisk > 0)
+            {
+                log.Add(new LogRecord("  {0} total connection(s) will be rewired.", LogRecordType.Message, connectionsAtRisk));
+            }
+
+            log.Add(new LogRecord("--- DRY RUN COMPLETE --- No changes were made to the document.", LogRecordType.Message));
+
+            return result;
+        }
+
+        public static List<GH_SAMComponent> DuplicateComponents(
+            IEnumerable<GH_SAMComponent> gH_SAMComponents,
+            GH_Document gH_Document,
+            out Log log,
+            out List<GH_SAMComponent> oldComponents)
+        {
+            log = new Log();
+            oldComponents = new List<GH_SAMComponent>();
+
+            if (gH_Document == null)
+            {
+                log.Add(new LogRecord("Document is null.", LogRecordType.Error));
+                return null;
+            }
+
+            List<GH_SAMComponent> targets;
+            if (gH_SAMComponents != null && gH_SAMComponents.Any())
+            {
+                targets = gH_SAMComponents.ToList();
+            }
+            else
+            {
+                targets = new List<GH_SAMComponent>();
+                IList<IGH_DocumentObject> gH_DocumentObjects = gH_Document.Objects;
+                if (gH_DocumentObjects != null)
+                {
+                    foreach (IGH_DocumentObject gH_DocumentObject in gH_DocumentObjects)
+                    {
+                        if (gH_DocumentObject is GH_SAMComponent gH_SAMComponent && gH_SAMComponent.Obsolete)
+                        {
+                            targets.Add(gH_SAMComponent);
+                        }
+                    }
+                }
+            }
+
+            if (targets.Count == 0)
+            {
+                log.Add(new LogRecord("No obsolete components found.", LogRecordType.Message));
+                return new List<GH_SAMComponent>();
+            }
+
+            log.Add(new LogRecord("Update started. Found {0} obsolete component(s).", LogRecordType.Message, targets.Count));
+
+            List<GH_SAMComponent> result = new List<GH_SAMComponent>();
+
+            foreach (GH_SAMComponent gH_SAMComponent in targets)
+            {
+                if (gH_SAMComponent == null)
+                {
+                    continue;
+                }
+
+                if (!gH_SAMComponent.Obsolete)
+                {
+                    continue;
+                }
+
+                try
+                {
+                    GH_SAMComponent gH_SAMComponent_New = DuplicateComponent(gH_SAMComponent, out Log log_Temp);
+                    if (gH_SAMComponent_New == null)
+                    {
+                        log.Add(new LogRecord("  Failed to update {0}", LogRecordType.Error, gH_SAMComponent.Name));
+                        if (log_Temp != null)
+                        {
+                            log.AddRange(log_Temp);
+                        }
+                        continue;
+                    }
+
+                    result.Add(gH_SAMComponent_New);
+                    oldComponents.Add(gH_SAMComponent);
+
+                    if (log_Temp != null)
+                    {
+                        log.AddRange(log_Temp);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    log.Add(new LogRecord("  Failed to update {0}: {1}", LogRecordType.Error, gH_SAMComponent.Name, ex.Message));
+                }
+            }
+
+            log.Add(new LogRecord("Components duplicated: {0} new created, {1} pending removal.",
+                LogRecordType.Message, result.Count, oldComponents.Count));
 
             return result;
         }

--- a/Grasshopper/SAM.Core.Grasshopper/Query/Obsolete.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Query/Obsolete.cs
@@ -1,22 +1,58 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
 
+using System;
+
 namespace SAM.Core.Grasshopper
 {
     public static partial class Query
     {
         public static bool Obsolete(this IGH_SAMComponent gH_SAMComponent)
         {
+            return GetObsoleteSeverity(gH_SAMComponent) != SAM.Core.Grasshopper.ObsoleteSeverity.None;
+        }
+
+        public static ObsoleteSeverity GetObsoleteSeverity(this IGH_SAMComponent gH_SAMComponent)
+        {
             if (gH_SAMComponent == null)
-                return false;
+            {
+                return SAM.Core.Grasshopper.ObsoleteSeverity.None;
+            }
 
             string componentVersion = gH_SAMComponent.ComponentVersion;
             string latestComponentVersion = gH_SAMComponent.LatestComponentVersion;
 
             if (string.IsNullOrEmpty(componentVersion) || string.IsNullOrEmpty(latestComponentVersion))
-                return false;
+            {
+                return SAM.Core.Grasshopper.ObsoleteSeverity.None;
+            }
 
-            return componentVersion != latestComponentVersion;
+            if (componentVersion == latestComponentVersion)
+            {
+                return SAM.Core.Grasshopper.ObsoleteSeverity.None;
+            }
+
+            if (!Version.TryParse(componentVersion, out Version version_Component))
+            {
+                return SAM.Core.Grasshopper.ObsoleteSeverity.Standard;
+            }
+
+            if (!Version.TryParse(latestComponentVersion, out Version version_Latest))
+            {
+                return SAM.Core.Grasshopper.ObsoleteSeverity.Standard;
+            }
+
+            if (version_Component.Major != version_Latest.Major)
+            {
+                return SAM.Core.Grasshopper.ObsoleteSeverity.Breaking;
+            }
+
+            if (version_Component.Minor != version_Latest.Minor)
+            {
+                return SAM.Core.Grasshopper.ObsoleteSeverity.Standard;
+            }
+
+            return SAM.Core.Grasshopper.ObsoleteSeverity.Advisory;
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/CreateSAMTransform3DOriginToPlane.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/CreateSAMTransform3DOriginToPlane.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class CreateSAMTransform3DOriginToPlane : GH_SAMComponent
+    public class CreateSAMTransform3DOriginToPlane : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,17 +41,29 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_plane", "_plane", "Rhino or SAM Plane", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_plane", NickName = "_plane", Description = "Rhino or SAM Plane", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooTransform3DParam(), "Transform3D", "Transform3D", "SAM Geometry Transform3D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooTransform3DParam() { Name = "Transform3D", NickName = "Transform3D", Description = "SAM Geometry Transform3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,9 +74,12 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             GH_ObjectWrapper objectWrapper = null;
 
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper.Value == null)
+            index = Params.IndexOfInputParam("_plane");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -76,7 +91,11 @@ namespace SAM.Geometry.Grasshopper
                 return;
             }
 
-            dataAccess.SetData(0, new GooTransform3D(Transform3D.GetOriginToPlane(planes[0])));
+            index = Params.IndexOfOutputParam("Transform3D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooTransform3D(Transform3D.GetOriginToPlane(planes[0])));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/CreateSAMTransform3DPlaneToOrigin.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/CreateSAMTransform3DPlaneToOrigin.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class CreateSAMTransform3DPlaneToOrigin : GH_SAMComponent
+    public class CreateSAMTransform3DPlaneToOrigin : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,17 +41,29 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_plane", "_plane", "Rhino or SAM Plane", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_plane", NickName = "_plane", Description = "Rhino or SAM Plane", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooTransform3DParam(), "Transform3D", "Transform3D", "SAM Geometry Transform3D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooTransform3DParam() { Name = "Transform3D", NickName = "Transform3D", Description = "SAM Geometry Transform3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,9 +74,12 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             GH_ObjectWrapper objectWrapper = null;
 
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper.Value == null)
+            index = Params.IndexOfInputParam("_plane");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -76,7 +91,11 @@ namespace SAM.Geometry.Grasshopper
                 return;
             }
 
-            dataAccess.SetData(0, new GooTransform3D(Transform3D.GetPlaneToOrigin(planes[0])));
+            index = Params.IndexOfOutputParam("Transform3D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooTransform3D(Transform3D.GetPlaneToOrigin(planes[0])));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/CreateSAMTransform3DPlaneToPlane.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/CreateSAMTransform3DPlaneToPlane.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class CreateSAMTransform3DPlaneToPlane : GH_SAMComponent
+    public class CreateSAMTransform3DPlaneToPlane : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,18 +41,31 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_source", "_source", "Source Rhino or SAM Plane", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_target", "_target", "Target Rhino or SAM Plane", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_source", NickName = "_source", Description = "Source Rhino or SAM Plane", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_target", NickName = "_target", Description = "Target Rhino or SAM Plane", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooTransform3DParam(), "Transform3D", "Transform3D", "SAM Geometry Transform3D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooTransform3DParam() { Name = "Transform3D", NickName = "Transform3D", Description = "SAM Geometry Transform3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,8 +76,11 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper.Value == null)
+            index = Params.IndexOfInputParam("_source");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -84,7 +100,8 @@ namespace SAM.Geometry.Grasshopper
             }
 
             objectWrapper = null;
-            if (!dataAccess.GetData(1, ref objectWrapper) || objectWrapper.Value == null)
+            index = Params.IndexOfInputParam("_target");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -103,7 +120,11 @@ namespace SAM.Geometry.Grasshopper
                 return;
             }
 
-            dataAccess.SetData(0, new GooTransform3D(Transform3D.GetPlaneToPlane(plane_1, plane_2)));
+            index = Params.IndexOfOutputParam("Transform3D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooTransform3D(Transform3D.GetPlaneToPlane(plane_1, plane_2)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryCreatePlane.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryCreatePlane.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometryCreatePlane : GH_SAMComponent
+    public class GeometryCreatePlane : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,19 +40,35 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_points", "Points", "snapping Rhino or SAM Points", GH_ParamAccess.list);
-            inputParamManager.AddNumberParameter("tolerance_", "tolerance", "Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_points", NickName = "Points", Description = "snapping Rhino or SAM Points", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "tolerance_", NickName = "tolerance", Description = "Tolerance", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "plane", "plane", "SAM Geometry Plane", GH_ParamAccess.item);
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "normal", "normal", "normal", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "plane", NickName = "plane", Description = "SAM Geometry Plane", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "normal", NickName = "normal", Description = "normal", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,19 +79,22 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
 
-            if (!dataAccess.GetDataList(0, objectWrappers) || objectWrappers == null)
+            index = Params.IndexOfInputParam("_points");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrappers) || objectWrappers == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             double tolerance = Core.Tolerance.Distance;
-            if (!dataAccess.GetData(1, ref tolerance))
+            index = Params.IndexOfInputParam("tolerance_");
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                dataAccess.GetData(index, ref tolerance);
             }
 
             if (!Query.TryGetSAMGeometries(objectWrappers, out List<Spatial.Point3D> point3Ds) || point3Ds == null || point3Ds.Count < 3)
@@ -86,8 +105,17 @@ namespace SAM.Geometry.Grasshopper
 
             Spatial.Plane plane = Spatial.Create.Plane(point3Ds, tolerance);
 
-            dataAccess.SetData(0, new GooSAMGeometry(plane));
-            dataAccess.SetData(1, new GooSAMGeometry(plane?.Normal));
+            index = Params.IndexOfOutputParam("plane");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooSAMGeometry(plane));
+            }
+
+            index = Params.IndexOfOutputParam("normal");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooSAMGeometry(plane?.Normal));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryCreateShell.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryCreateShell.cs
@@ -7,10 +7,11 @@ using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using SAM.Geometry.Spatial;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometryCreateShell : GH_SAMComponent
+    public class GeometryCreateShell : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +21,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.2";
+        public override string LatestComponentVersion => "1.0.3";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,19 +41,39 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddMeshParameter("_mesh", "mesh", "Mesh", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_simplify_", "_simplify_", "Simplify Geometry", GH_ParamAccess.item, true);
-            inputParamManager.AddNumberParameter("tolerance_", "tolerance", "Tolerance", GH_ParamAccess.item, Core.Tolerance.MacroDistance);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Mesh() { Name = "_mesh", NickName = "mesh", Description = "Mesh", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_simplify_", NickName = "_simplify_", Description = "Simplify Geometry", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "tolerance_", NickName = "tolerance", Description = "Tolerance", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(Core.Tolerance.MacroDistance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "shell", "shell", "shell", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "shell", NickName = "shell", Description = "shell", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,30 +84,37 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             Mesh mesh = null;
-            if (!dataAccess.GetData(0, ref mesh) || mesh == null)
+            index = Params.IndexOfInputParam("_mesh");
+            if (index == -1 || !dataAccess.GetData(index, ref mesh) || mesh == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             double tolerance = Core.Tolerance.MacroDistance;
-            if (!dataAccess.GetData(2, ref tolerance))
+            index = Params.IndexOfInputParam("tolerance_");
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                dataAccess.GetData(index, ref tolerance);
             }
 
             bool simplify = true;
-            if (!dataAccess.GetData(1, ref simplify))
+            index = Params.IndexOfInputParam("_simplify_");
+            if (index != -1)
             {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
+                dataAccess.GetData(index, ref simplify);
             }
 
             Shell shell = Rhino.Create.Shell(mesh, simplify, tolerance_Distance: tolerance);
 
-            dataAccess.SetData(0, new GooSAMGeometry(shell));
+            index = Params.IndexOfOutputParam("shell");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooSAMGeometry(shell));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryMeshClose.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryMeshClose.cs
@@ -6,10 +6,11 @@ using Rhino.Geometry;
 using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometryMeshClose : GH_SAMComponent
+    public class GeometryMeshClose : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,19 +40,30 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddMeshParameter("_mesh", "_mesh", "Rhino Mesh", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Mesh() { Name = "_mesh", NickName = "_mesh", Description = "Rhino Mesh", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddMeshParameter("Mesh", "Mesh", "Mesh", GH_ParamAccess.item);
-            outputParamManager.AddBooleanParameter("Closed", "Closed", "Closed", GH_ParamAccess.item);
-            //outputParamManager.AddParameter( string, "Normal", "Normal", "Normal", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Mesh() { Name = "Mesh", NickName = "Mesh", Description = "Mesh", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Closed", NickName = "Closed", Description = "Closed", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,8 +74,11 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             Mesh mesh = null;
-            if (!dataAccess.GetData(0, ref mesh))
+            index = Params.IndexOfInputParam("_mesh");
+            if (index == -1 || !dataAccess.GetData(index, ref mesh))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -72,8 +87,17 @@ namespace SAM.Geometry.Grasshopper
             Mesh mesh_Result = null;
             bool result = Query.TryClose(mesh, out mesh_Result);
 
-            dataAccess.SetData(0, mesh_Result);
-            dataAccess.SetData(1, result);
+            index = Params.IndexOfOutputParam("Mesh");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, mesh_Result);
+            }
+
+            index = Params.IndexOfOutputParam("Closed");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, result);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryMeshReduce.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryMeshReduce.cs
@@ -6,10 +6,11 @@ using Rhino.Geometry;
 using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometryMeshReduce : GH_SAMComponent
+    public class GeometryMeshReduce : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,23 +40,49 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddMeshParameter("_mesh", "_mesh", "Rhino Mesh", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_distortion_", "_distortion_", "Allow Distortion towards desire count", GH_ParamAccess.item, true);
-            inputParamManager.AddIntegerParameter("_count_", "_count_", "Desired Polygon Count", GH_ParamAccess.item, 44);
-            inputParamManager.AddIntegerParameter("_accuracy_", "_accuracy_", "Accuracy lowest 1 to 10 highest", GH_ParamAccess.item, 10);
-            inputParamManager.AddBooleanParameter("_normalizedSize_", "_normalizedSize", "Normalized Face Size", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Mesh() { Name = "_mesh", NickName = "_mesh", Description = "Rhino Mesh", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_distortion_", NickName = "_distortion_", Description = "Allow Distortion towards desire count", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Integer param_Integer;
+
+                param_Integer = new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "_count_", NickName = "_count_", Description = "Desired Polygon Count", Access = GH_ParamAccess.item, Optional = true };
+                param_Integer.SetPersistentData(44);
+                result.Add(new GH_SAMParam(param_Integer, ParamVisibility.Binding));
+
+                param_Integer = new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "_accuracy_", NickName = "_accuracy_", Description = "Accuracy lowest 1 to 10 highest", Access = GH_ParamAccess.item, Optional = true };
+                param_Integer.SetPersistentData(10);
+                result.Add(new GH_SAMParam(param_Integer, ParamVisibility.Binding));
+
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_normalizedSize_", NickName = "_normalizedSize_", Description = "Normalized Face Size", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddMeshParameter("Mesh", "Mesh", "Mesh", GH_ParamAccess.item);
-            //outputParamManager.AddParameter( string, "Normal", "Normal", "Normal", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Mesh() { Name = "Mesh", NickName = "Mesh", Description = "Mesh", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -66,29 +93,51 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            Mesh mesh = new Mesh();
-            if (!dataAccess.GetData(0, ref mesh))
+            int index;
+
+            index = Params.IndexOfInputParam("_mesh");
+            Mesh mesh = null;
+            if (index == -1 || !dataAccess.GetData(index, ref mesh) || mesh == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             bool allowDistortion = true;
-            dataAccess.GetData(1, ref allowDistortion);
+            index = Params.IndexOfInputParam("_distortion_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref allowDistortion);
+            }
 
-            int deisredPolygonCount = 0;
-            dataAccess.GetData(2, ref deisredPolygonCount);
+            int desiredPolygonCount = 0;
+            index = Params.IndexOfInputParam("_count_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref desiredPolygonCount);
+            }
 
             int accuracy = 0;
-            dataAccess.GetData(3, ref accuracy);
+            index = Params.IndexOfInputParam("_accuracy_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref accuracy);
+            }
 
             bool normalizedSize = true;
-            dataAccess.GetData(4, ref normalizedSize);
+            index = Params.IndexOfInputParam("_normalizedSize_");
+            if (index != -1)
+            {
+                dataAccess.GetData(index, ref normalizedSize);
+            }
 
-            //Mesh result = mesh.DuplicateMesh();
-            Modify.Reduce(mesh, allowDistortion, deisredPolygonCount, accuracy, normalizedSize);
+            Modify.Reduce(mesh, allowDistortion, desiredPolygonCount, accuracy, normalizedSize);
 
-            dataAccess.SetData(0, mesh);
+            index = Params.IndexOfOutputParam("Mesh");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, mesh);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryModifyDifference.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryModifyDifference.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometryModifyDifference : GH_SAMComponent
+    public class GeometryModifyDifference : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,21 +40,35 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_polygon1", "_polygon1", "Polygon 1", GH_ParamAccess.list);
-            inputParamManager.AddGenericParameter("_polygon2", "_polygon2", "Polygon 2", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddNumberParameter("_tolerance_", "_tolerance", "Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_polygon1", NickName = "_polygon1", Description = "Polygon 1", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_polygon2", NickName = "_polygon2", Description = "Polygon 2", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "Polygon", "Polygon", "Polygon", GH_ParamAccess.list);
-            //outputParamManager.AddParameter( string, "Normal", "Normal", "Normal", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "Polygon", NickName = "Polygon", Description = "Polygon", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,16 +79,19 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_tolerance_");
             double tolerance = Core.Tolerance.Distance;
-            if (!dataAccess.GetData(2, ref tolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_polygon1");
             List<GH_ObjectWrapper> objectWrapperList = new List<GH_ObjectWrapper>();
-
-            if (!dataAccess.GetDataList(0, objectWrapperList) || objectWrapperList == null)
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -91,8 +108,9 @@ namespace SAM.Geometry.Grasshopper
                 }
             }
 
+            index = Params.IndexOfInputParam("_polygon2");
             objectWrapperList = new List<GH_ObjectWrapper>();
-            if (!dataAccess.GetDataList(1, objectWrapperList) || objectWrapperList == null)
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -112,9 +130,11 @@ namespace SAM.Geometry.Grasshopper
             List<Planar.Polygon2D> polygon2Ds_Difference = new List<Planar.Polygon2D>();
             polygon2Ds_Difference = Planar.Query.Difference(polygon2Ds_1, polygon2Ds_2, tolerance);
 
-            dataAccess.SetDataList(0, polygon2Ds_Difference.ConvertAll(x => new GooSAMGeometry(x)));
-
-            //AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Run No#");
+            index = Params.IndexOfOutputParam("Polygon");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, polygon2Ds_Difference.ConvertAll(x => new GooSAMGeometry(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryModifyIntersection.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryModifyIntersection.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometryModifyIntersection : GH_SAMComponent
+    public class GeometryModifyIntersection : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,21 +40,35 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_polygon1", "_polygon1", "Polygon 1", GH_ParamAccess.list);
-            inputParamManager.AddGenericParameter("_polygon2", "_polygon2", "Polygon 2", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddNumberParameter("_tolerance_", "_tolerance", "Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_polygon1", NickName = "_polygon1", Description = "Polygon 1", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_polygon2", NickName = "_polygon2", Description = "Polygon 2", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "Polygon", "Polygon", "Polygon", GH_ParamAccess.list);
-            //outputParamManager.AddParameter( string, "Normal", "Normal", "Normal", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "Polygon", NickName = "Polygon", Description = "Polygon", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,16 +79,19 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_tolerance_");
             double tolerance = Core.Tolerance.Distance;
-            if (!dataAccess.GetData(2, ref tolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_polygon1");
             List<GH_ObjectWrapper> objectWrapperList = new List<GH_ObjectWrapper>();
-
-            if (!dataAccess.GetDataList(0, objectWrapperList) || objectWrapperList == null)
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -91,8 +108,9 @@ namespace SAM.Geometry.Grasshopper
                 }
             }
 
+            index = Params.IndexOfInputParam("_polygon2");
             objectWrapperList = new List<GH_ObjectWrapper>();
-            if (!dataAccess.GetDataList(1, objectWrapperList) || objectWrapperList == null)
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -111,9 +129,11 @@ namespace SAM.Geometry.Grasshopper
 
             List<Planar.Polygon2D> polygon2Ds_result = Planar.Query.Intersection(polygon2Ds_1[0], polygon2Ds_2[0], tolerance);
 
-            dataAccess.SetDataList(0, polygon2Ds_result.ConvertAll(x => new GooSAMGeometry(x)));
-
-            //AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Run No#");
+            index = Params.IndexOfOutputParam("Polygon");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, polygon2Ds_result.ConvertAll(x => new GooSAMGeometry(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryModifyUnion.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometryModifyUnion.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometryModifyUnion : GH_SAMComponent
+    public class GeometryModifyUnion : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,21 +40,35 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_polygon1", "_polygon1", "Polygon 1", GH_ParamAccess.list);
-            inputParamManager.AddGenericParameter("_polygon2", "_polygon2", "Polygon 2", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            inputParamManager.AddNumberParameter("_tolerance_", "_tolerance", "Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_polygon1", NickName = "_polygon1", Description = "Polygon 1", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_polygon2", NickName = "_polygon2", Description = "Polygon 2", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "_tolerance_", Description = "Tolerance", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "Polygon", "Polygon", "Polygon", GH_ParamAccess.list);
-            //outputParamManager.AddParameter( string, "Normal", "Normal", "Normal", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "Polygon", NickName = "Polygon", Description = "Polygon", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,16 +79,19 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_tolerance_");
             double tolerance = Core.Tolerance.Distance;
-            if (!dataAccess.GetData(2, ref tolerance))
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_polygon1");
             List<GH_ObjectWrapper> objectWrapperList = new List<GH_ObjectWrapper>();
-
-            if (!dataAccess.GetDataList(0, objectWrapperList) || objectWrapperList == null)
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -91,8 +108,9 @@ namespace SAM.Geometry.Grasshopper
                 }
             }
 
+            index = Params.IndexOfInputParam("_polygon2");
             objectWrapperList = new List<GH_ObjectWrapper>();
-            if (!dataAccess.GetDataList(1, objectWrapperList) || objectWrapperList == null)
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -112,9 +130,11 @@ namespace SAM.Geometry.Grasshopper
             List<Planar.Polygon2D> polygon2Ds_Union = new List<Planar.Polygon2D>();
             polygon2Ds_Union = Planar.Query.Union(polygon2Ds_1[0], polygon2Ds_2[0], tolerance);
 
-            dataAccess.SetDataList(0, polygon2Ds_Union.ConvertAll(x => new GooSAMGeometry(x)));
-
-            //AddRuntimeMessage(GH_RuntimeMessageLevel.Remark, "Run No#");
+            index = Params.IndexOfOutputParam("Polygon");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, polygon2Ds_Union.ConvertAll(x => new GooSAMGeometry(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometrySAMGeometry.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometrySAMGeometry.cs
@@ -7,10 +7,11 @@ using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometrySAMGeometry : GH_SAMComponent
+    public class GeometrySAMGeometry : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +21,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,17 +41,27 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGeometryParameter("_geometry", "_geometry", "Rhino/GH geometry", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Geometry() { Name = "_geometry", NickName = "_geometry", Description = "Rhino/GH geometry", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "SAMGeometries", "SAMGeos", "SAM Geometries", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "SAMGeometries", NickName = "SAMGeos", Description = "SAM Geometries", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -61,8 +72,11 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_geometry");
             IGH_GeometricGoo geometricGoo = null;
-            if (!dataAccess.GetData(0, ref geometricGoo) || geometricGoo == null)
+            if (index == -1 || !dataAccess.GetData(index, ref geometricGoo) || geometricGoo == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -73,9 +87,21 @@ namespace SAM.Geometry.Grasshopper
             if (@object == null)
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Cannot convert geometry");
             else if (@object is IEnumerable)
-                dataAccess.SetDataList(0, (IEnumerable)@object);
+            {
+                index = Params.IndexOfOutputParam("SAMGeometries");
+                if (index != -1)
+                {
+                    dataAccess.SetDataList(index, (IEnumerable)@object);
+                }
+            }
             else
-                dataAccess.SetData(0, @object);
+            {
+                index = Params.IndexOfOutputParam("SAMGeometries");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, @object);
+                }
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometrySnapByDistance.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometrySnapByDistance.cs
@@ -7,11 +7,12 @@ using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using SAM.Geometry.Spatial;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometrySnapByDistance : GH_SAMComponent
+    public class GeometrySnapByDistance : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +22,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,21 +42,37 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_Face3D_1", "F_1", "SAM Geometry Face3D", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_Face3D_2", "F_2", "SAM Geometry Face3D", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_snapDistance", "SnDist", "Snapping Distance", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_Face3D_1", NickName = "F_1", Description = "SAM Geometry Face3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_Face3D_2", NickName = "F_2", Description = "SAM Geometry Face3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_snapDistance", NickName = "SnDist", Description = "Snapping Distance", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("Geometry", "Geo", "modified SAM Geometry", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Geometry", NickName = "Geo", Description = "modified SAM Geometry", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -66,30 +83,46 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_run");
             bool run = false;
-            if (!dataAccess.GetData(3, ref run))
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
             if (!run)
                 return;
 
+            index = Params.IndexOfInputParam("_snapDistance");
             double snapDistance = double.NaN;
-            if (!dataAccess.GetData(2, ref snapDistance))
+            if (index == -1 || !dataAccess.GetData(index, ref snapDistance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
+            index = Params.IndexOfInputParam("_Face3D_1");
             GH_ObjectWrapper objectWrapper = null;
-
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper == null)
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(0, false);
+                index = Params.IndexOfOutputParam("Geometry");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
@@ -102,14 +135,23 @@ namespace SAM.Geometry.Grasshopper
             if (face3D_1 == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
-            if (!dataAccess.GetData(1, ref objectWrapper) || objectWrapper == null)
+            index = Params.IndexOfInputParam("_Face3D_2");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
@@ -122,15 +164,28 @@ namespace SAM.Geometry.Grasshopper
             if (face3D_2 == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
             face3D_1 = Spatial.Query.Snap(face3D_1, face3D_2, snapDistance);
             face3D_2 = Spatial.Query.Snap(face3D_2, face3D_1, snapDistance);
 
-            dataAccess.SetDataList(0, new Face3D[] { face3D_1, face3D_2 });
-            dataAccess.SetData(1, true);
+            index = Params.IndexOfOutputParam("Geometry");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, new Face3D[] { face3D_1, face3D_2 });
+            }
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometrySnapByPoints.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/GeometrySnapByPoints.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class GeometrySnapByPoints : GH_SAMComponent
+    public class GeometrySnapByPoints : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,21 +40,42 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_geometry", "Geo", "Geometry", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_points", "Points", "snapping Points", GH_ParamAccess.list);
-            inputParamManager.AddNumberParameter("_maxDistance_", "mDis", "Max Distance to snap Geometry points", GH_ParamAccess.item, 1);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_geometry", NickName = "Geo", Description = "Geometry", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_points", NickName = "Points", Description = "snapping Points", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_maxDistance_", NickName = "mDis", Description = "Max Distance to snap Geometry points", Access = GH_ParamAccess.item };
+                param_Number.SetPersistentData(1);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("Geometry", "Geo", "modified SAM Geometry", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Geometry", NickName = "Geo", Description = "modified SAM Geometry", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,11 +86,19 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, false);
+            }
+
             bool run = false;
-            if (!dataAccess.GetData(3, ref run))
+            index = Params.IndexOfInputParam("_run");
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
             if (!run)
@@ -77,10 +106,10 @@ namespace SAM.Geometry.Grasshopper
 
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
 
-            if (!dataAccess.GetDataList(1, objectWrappers) || objectWrappers == null)
+            index = Params.IndexOfInputParam("_points");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrappers) || objectWrappers == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -103,10 +132,10 @@ namespace SAM.Geometry.Grasshopper
 
             GH_ObjectWrapper objectWrapper = null;
 
-            if (!dataAccess.GetData(2, ref objectWrapper) || objectWrapper.Value == null)
+            index = Params.IndexOfInputParam("_maxDistance_");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -117,10 +146,10 @@ namespace SAM.Geometry.Grasshopper
                 maxDistance = number.Value;
 
             objectWrapper = null;
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper.Value == null)
+            index = Params.IndexOfInputParam("_geometry");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -128,7 +157,6 @@ namespace SAM.Geometry.Grasshopper
             if (@object == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -155,10 +183,17 @@ namespace SAM.Geometry.Grasshopper
                 }
             }
 
-            dataAccess.SetData(0, geometry3Ds);
-            dataAccess.SetData(1, true);
+            index = Params.IndexOfOutputParam("Geometry");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, geometry3Ds);
+            }
 
-            //AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Cannot split segments");
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/NTSSAMGeometry2D.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/NTSSAMGeometry2D.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class NTSSAMGeometry2D : GH_SAMComponent
+    public class NTSSAMGeometry2D : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +20,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -40,17 +40,27 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddTextParameter("_NTS", "NTS", "NTS Text", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "_NTS", NickName = "NTS", Description = "NTS Text", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "Geometry2Ds", "Geometry2Ds", "SAM Geometry 2D", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "Geometry2Ds", NickName = "Geometry2Ds", Description = "SAM Geometry 2D", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -61,20 +71,24 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_NTS");
             List<string> lines_NTS = new List<string>();
-            if (!dataAccess.GetDataList(0, lines_NTS))
+            if (index == -1 || !dataAccess.GetDataList(index, lines_NTS))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
             List<ISAMGeometry2D> geometry2Ds = Planar.Convert.ToSAM<ISAMGeometry2D>(lines_NTS);
-            if (geometry2Ds == null)
-                dataAccess.SetDataList(0, null);
-            else
-                dataAccess.SetDataList(0, geometry2Ds.ConvertAll(x => new GooSAMGeometry(x)));
 
-
+            index = Params.IndexOfOutputParam("Geometry2Ds");
+            if (index != -1)
+            {
+                if (geometry2Ds == null)
+                    dataAccess.SetDataList(index, null);
+                else
+                    dataAccess.SetDataList(index, geometry2Ds.ConvertAll(x => new GooSAMGeometry(x)));
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometry2DSAMGeometry.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometry2DSAMGeometry.cs
@@ -6,10 +6,11 @@ using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using SAM.Geometry.Spatial;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class SAMGeometry2DSAMGeometry : GH_SAMComponent
+    public class SAMGeometry2DSAMGeometry : GH_SAMVariableOutputParameterComponent
     {
 
         /// <summary>
@@ -20,7 +21,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -35,21 +36,33 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooSAMGeometryParam(), "_SAMGeometry2D", "SAMgeo2D", "SAM Geometry 2D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
 
-            GooSAMGeometryParam gooSAMGeometryParam = new GooSAMGeometryParam();
-            gooSAMGeometryParam.PersistentData.Append(new GooSAMGeometry(Plane.WorldXY));
-            inputParamManager.AddParameter(gooSAMGeometryParam, "Plane", "Plane", "SAM Plane", GH_ParamAccess.item);
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "_SAMGeometry2D", NickName = "SAMgeo2D", Description = "SAM Geometry 2D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+
+                GooSAMGeometryParam gooSAMGeometryParam = new GooSAMGeometryParam() { Name = "Plane", NickName = "Plane", Description = "SAM Plane", Access = GH_ParamAccess.item };
+                gooSAMGeometryParam.SetPersistentData(new GooSAMGeometry(Plane.WorldXY));
+                result.Add(new GH_SAMParam(gooSAMGeometryParam, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "SAMGeometry3D", "SAMgeo3D", "SAM Geometry 3D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "SAMGeometry3D", NickName = "SAMgeo3D", Description = "SAM Geometry 3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,9 +73,11 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            ISAMGeometry sAMGeometry = null;
+            int index;
 
-            if (!dataAccess.GetData(0, ref sAMGeometry) || sAMGeometry == null)
+            index = Params.IndexOfInputParam("_SAMGeometry2D");
+            ISAMGeometry sAMGeometry = null;
+            if (index == -1 || !dataAccess.GetData(index, ref sAMGeometry) || sAMGeometry == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -76,7 +91,8 @@ namespace SAM.Geometry.Grasshopper
             }
 
             sAMGeometry = null;
-            if (!dataAccess.GetData(1, ref sAMGeometry) || sAMGeometry == null)
+            index = Params.IndexOfInputParam("Plane");
+            if (index == -1 || !dataAccess.GetData(index, ref sAMGeometry) || sAMGeometry == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -96,7 +112,11 @@ namespace SAM.Geometry.Grasshopper
                 return;
             }
 
-            dataAccess.SetData(0, geometry3D);
+            index = Params.IndexOfOutputParam("SAMGeometry3D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, geometry3D);
+            }
         }
 
         /// <summary>

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometry2DToNTS.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometry2DToNTS.cs
@@ -14,9 +14,9 @@ namespace SAM.Geometry.Grasshopper
 {
     /// <summary>
     /// The SAMGeometry2DToNTS class is a component that converts SAM 2D geometries to NetTopologySuite (NTS) geometries.
-    /// It inherits from the GH_SAMComponent base class.
+    /// It inherits from the GH_SAMVariableOutputParameterComponent base class.
     /// </summary>
-    public class SAMGeometry2DToNTS : GH_SAMComponent
+    public class SAMGeometry2DToNTS : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -26,7 +26,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -46,19 +46,29 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_geometry", "Geo", "Geometry", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_geometry", NickName = "Geo", Description = "Geometry", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("nTSGeometries", "nTSGeometries", "NTS Geometries", GH_ParamAccess.list);
-            outputParamManager.AddGenericParameter("nTS Text", "nTS Text", "Text", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("successful", "successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "nTSGeometries", NickName = "nTSGeometries", Description = "NTS Geometries", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "nTS Text", NickName = "nTS Text", Description = "Text", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "successful", NickName = "successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -69,11 +79,18 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper == null)
+            index = Params.IndexOfInputParam("_geometry");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("nTS Text");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
@@ -141,11 +158,23 @@ namespace SAM.Geometry.Grasshopper
 
             List<NetTopologySuite.Geometries.Geometry> geometries = sAMGeometry2Ds.ConvertAll(x => x.ToNTS());
 
-            dataAccess.SetDataList(0, geometries);
-            dataAccess.SetDataList(1, geometries.ConvertAll(x => x.ToString()));
-            dataAccess.SetData(2, true);
+            index = Params.IndexOfOutputParam("nTSGeometries");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, geometries);
+            }
 
-            //AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Cannot split segments");
+            index = Params.IndexOfOutputParam("nTS Text");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, geometries.ConvertAll(x => x.ToString()));
+            }
+
+            index = Params.IndexOfOutputParam("successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryCreateShellsByTopAndBottom.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryCreateShellsByTopAndBottom.cs
@@ -236,7 +236,7 @@ namespace SAM.Geometry.Grasshopper
 
             List<Shell> shells = Spatial.Create.Shells_ByTopAndBottom(face3Ds, tolerance);
 
-            index = Params.IndexOfInputParam("shells");
+            index = Params.IndexOfOutputParam("shells");
             if (index != -1)
                 dataAccess.SetDataList(index, shells?.ConvertAll(x => new GooSAMGeometry(x)));
         }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryFill.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryFill.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class SAMGeometryFill : GH_SAMComponent
+    public class SAMGeometryFill : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -42,19 +42,29 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_face3D", "_face3D", "SAM Geometry Face3D bo be filled", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_face3Ds", "_face3Ds", "Filling SAM Geometry Face3Ds", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_face3D", NickName = "_face3D", Description = "SAM Geometry Face3D bo be filled", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_face3Ds", NickName = "_face3Ds", Description = "Filling SAM Geometry Face3Ds", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "face3Ds", "face3Ds", "SAM Geometry Face3Ds", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Successful", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "face3Ds", NickName = "face3Ds", Description = "SAM Geometry Face3Ds", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Successful", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -65,11 +75,18 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfInputParam("_face3D");
             GH_ObjectWrapper objectWrapper = null;
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper == null)
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
@@ -84,16 +101,25 @@ namespace SAM.Geometry.Grasshopper
             if (face3D == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
 
-            if (!dataAccess.GetDataList(1, objectWrappers) || objectWrappers == null)
+            index = Params.IndexOfInputParam("_face3Ds");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrappers) || objectWrappers == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
@@ -111,14 +137,27 @@ namespace SAM.Geometry.Grasshopper
             if (face3Ds != null && face3Ds.Count == 0)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
+                index = Params.IndexOfOutputParam("Successful");
+                if (index != -1)
+                {
+                    dataAccess.SetData(index, false);
+                }
                 return;
             }
 
             List<Face3D> result = face3D.Fill(face3Ds, 0.1, Core.Tolerance.MacroDistance, Core.Tolerance.Distance);
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooSAMGeometry(x)));
-            dataAccess.SetData(1, true);
+            index = Params.IndexOfOutputParam("face3Ds");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result.ConvertAll(x => new GooSAMGeometry(x)));
+            }
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryFlipNormal.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryFlipNormal.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class SAMGeometryFlipNormal : GH_SAMComponent
+    public class SAMGeometryFlipNormal : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Provides an Icon for the component.
@@ -23,7 +24,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -38,17 +39,27 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooSAMGeometryParam(), "_face3D", "_face3D", "SAM Geometry Face3D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "_face3D", NickName = "_face3D", Description = "SAM Geometry Face3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "Face3D", "Face3D", "SAM Geometry Face3D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "Face3D", NickName = "Face3D", Description = "SAM Geometry Face3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -59,8 +70,9 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = Params.IndexOfInputParam("_face3D");
             ISAMGeometry geometry = null;
-            if (!dataAccess.GetData(0, ref geometry) || geometry == null)
+            if (index == -1 || !dataAccess.GetData(index, ref geometry) || geometry == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -76,7 +88,11 @@ namespace SAM.Geometry.Grasshopper
             face3D = new Spatial.Face3D(face3D);
             face3D.FlipNormal();
 
-            dataAccess.SetData(0, face3D);
+            index = Params.IndexOfOutputParam("Face3D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, face3D);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryGeometry.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryGeometry.cs
@@ -6,10 +6,11 @@ using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class SAMGeometryGeometry : GH_SAMComponent
+    public class SAMGeometryGeometry : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Provides an Icon for the component.
@@ -24,7 +25,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -39,17 +40,27 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooSAMGeometryParam(), "_SAMGeometry", "_SAMGeometry", "SAM Geometry", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "_SAMGeometry", NickName = "_SAMGeometry", Description = "SAM Geometry", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGeometryParameter("Geometry", "Geo", "Rhino geometry", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Geometry() { Name = "Geometry", NickName = "Geo", Description = "Rhino geometry", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -60,8 +71,11 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_SAMGeometry");
             ISAMGeometry geometry = null;
-            if (!dataAccess.GetData(0, ref geometry) || geometry == null)
+            if (index == -1 || !dataAccess.GetData(index, ref geometry) || geometry == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -69,12 +83,13 @@ namespace SAM.Geometry.Grasshopper
 
             object @object = geometry.ToGrasshopper();
 
+            index = Params.IndexOfOutputParam("Geometry");
             if (@object == null)
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Cannot convert geometry");
             else if (@object is IEnumerable)
-                dataAccess.SetDataList(0, (IEnumerable)@object);
+                dataAccess.SetDataList(index, (IEnumerable)@object);
             else
-                dataAccess.SetData(0, @object);
+                dataAccess.SetData(index, @object);
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryMargeOverlaps.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryMargeOverlaps.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class SAMGeometryMergeOverlaps : GH_SAMComponent
+    public class SAMGeometryMergeOverlaps : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,18 +41,28 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_face3Ds", "_face3Ds", "SAM Geometry Face3Ds", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_face3Ds", NickName = "_face3Ds", Description = "SAM Geometry Face3Ds", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "face3Ds", "face3Ds", "SAM Geometry Face3Ds", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Successful", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "face3Ds", NickName = "face3Ds", Description = "SAM Geometry Face3Ds", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Successful", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,12 +73,20 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index;
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, false);
+            }
+
             List<GH_ObjectWrapper> objectWrappers = new List<GH_ObjectWrapper>();
 
-            if (!dataAccess.GetDataList(0, objectWrappers) || objectWrappers == null)
+            index = Params.IndexOfInputParam("_face3Ds");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrappers) || objectWrappers == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -84,7 +102,6 @@ namespace SAM.Geometry.Grasshopper
             if (face3Ds != null && face3Ds.Count == 0)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -99,8 +116,17 @@ namespace SAM.Geometry.Grasshopper
                 face3Ds = face2Ds.ConvertAll(x => plane.Convert(x));
             }
 
-            dataAccess.SetDataList(0, face3Ds.ConvertAll(x => new GooSAMGeometry(x)));
-            dataAccess.SetData(1, true);
+            index = Params.IndexOfOutputParam("face3Ds");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, face3Ds.ConvertAll(x => new GooSAMGeometry(x)));
+            }
+
+            index = Params.IndexOfOutputParam("Successful");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryPlaneIntersection.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryPlaneIntersection.cs
@@ -11,7 +11,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class SAMGeometryPlaneIntersection : GH_SAMComponent
+    public class SAMGeometryPlaneIntersection : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -21,7 +21,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -41,19 +41,29 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_geometry3D", "_geometry3D", "SAM Geometry 3D", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_plane", "_plane", "SAM Plane", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_geometry3D", NickName = "_geometry3D", Description = "SAM Geometry 3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_plane", NickName = "_plane", Description = "SAM Plane", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "Geometries", "Geometries", "Intersection Geometries", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Successful", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "Geometries", NickName = "Geometries", Description = "Intersection Geometries", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Successful", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -64,13 +74,21 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index_Successful = Params.IndexOfOutputParam("Successful");
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, false);
+            }
+
+            int index = -1;
+
             GH_ObjectWrapper objectWrapper = null;
 
+            index = Params.IndexOfInputParam("_geometry3D");
             objectWrapper = null;
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper.Value == null)
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -78,7 +96,6 @@ namespace SAM.Geometry.Grasshopper
             if (obj == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -91,11 +108,11 @@ namespace SAM.Geometry.Grasshopper
             else if (obj is GooSAMGeometry)
                 geometry3Ds = new List<ISAMGeometry3D>() { ((GooSAMGeometry)obj).Value as ISAMGeometry3D };
 
+            index = Params.IndexOfInputParam("_plane");
             objectWrapper = null;
-            if (!dataAccess.GetData(1, ref objectWrapper) || objectWrapper.Value == null)
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
@@ -111,11 +128,10 @@ namespace SAM.Geometry.Grasshopper
             if (plane == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
-            List<ISAMGeometry3D> result = new List<ISAMGeometry3D>();
+            List<ISAMGeometry3D> result_Geometries = new List<ISAMGeometry3D>();
             foreach (ISAMGeometry3D geometry3D in geometry3Ds)
             {
                 PlanarIntersectionResult planarIntersectionResult = Spatial.Create.PlanarIntersectionResult(plane, geometry3D as dynamic);
@@ -124,11 +140,19 @@ namespace SAM.Geometry.Grasshopper
 
                 List<ISAMGeometry3D> geometry3Ds_Temp = planarIntersectionResult.Geometry3Ds;
                 if (geometry3Ds_Temp != null && geometry3Ds_Temp.Count > 0)
-                    result.AddRange(geometry3Ds_Temp);
+                    result_Geometries.AddRange(geometry3Ds_Temp);
             }
 
-            dataAccess.SetDataList(0, result.ConvertAll(x => new GooSAMGeometry(x)));
-            dataAccess.SetData(1, true);
+            index = Params.IndexOfOutputParam("Geometries");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, result_Geometries.ConvertAll(x => new GooSAMGeometry(x)));
+            }
+
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometrySAMGeometry2D.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometrySAMGeometry2D.cs
@@ -13,7 +13,7 @@ using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class SAMGeometrySAMGeometry2D : GH_SAMComponent
+    public class SAMGeometrySAMGeometry2D : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -23,7 +23,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.1";
+        public override string LatestComponentVersion => "1.0.2";
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -38,25 +38,39 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            int index = -1;
-            Param_GenericObject genericObjectParameter = null;
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                global::Grasshopper.Kernel.Parameters.Param_GenericObject genericObjectParameter;
 
-            inputParamManager.AddGenericParameter("_SAMGeometry3D", "_SAMGeometry3D", "SAM Geometry 3D", GH_ParamAccess.item);
-            inputParamManager.AddBooleanParameter("_ownPlane", "_ownPlane", "Projection on own plane if possible", GH_ParamAccess.item, true);
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_SAMGeometry3D", NickName = "_SAMGeometry3D", Description = "SAM Geometry 3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
 
-            index = inputParamManager.AddGenericParameter("Plane", "Plane", "SAM Plane", GH_ParamAccess.item);
-            genericObjectParameter = (Param_GenericObject)inputParamManager[index];
-            genericObjectParameter.PersistentData.Append(new GH_Plane(new global::Rhino.Geometry.Plane(new global::Rhino.Geometry.Point3d(0, 0, 0), new global::Rhino.Geometry.Vector3d(0, 0, 1))));
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_ownPlane", NickName = "_ownPlane", Description = "Projection on own plane if possible", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(true);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                genericObjectParameter = new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Plane", NickName = "Plane", Description = "SAM Plane", Access = GH_ParamAccess.item, Optional = true };
+                genericObjectParameter.SetPersistentData(new GH_Plane(new global::Rhino.Geometry.Plane(new global::Rhino.Geometry.Point3d(0, 0, 0), new global::Rhino.Geometry.Vector3d(0, 0, 1))));
+                result.Add(new GH_SAMParam(genericObjectParameter, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("sAMGeometry2D", "sAMgeo2D", "SAM Geometry 2D", GH_ParamAccess.list);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "sAMGeometry2D", NickName = "sAMgeo2D", Description = "SAM Geometry 2D", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -67,9 +81,12 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
             GH_ObjectWrapper objectWrapper = null;
 
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper.Value == null)
+            index = Params.IndexOfInputParam("_SAMGeometry3D");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -119,7 +136,8 @@ namespace SAM.Geometry.Grasshopper
             }
 
             bool ownPlane = true;
-            if (!dataAccess.GetData(1, ref ownPlane))
+            index = Params.IndexOfInputParam("_ownPlane");
+            if (index == -1 || !dataAccess.GetData(index, ref ownPlane))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -129,7 +147,8 @@ namespace SAM.Geometry.Grasshopper
 
             if (!ownPlane)
             {
-                if (!dataAccess.GetData(2, ref objectWrapper) || objectWrapper.Value == null)
+                index = Params.IndexOfInputParam("Plane");
+                if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
                 {
                     AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                     return;
@@ -178,7 +197,11 @@ namespace SAM.Geometry.Grasshopper
                 sAMGeometry2Ds.Add(plane_Boundable3D.Convert(boundable3D));
             }
 
-            dataAccess.SetDataList(0, sAMGeometry2Ds);
+            index = Params.IndexOfOutputParam("sAMGeometry2D");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, sAMGeometry2Ds);
+            }
         }
 
         /// <summary>
@@ -188,8 +211,6 @@ namespace SAM.Geometry.Grasshopper
         {
             get
             {
-                //You can add image files to your project resources and access them like this:
-                // return Resources.IconForThisComponent;
                 return Resources.SAM_Geometry;
             }
         }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometrySegment2DIntersection.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometrySegment2DIntersection.cs
@@ -7,10 +7,11 @@ using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using SAM.Geometry.Planar;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class SAMGeometrySegment2DIntersection : GH_SAMComponent
+    public class SAMGeometrySegment2DIntersection : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -20,7 +21,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
         /// <summary>
         /// Provides an Icon for the component.
         /// </summary>
@@ -39,20 +40,30 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_1stSegment2D", "_1stSegment2D", "SAM Geometry segment2D", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_2ndSegment2D", "_2ndSegment2D", "SAM Geometry segment2D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_1stSegment2D", NickName = "_1stSegment2D", Description = "SAM Geometry segment2D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_2ndSegment2D", NickName = "_2ndSegment2D", Description = "SAM Geometry segment2D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("Point2D", "Pt2D", "Intersection between segment2Ds SAM Point2D", GH_ParamAccess.item);
-            outputParamManager.AddGenericParameter("1stClosestPoint2D", "1stCPt2D", "First closest SAM Point2D", GH_ParamAccess.item);
-            outputParamManager.AddGenericParameter("2ndClosestPoint2D", "2ndCPt2D", "Second closest SAM Point2D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Point2D", NickName = "Pt2D", Description = "Intersection between segment2Ds SAM Point2D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "1stClosestPoint2D", NickName = "1stCPt2D", Description = "First closest SAM Point2D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "2ndClosestPoint2D", NickName = "2ndCPt2D", Description = "Second closest SAM Point2D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -63,9 +74,12 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
             GH_ObjectWrapper objectWrapper = null;
 
-            if (!dataAccess.GetData(0, ref objectWrapper) || objectWrapper.Value == null)
+            index = Params.IndexOfInputParam("_1stSegment2D");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -78,7 +92,8 @@ namespace SAM.Geometry.Grasshopper
                 return;
             }
 
-            if (!dataAccess.GetData(1, ref objectWrapper) || objectWrapper.Value == null)
+            index = Params.IndexOfInputParam("_2ndSegment2D");
+            if (index == -1 || !dataAccess.GetData(index, ref objectWrapper) || objectWrapper.Value == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -96,9 +111,23 @@ namespace SAM.Geometry.Grasshopper
 
             Point2D point2D_Intersection = segment2D_1.Intersection(segment2D_2, out point2D_Closest_1, out point2D_Closest_2);
 
-            dataAccess.SetData(0, point2D_Intersection);
-            dataAccess.SetData(1, point2D_Closest_1);
-            dataAccess.SetData(2, point2D_Closest_2);
+            index = Params.IndexOfOutputParam("Point2D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, point2D_Intersection);
+            }
+
+            index = Params.IndexOfOutputParam("1stClosestPoint2D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, point2D_Closest_1);
+            }
+
+            index = Params.IndexOfOutputParam("2ndClosestPoint2D");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, point2D_Closest_2);
+            }
 
             AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Cannot split segments");
         }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryShellContains.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryShellContains.cs
@@ -153,7 +153,7 @@ namespace SAM.Geometry.Grasshopper
                     silverSpacing = silverSpacing_Temp;
             }
 
-            index = Params.IndexOfInputParam("silverSpacing_");
+            index = Params.IndexOfInputParam("allowOnBoundary_");
             bool allowOnBoundary = true;
             if (index != -1)
             {

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometrySplit.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometrySplit.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 namespace SAM.Geometry.Grasshopper
 {
     [Obsolete("Obsolete since 2022.08.24")]
-    public class SAMGeometrySplit : GH_SAMComponent
+    public class SAMGeometrySplit : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -22,7 +22,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -44,20 +44,40 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddGenericParameter("_geometry", "Geo", "Geometry", GH_ParamAccess.list);
-            inputParamManager.AddNumberParameter("_tolerance_", "tolrnc", "Split Tolerance", GH_ParamAccess.item, Core.Tolerance.Distance);
-            inputParamManager.AddBooleanParameter("_run", "_run", "Run", GH_ParamAccess.item, false);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_geometry", NickName = "Geo", Description = "Geometry", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Number param_Number;
+                param_Number = new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "_tolerance_", NickName = "tolrnc", Description = "Split Tolerance", Access = GH_ParamAccess.item, Optional = true };
+                param_Number.SetPersistentData(Core.Tolerance.Distance);
+                result.Add(new GH_SAMParam(param_Number, ParamVisibility.Binding));
+
+                global::Grasshopper.Kernel.Parameters.Param_Boolean param_Boolean;
+                param_Boolean = new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "_run", NickName = "_run", Description = "Run", Access = GH_ParamAccess.item, Optional = true };
+                param_Boolean.SetPersistentData(false);
+                result.Add(new GH_SAMParam(param_Boolean, ParamVisibility.Binding));
+
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddGenericParameter("Geometry", "Geo", "modified SAM Geometry", GH_ParamAccess.list);
-            outputParamManager.AddBooleanParameter("Successful", "Successful", "Correctly imported?", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "Geometry", NickName = "Geo", Description = "modified SAM Geometry", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "Successful", NickName = "Successful", Description = "Correctly imported?", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -68,30 +88,38 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            int index_Successful = Params.IndexOfOutputParam("Successful");
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, false);
+            }
+
             bool run = false;
-            if (!dataAccess.GetData(2, ref run))
+            index = Params.IndexOfInputParam("_run");
+            if (index == -1 || !dataAccess.GetData(index, ref run))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
             if (!run)
                 return;
 
             double tolerance = Core.Tolerance.Distance;
-            if (!dataAccess.GetData(1, ref tolerance))
+            index = Params.IndexOfInputParam("_tolerance_");
+            if (index == -1 || !dataAccess.GetData(index, ref tolerance))
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(1, false);
                 return;
             }
 
             List<GH_ObjectWrapper> objectWrapperList = new List<GH_ObjectWrapper>();
 
-            if (!dataAccess.GetDataList(0, objectWrapperList) || objectWrapperList == null)
+            index = Params.IndexOfInputParam("_geometry");
+            if (index == -1 || !dataAccess.GetDataList(index, objectWrapperList) || objectWrapperList == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                dataAccess.SetData(3, false);
                 return;
             }
 
@@ -147,8 +175,16 @@ namespace SAM.Geometry.Grasshopper
                 }
             }
 
-            dataAccess.SetDataList(0, segment2Ds.Split(tolerance));
-            dataAccess.SetData(1, true);
+            index = Params.IndexOfOutputParam("Geometry");
+            if (index != -1)
+            {
+                dataAccess.SetDataList(index, segment2Ds.Split(tolerance));
+            }
+
+            if (index_Successful != -1)
+            {
+                dataAccess.SetData(index_Successful, true);
+            }
         }
     }
 }

--- a/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryTransform.cs
+++ b/Grasshopper/SAM.Geometry.Grasshopper/Component/SAMGeometryTransform.cs
@@ -5,10 +5,11 @@ using Grasshopper.Kernel;
 using SAM.Core.Grasshopper;
 using SAM.Geometry.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 
 namespace SAM.Geometry.Grasshopper
 {
-    public class SAMGeometryTransform : GH_SAMComponent
+    public class SAMGeometryTransform : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -18,7 +19,7 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.0.1";
 
         /// <summary>
         /// Initializes a new instance of the SAM_point3D class.
@@ -33,18 +34,28 @@ namespace SAM.Geometry.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooSAMGeometryParam(), "_SAMGeometry", "_SAMGeometry", "SAM Geometry", GH_ParamAccess.item);
-            inputParamManager.AddParameter(new GooTransform3DParam(), "_transform3D", "_transform3D", "SAM Transform 3D", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "_SAMGeometry", NickName = "_SAMGeometry", Description = "SAM Geometry", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new GooTransform3DParam() { Name = "_transform3D", NickName = "_transform3D", Description = "SAM Transform 3D", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddParameter(new GooSAMGeometryParam(), "SAMGeometry", "SAMGeometry", "SAM Geometry", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooSAMGeometryParam() { Name = "SAMGeometry", NickName = "SAMGeometry", Description = "SAM Geometry", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -55,15 +66,19 @@ namespace SAM.Geometry.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
+            int index = -1;
+
+            index = Params.IndexOfInputParam("_SAMGeometry");
             ISAMGeometry geometry = null;
-            if (!dataAccess.GetData(0, ref geometry) || geometry == null)
+            if (index == -1 || !dataAccess.GetData(index, ref geometry) || geometry == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
             }
 
+            index = Params.IndexOfInputParam("_transform3D");
             Spatial.Transform3D transform3D = null;
-            if (!dataAccess.GetData(1, ref transform3D) || transform3D == null)
+            if (index == -1 || !dataAccess.GetData(index, ref transform3D) || transform3D == null)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -76,7 +91,11 @@ namespace SAM.Geometry.Grasshopper
                 return;
             }
 
-            dataAccess.SetData(0, new GooSAMGeometry(geometry));
+            index = Params.IndexOfOutputParam("SAMGeometry");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, new GooSAMGeometry(geometry));
+            }
         }
 
         /// <summary>
@@ -86,11 +105,8 @@ namespace SAM.Geometry.Grasshopper
         {
             get
             {
-                //You can add image files to your project resources and access them like this:
-                // return Resources.IconForThisComponent;
                 return Resources.SAM_Geometry;
             }
         }
-
     }
 }

--- a/Grasshopper/SAM.Weather.Grasshopper/Component/SAMWeatherHourlyValue.cs
+++ b/Grasshopper/SAM.Weather.Grasshopper/Component/SAMWeatherHourlyValue.cs
@@ -5,11 +5,12 @@ using Grasshopper.Kernel;
 using SAM.Core.Grasshopper;
 using SAM.Weather.Grasshopper.Properties;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace SAM.Weather.Grasshopper
 {
-    public class SAMWeatherHourlyValue : GH_SAMComponent
+    public class SAMWeatherHourlyValue : GH_SAMVariableOutputParameterComponent
     {
         /// <summary>
         /// Gets the unique ID for this component. Do not change this ID after release.
@@ -19,7 +20,7 @@ namespace SAM.Weather.Grasshopper
         /// <summary>
         /// The latest version of this component
         /// </summary>
-        public override string LatestComponentVersion => "1.0.2";
+        public override string LatestComponentVersion => "1.0.3";
 
         /// <summary>
         /// Provides an Icon for the component.
@@ -39,19 +40,29 @@ namespace SAM.Weather.Grasshopper
         /// <summary>
         /// Registers all the input parameters for this component.
         /// </summary>
-        protected override void RegisterInputParams(GH_InputParamManager inputParamManager)
+        protected override GH_SAMParam[] Inputs
         {
-            inputParamManager.AddParameter(new GooWeatherObjectParam(), "_weatherObject", "_weatherObject", "SAM WeatherObject", GH_ParamAccess.item);
-            inputParamManager.AddGenericParameter("_weatherDataType", "_weatherDataType", "Weather Data Type", GH_ParamAccess.item);
-            inputParamManager.AddIntegerParameter("_hourOfYear", "_hourOfYear", "Hour of Year Index [0-8759]", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new GooWeatherObjectParam() { Name = "_weatherObject", NickName = "_weatherObject", Description = "SAM WeatherObject", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_GenericObject() { Name = "_weatherDataType", NickName = "_weatherDataType", Description = "Weather Data Type", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Integer() { Name = "_hourOfYear", NickName = "_hourOfYear", Description = "Hour of Year Index [0-8759]", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
         /// Registers all the output parameters for this component.
         /// </summary>
-        protected override void RegisterOutputParams(GH_OutputParamManager outputParamManager)
+        protected override GH_SAMParam[] Outputs
         {
-            outputParamManager.AddNumberParameter("value", "value", "value", GH_ParamAccess.item);
+            get
+            {
+                List<GH_SAMParam> result = new List<GH_SAMParam>();
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Number() { Name = "value", NickName = "value", Description = "value", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                return result.ToArray();
+            }
         }
 
         /// <summary>
@@ -62,22 +73,27 @@ namespace SAM.Weather.Grasshopper
         /// </param>
         protected override void SolveInstance(IGH_DataAccess dataAccess)
         {
-            IWeatherObject weatherObject = null;
-            if (!dataAccess.GetData(0, ref weatherObject) || weatherObject == null)
-            {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
-            }
-
-            WeatherDataType weatherDataType = WeatherDataType.Undefined;
-            if (!dataAccess.GetData(1, ref weatherDataType) || weatherDataType == WeatherDataType.Undefined)
-            {
-                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                return;
-            }
-
             int index = -1;
-            if (!dataAccess.GetData(2, ref index) || index == -1)
+
+            index = Params.IndexOfInputParam("_weatherObject");
+            IWeatherObject weatherObject = null;
+            if (index == -1 || !dataAccess.GetData(index, ref weatherObject) || weatherObject == null)
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                return;
+            }
+
+            index = Params.IndexOfInputParam("_weatherDataType");
+            WeatherDataType weatherDataType = WeatherDataType.Undefined;
+            if (index == -1 || !dataAccess.GetData(index, ref weatherDataType) || weatherDataType == WeatherDataType.Undefined)
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
+                return;
+            }
+
+            int hourIndex = -1;
+            index = Params.IndexOfInputParam("_hourOfYear");
+            if (index == -1 || !dataAccess.GetData(index, ref hourIndex) || hourIndex == -1)
             {
                 AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
                 return;
@@ -87,14 +103,14 @@ namespace SAM.Weather.Grasshopper
 
             if (weatherObject is WeatherYear)
             {
-                if (!((WeatherYear)weatherObject).TryGetValue(weatherDataType, index, out result))
+                if (!((WeatherYear)weatherObject).TryGetValue(weatherDataType, hourIndex, out result))
                 {
                     result = double.NaN;
                 }
             }
             else if (weatherObject is WeatherDay)
             {
-                if (!((WeatherDay)weatherObject).TryGetValue(weatherDataType, index, out result))
+                if (!((WeatherDay)weatherObject).TryGetValue(weatherDataType, hourIndex, out result))
                 {
                     result = double.NaN;
                 }
@@ -107,13 +123,17 @@ namespace SAM.Weather.Grasshopper
             {
                 WeatherYear weatherYear = ((WeatherData)weatherObject).WeatherYears?.FirstOrDefault();
 
-                if (weatherYear == null || !weatherYear.TryGetValue(weatherDataType, index, out result))
+                if (weatherYear == null || !weatherYear.TryGetValue(weatherDataType, hourIndex, out result))
                 {
                     result = double.NaN;
                 }
             }
 
-            dataAccess.SetData(0, result);
+            index = Params.IndexOfOutputParam("value");
+            if (index != -1)
+            {
+                dataAccess.SetData(index, result);
+            }
         }
     }
 }

--- a/SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs
+++ b/SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs
@@ -232,9 +232,9 @@ namespace SAM.Analytical
             return Coplanar(planarBoundary3D.plane, tolerance);
         }
 
-        public bool Coplanar(Plane plane_Other, double tolerance = Tolerance.Angle)
+        public bool Coplanar(Plane plane, double tolerance = Tolerance.Angle)
         {
-            return plane.Coplanar(plane_Other, tolerance);
+            return this.plane.Coplanar(plane, tolerance);
         }
 
         public Face3D GetFace3D()

--- a/SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs
+++ b/SAM/SAM.Analytical/Classes/PlanarBoundary3D.cs
@@ -232,9 +232,9 @@ namespace SAM.Analytical
             return Coplanar(planarBoundary3D.plane, tolerance);
         }
 
-        public bool Coplanar(Plane plane, double tolerance = Tolerance.Angle)
+        public bool Coplanar(Plane plane_Other, double tolerance = Tolerance.Angle)
         {
-            return plane.Coplanar(plane, tolerance);
+            return plane.Coplanar(plane_Other, tolerance);
         }
 
         public Face3D GetFace3D()

--- a/SAM/SAM.Analytical/Create/AnalyticalModel.cs
+++ b/SAM/SAM.Analytical/Create/AnalyticalModel.cs
@@ -440,6 +440,48 @@ namespace SAM.Analytical
             return AnalyticalModel_ByApertureConstruction(analyticalModel, apertureConstructionCase.ApertureConstruction, apertureConstructionCase.CaseSelection?.IJSAMObjects<Aperture>(analyticalModel));
         }
 
+        private static Dictionary<Guid, Panel> CreateAperturePanelMap(AdjacencyCluster adjacencyCluster)
+        {
+            List<Panel> panels = adjacencyCluster?.GetPanels();
+
+            if (panels == null || panels.Count == 0)
+            {
+                return new Dictionary<Guid, Panel>();
+            }
+
+            Dictionary<Guid, Panel> result = new Dictionary<Guid, Panel>();
+
+            foreach (Panel panel in panels)
+            {
+                if (panel == null || !panel.HasApertures)
+                {
+                    continue;
+                }
+
+                List<Aperture> apertures = panel.Apertures;
+
+                if (apertures == null)
+                {
+                    continue;
+                }
+
+                foreach (Aperture aperture in apertures)
+                {
+                    if (aperture == null)
+                    {
+                        continue;
+                    }
+
+                    if (!result.ContainsKey(aperture.Guid))
+                    {
+                        result[aperture.Guid] = panel;
+                    }
+                }
+            }
+
+            return result;
+        }
+
         public static AnalyticalModel AnalyticalModel_ByOpening(this AnalyticalModel analyticalModel,
             IEnumerable<double> openingAngles,
             IEnumerable<string> descriptions = null,
@@ -481,6 +523,8 @@ namespace SAM.Analytical
 
             adjacencyCluster = new AdjacencyCluster(adjacencyCluster, true);
 
+            Dictionary<Guid, Panel> aperturePanelMap = CreateAperturePanelMap(adjacencyCluster);
+
             //List<Aperture> apertures_Result = [];
             //List<double> dischargeCoefficients_Result = [];
             //List<IOpeningProperties> openingProperties_Result = [];
@@ -489,7 +533,7 @@ namespace SAM.Analytical
             {
                 Aperture aperture = apertures_Temp[i];
 
-                Panel panel = adjacencyCluster.GetPanel(aperture);
+                aperturePanelMap.TryGetValue(aperture.Guid, out Panel panel);
                 if (panel == null)
                 {
                     continue;
@@ -568,6 +612,20 @@ namespace SAM.Analytical
                     //apertures_Result.Add(aperture_Temp);
                     //dischargeCoefficients_Result.Add(singleOpeningProperties.GetDischargeCoefficient());
                     //openingProperties_Result.Add(singleOpeningProperties);
+
+                    // Update snapshot so later apertures on this panel
+                    // do not re-read a stale pre-update panel reference.
+                    List<Aperture> updatedApertures = panel.Apertures;
+                    if (updatedApertures != null)
+                    {
+                        foreach (Aperture updatedAp in updatedApertures)
+                        {
+                            if (updatedAp != null)
+                            {
+                                aperturePanelMap[updatedAp.Guid] = panel;
+                            }
+                        }
+                    }
                 }
             }
 

--- a/SAM/SAM.Analytical/Modify/AddApertures.cs
+++ b/SAM/SAM.Analytical/Modify/AddApertures.cs
@@ -223,6 +223,88 @@ namespace SAM.Analytical
             //return result;
         }
 
+        public static List<Aperture> AddAperturesByApertures(this AdjacencyCluster adjacencyCluster, IEnumerable<Aperture> apertures, bool trimGeometry = true, double minArea = Core.Tolerance.MacroDistance, double maxDistance = Core.Tolerance.MacroDistance, double tolerance = Core.Tolerance.Distance)
+        {
+            if (adjacencyCluster == null || apertures == null)
+                return null;
+
+            List<Panel> panels = adjacencyCluster.GetPanels();
+            if (panels == null || panels.Count == 0)
+                return null;
+
+            double max = System.Math.Max(maxDistance, tolerance);
+
+            List<Tuple<ApertureConstruction, Face3D, double[]>> tuples_Aperture = new List<Tuple<ApertureConstruction, Face3D, double[]>>();
+            foreach (Aperture aperture in apertures)
+            {
+                if (aperture == null)
+                    continue;
+
+                ApertureConstruction apertureConstruction = aperture.ApertureConstruction;
+                Face3D face3D = aperture.GetFace3D();
+                if (apertureConstruction == null || face3D == null)
+                    continue;
+
+                BoundingBox3D boundingBox3D = face3D.GetBoundingBox(max);
+                if (boundingBox3D == null)
+                    continue;
+
+                Point3D point3D_Min = boundingBox3D.Min;
+                Point3D point3D_Max = boundingBox3D.Max;
+                tuples_Aperture.Add(new Tuple<ApertureConstruction, Face3D, double[]>(apertureConstruction, face3D, new double[] { point3D_Min.X, point3D_Min.Y, point3D_Min.Z, point3D_Max.X, point3D_Max.Y, point3D_Max.Z }));
+            }
+
+            List<Aperture> result = new List<Aperture>();
+            if (tuples_Aperture.Count == 0)
+                return result;
+
+            foreach (Panel panel in panels)
+            {
+                if (panel == null || panel.PanelType == PanelType.Air)
+                    continue;
+
+                BoundingBox3D boundingBox3D_Panel = panel.GetBoundingBox(max);
+                if (boundingBox3D_Panel == null)
+                    continue;
+
+                Point3D point3D_Min = boundingBox3D_Panel.Min;
+                Point3D point3D_Max = boundingBox3D_Panel.Max;
+                double min_X = point3D_Min.X;
+                double min_Y = point3D_Min.Y;
+                double min_Z = point3D_Min.Z;
+                double max_X = point3D_Max.X;
+                double max_Y = point3D_Max.Y;
+                double max_Z = point3D_Max.Z;
+
+                Panel panel_New = null;
+                bool updated = false;
+                foreach (Tuple<ApertureConstruction, Face3D, double[]> tuple_Aperture in tuples_Aperture)
+                {
+                    double[] values = tuple_Aperture.Item3;
+
+                    if (values[3] + Core.Tolerance.Distance < min_X || values[0] - Core.Tolerance.Distance > max_X ||
+                        values[4] + Core.Tolerance.Distance < min_Y || values[1] - Core.Tolerance.Distance > max_Y ||
+                        values[5] + Core.Tolerance.Distance < min_Z || values[2] - Core.Tolerance.Distance > max_Z)
+                        continue;
+
+                    if (panel_New == null)
+                        panel_New = Create.Panel(panel);
+
+                    List<Aperture> apertures_New = AddApertures(panel_New, tuple_Aperture.Item1, tuple_Aperture.Item2, trimGeometry, minArea, maxDistance, tolerance);
+                    if (apertures_New != null && apertures_New.Count > 0)
+                    {
+                        updated = true;
+                        result.AddRange(apertures_New);
+                    }
+                }
+
+                if (updated)
+                    adjacencyCluster.AddObject(panel_New);
+            }
+
+            return result;
+        }
+
         public static List<Aperture> AddApertures(this IEnumerable<Panel> panels, ApertureConstruction apertureConstruction, double ratio, double azimuth_Start, double azimuth_End, double tolerance_Area = Core.Tolerance.MacroDistance, double tolerance = Core.Tolerance.Distance)
         {
             if (panels == null || apertureConstruction == null)

--- a/SAM/SAM.Analytical/Modify/AddApertures.cs
+++ b/SAM/SAM.Analytical/Modify/AddApertures.cs
@@ -258,6 +258,8 @@ namespace SAM.Analytical
             if (tuples_Aperture.Count == 0)
                 return result;
 
+            //Phase 1 (sequential): cheap zero-alloc AABB pre-filter -> candidate panels + their surviving aperture indexes
+            List<Tuple<Panel, List<int>>> candidates = new List<Tuple<Panel, List<int>>>();
             foreach (Panel panel in panels)
             {
                 if (panel == null || panel.PanelType == PanelType.Air)
@@ -276,30 +278,79 @@ namespace SAM.Analytical
                 double max_Y = point3D_Max.Y;
                 double max_Z = point3D_Max.Z;
 
-                Panel panel_New = null;
-                bool updated = false;
-                foreach (Tuple<ApertureConstruction, Face3D, double[]> tuple_Aperture in tuples_Aperture)
+                List<int> indexes = null;
+                for (int i = 0; i < tuples_Aperture.Count; i++)
                 {
-                    double[] values = tuple_Aperture.Item3;
+                    double[] values = tuples_Aperture[i].Item3;
 
                     if (values[3] + Core.Tolerance.Distance < min_X || values[0] - Core.Tolerance.Distance > max_X ||
                         values[4] + Core.Tolerance.Distance < min_Y || values[1] - Core.Tolerance.Distance > max_Y ||
                         values[5] + Core.Tolerance.Distance < min_Z || values[2] - Core.Tolerance.Distance > max_Z)
                         continue;
 
-                    if (panel_New == null)
-                        panel_New = Create.Panel(panel);
+                    if (indexes == null)
+                        indexes = new List<int>();
+
+                    indexes.Add(i);
+                }
+
+                if (indexes != null)
+                    candidates.Add(new Tuple<Panel, List<int>>(panel, indexes));
+            }
+
+            if (candidates.Count == 0)
+                return result;
+
+            //Phase 2: process each candidate panel (its own clone, apertures tried in input order) -
+            //parallel across panels once the candidate count justifies it (repo convention: > 30, cf. NormalDictionary.cs),
+            //otherwise sequential. Each task only reads shared state (panel, precomputed aperture Face3D/ApertureConstruction)
+            //and writes into its own pre-sized slot - no shared mutation during the parallel region.
+            Panel[] panels_New = new Panel[candidates.Count];
+            List<Aperture>[] apertures_New_ByPanel = new List<Aperture>[candidates.Count];
+
+            void ProcessCandidate(int i)
+            {
+                Tuple<Panel, List<int>> candidate = candidates[i];
+                Panel panel_New = Create.Panel(candidate.Item1);
+
+                List<Aperture> apertures_New_Panel = null;
+                foreach (int j in candidate.Item2)
+                {
+                    Tuple<ApertureConstruction, Face3D, double[]> tuple_Aperture = tuples_Aperture[j];
 
                     List<Aperture> apertures_New = AddApertures(panel_New, tuple_Aperture.Item1, tuple_Aperture.Item2, trimGeometry, minArea, maxDistance, tolerance);
                     if (apertures_New != null && apertures_New.Count > 0)
                     {
-                        updated = true;
-                        result.AddRange(apertures_New);
+                        if (apertures_New_Panel == null)
+                            apertures_New_Panel = new List<Aperture>();
+
+                        apertures_New_Panel.AddRange(apertures_New);
                     }
                 }
 
-                if (updated)
-                    adjacencyCluster.AddObject(panel_New);
+                panels_New[i] = panel_New;
+                apertures_New_ByPanel[i] = apertures_New_Panel;
+            }
+
+            if (candidates.Count > 30)
+            {
+                System.Threading.Tasks.Parallel.For(0, candidates.Count, ProcessCandidate);
+            }
+            else
+            {
+                for (int i = 0; i < candidates.Count; i++)
+                    ProcessCandidate(i);
+            }
+
+            //Phase 3 (sequential): assemble in original panel order and mutate the cluster
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                List<Aperture> apertures_New_Panel = apertures_New_ByPanel[i];
+                if (apertures_New_Panel == null || apertures_New_Panel.Count == 0)
+                    continue;
+
+                result.AddRange(apertures_New_Panel);
+                adjacencyCluster.AddObject(panels_New[i]);
             }
 
             return result;

--- a/SAM/SAM.Analytical/Modify/AddApertures.cs
+++ b/SAM/SAM.Analytical/Modify/AddApertures.cs
@@ -749,15 +749,20 @@ namespace SAM.Analytical
             if (apertureConstruction == null || closedPlanar3D == null || panel == null)
                 return null;
 
-            if (!Query.ApertureHost(panel, closedPlanar3D, minArea, maxDistance, tolerance))
-                return null;
-
             Face3D face3D = panel.GetFace3D();
             if (face3D == null)
                 return null;
 
             Plane plane = face3D.GetPlane();
             if (plane == null)
+                return null;
+
+            BoundingBox3D boundingBox3D_Panel = face3D.GetBoundingBox(System.Math.Max(maxDistance, tolerance));
+            if (boundingBox3D_Panel == null)
+                return null;
+
+            //NOTE: must be called with the UNFLIPPED plane (below) - ApertureHost expects the panel's own plane orientation
+            if (!Query.ApertureHost(panel, closedPlanar3D, plane, boundingBox3D_Panel, minArea, maxDistance, tolerance))
                 return null;
 
             Plane plane_Aperture = closedPlanar3D.GetPlane();
@@ -802,9 +807,9 @@ namespace SAM.Analytical
                 Point3D point3D_Location = Query.OpeningLocation(face3D_Aperture_New, tolerance);
 
                 Aperture aperture = new Aperture(apertureConstruction, face3D_Aperture_New, point3D_Location);
-                if (!Query.IsValid(panel, aperture))
-                    continue;
 
+                //NOTE: Query.IsValid is not called here - panel.AddAperture performs the identical
+                //check (same default tolerances) and returns false on failure, so the result is unchanged.
                 if (panel.AddAperture(aperture))
                     result.Add(aperture);
             }

--- a/SAM/SAM.Analytical/Modify/MapPanels.cs
+++ b/SAM/SAM.Analytical/Modify/MapPanels.cs
@@ -41,9 +41,14 @@ namespace SAM.Analytical
                 if (face3D == null)
                     continue;
 
+                BoundingBox3D boundingBox3D = face3D.GetBoundingBox(maxDistance);
+
                 List<Panel> panels_Panel = new List<Panel>();
                 foreach (Tuple<Point3D, Panel> tuple in tuples)
                 {
+                    if (!boundingBox3D.Inside(tuple.Item1, true, Core.Tolerance.Distance))
+                        continue;
+
                     double distance = face3D.Distance(tuple.Item1);
                     if (distance <= maxDistance)
                         panels_Panel.Add(tuple.Item2);

--- a/SAM/SAM.Analytical/Query/ApertureHost.cs
+++ b/SAM/SAM.Analytical/Query/ApertureHost.cs
@@ -10,13 +10,34 @@ namespace SAM.Analytical
     {
         public static bool ApertureHost(this Panel panel, IClosedPlanar3D closedPlanar3D, double minArea = Core.Tolerance.MacroDistance, double maxDistance = Core.Tolerance.MacroDistance, double tolerance = Core.Tolerance.Distance)
         {
-            if (closedPlanar3D == null)
+            if (panel == null || closedPlanar3D == null)
             {
                 return false;
             }
 
-            Plane plane = panel?.PlanarBoundary3D?.Plane;
+            Plane plane = panel.Plane;
             if (plane == null)
+            {
+                return false;
+            }
+
+            BoundingBox3D boundingBox3D_Panel = panel.GetBoundingBox(System.Math.Max(maxDistance, tolerance));
+            if (boundingBox3D_Panel == null)
+            {
+                return false;
+            }
+
+            return ApertureHost(panel, closedPlanar3D, plane, boundingBox3D_Panel, minArea, maxDistance, tolerance);
+        }
+
+        /// <summary>
+        /// ApertureHost overload accepting a precomputed, UNFLIPPED panel Plane and panel BoundingBox3D
+        /// (already inflated by Math.Max(maxDistance, tolerance)) to avoid recomputing them per aperture
+        /// when testing many apertures against the same panel.
+        /// </summary>
+        public static bool ApertureHost(this Panel panel, IClosedPlanar3D closedPlanar3D, Plane plane, BoundingBox3D boundingBox3D_Panel, double minArea = Core.Tolerance.MacroDistance, double maxDistance = Core.Tolerance.MacroDistance, double tolerance = Core.Tolerance.Distance)
+        {
+            if (panel == null || closedPlanar3D == null || plane == null || boundingBox3D_Panel == null)
             {
                 return false;
             }
@@ -46,12 +67,6 @@ namespace SAM.Analytical
             }
 
             double max = System.Math.Max(maxDistance, tolerance);
-
-            BoundingBox3D boundingBox3D_Panel = panel.GetBoundingBox(max);
-            if (boundingBox3D_Panel == null)
-            {
-                return false;
-            }
 
             BoundingBox3D boundingBox3D_ClosedPlanar3D = closedPlanar3D.GetBoundingBox(max);
             if (boundingBox3D_ClosedPlanar3D == null)

--- a/SAM/SAM.Geometry/Geometry/Planar/Query/Difference.cs
+++ b/SAM/SAM.Geometry/Geometry/Planar/Query/Difference.cs
@@ -162,7 +162,9 @@ namespace SAM.Geometry.Planar
                 return polygon2Ds_1.ToList().ConvertAll(x => new Polygon2D(x));
             }
 
-            int count = polygon2Ds_1.Count();
+            List<Polygon2D> polygon2Ds_1_List = polygon2Ds_1 as List<Polygon2D> ?? polygon2Ds_1.ToList();
+
+            int count = polygon2Ds_1_List.Count;
 
             if (count == 0)
             {
@@ -171,14 +173,14 @@ namespace SAM.Geometry.Planar
 
             if (count == 1)
             {
-                return Difference(polygon2Ds_1.ElementAt(0), polygon2Ds_2, tolerance);
+                return Difference(polygon2Ds_1_List[0], polygon2Ds_2, tolerance);
             }
 
             List<Polygon2D> result = new List<Polygon2D>();
 
             if (count < 10 && polygon2Ds_2.Count() < 10)
             {
-                foreach (Polygon2D polygon2D in polygon2Ds_1)
+                foreach (Polygon2D polygon2D in polygon2Ds_1_List)
                 {
                     List<Polygon2D> polygon2Ds = polygon2D?.Difference(polygon2Ds_2, tolerance);
                     if (polygon2Ds != null)
@@ -193,7 +195,7 @@ namespace SAM.Geometry.Planar
 
                 Parallel.For(0, count, (int i) =>
                 {
-                    polygon2DsList[i] = polygon2Ds_1.ElementAt(0)?.Difference(polygon2Ds_2, tolerance);
+                    polygon2DsList[i] = polygon2Ds_1_List[i]?.Difference(polygon2Ds_2, tolerance);
                 });
 
                 foreach (List<Polygon2D> polygon2Ds in polygon2DsList)

--- a/SAM/SAM.Geometry/Geometry/Spatial/Classes/BoundingBox3D.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Classes/BoundingBox3D.cs
@@ -13,6 +13,13 @@ namespace SAM.Geometry.Spatial
         private Point3D min;
         private Point3D max;
 
+        public double MinX => min?.X ?? double.NaN;
+        public double MinY => min?.Y ?? double.NaN;
+        public double MinZ => min?.Z ?? double.NaN;
+        public double MaxX => max?.X ?? double.NaN;
+        public double MaxY => max?.Y ?? double.NaN;
+        public double MaxZ => max?.Z ?? double.NaN;
+
         public BoundingBox3D(IEnumerable<Point3D> point3Ds)
         {
             double aX_Min = double.MaxValue;
@@ -59,7 +66,7 @@ namespace SAM.Geometry.Spatial
         public BoundingBox3D(Point3D point3D, double offset)
         {
             min = new Point3D(point3D.X - offset, point3D.Y - offset, point3D.Z - offset);
-            max = new Point3D(point3D.X + offset, point3D.Y + offset, point3D.Z - offset);
+            max = new Point3D(point3D.X + offset, point3D.Y + offset, point3D.Z + offset);
         }
 
         public BoundingBox3D(IEnumerable<Point3D> point3Ds, double offset)
@@ -107,14 +114,14 @@ namespace SAM.Geometry.Spatial
             foreach (BoundingBox3D boundingBox3D in boundingBox3Ds)
             {
                 if (min == null)
-                    min = new Point3D(boundingBox3D.Min);
+                    min = new Point3D(boundingBox3D.min);
                 else
-                    min = Query.Min(boundingBox3D.Min, min);
+                    min = Query.Min(boundingBox3D.min, min);
 
                 if (max == null)
-                    max = new Point3D(boundingBox3D.Max);
+                    max = new Point3D(boundingBox3D.max);
                 else
-                    max = Query.Max(boundingBox3D.Max, max);
+                    max = Query.Max(boundingBox3D.max, max);
             }
         }
         public BoundingBox3D(JsonObject jsonObject)
@@ -178,7 +185,6 @@ namespace SAM.Geometry.Spatial
                         }
                     }
                 }
-                return true;
             }
 
             return false;
@@ -337,7 +343,6 @@ namespace SAM.Geometry.Spatial
             result.Add(new Segment3D(new Point3D(min), new Point3D(min.X, min.Y, min.Z + z)));
             result.Add(new Segment3D(new Point3D(min.X + x, min.Y, min.Z), new Point3D(min.X + x, min.Y, min.Z + z)));
             result.Add(new Segment3D(new Point3D(min.X + x, min.Y + y, min.Z), new Point3D(min.X + x, min.Y + y, min.Z + z)));
-            result.Add(new Segment3D(new Point3D(min.X + x, min.Y + y, min.Z), new Point3D(min.X + x, min.Y + y, min.Z + z)));
             result.Add(new Segment3D(new Point3D(min.X, min.Y + y, min.Z), new Point3D(min.X, min.Y + y, min.Z + z)));
             return result;
         }
@@ -350,14 +355,14 @@ namespace SAM.Geometry.Spatial
 
             List<Point3D> point3Ds = new List<Point3D>();
             point3Ds.Add(new Point3D(min));
-            point3Ds.Add(new Point3D(min.X + x, min.Y, Min.Z));
-            point3Ds.Add(new Point3D(min.X + x, min.Y + y, Min.Z));
-            point3Ds.Add(new Point3D(min.X, min.Y + y, Min.Z));
+            point3Ds.Add(new Point3D(min.X + x, min.Y, min.Z));
+            point3Ds.Add(new Point3D(min.X + x, min.Y + y, min.Z));
+            point3Ds.Add(new Point3D(min.X, min.Y + y, min.Z));
 
+            point3Ds.Add(new Point3D(min.X, min.Y, max.Z));
+            point3Ds.Add(new Point3D(min.X + x, min.Y, max.Z));
             point3Ds.Add(new Point3D(max));
-            point3Ds.Add(new Point3D(max.X + x, max.Y, max.Z));
-            point3Ds.Add(new Point3D(max.X + x, max.Y + y, max.Z));
-            point3Ds.Add(new Point3D(max.X, max.Y + y, max.Z));
+            point3Ds.Add(new Point3D(min.X, min.Y + y, max.Z));
 
             return point3Ds;
         }
@@ -483,7 +488,13 @@ namespace SAM.Geometry.Spatial
 
         public override int GetHashCode()
         {
-            return new Tuple<Point3D, Point3D>(min, max).GetHashCode();
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 23 + (min?.GetHashCode() ?? 0);
+                hash = hash * 23 + (max?.GetHashCode() ?? 0);
+                return hash;
+            }
         }
 
         public static bool operator ==(BoundingBox3D boundingBox3D_1, BoundingBox3D boundingBox3D_2)

--- a/SAM/SAM.Geometry/Geometry/Spatial/Create/Point3Ds.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Create/Point3Ds.cs
@@ -24,11 +24,21 @@ namespace SAM.Geometry.Spatial
 
         public static List<Point3D> Point3Ds(this BoundingBox3D boundingBox3D, double offset)
         {
+            if (boundingBox3D == null)
+                return null;
+
+            if (offset <= 0)
+                throw new System.ArgumentOutOfRangeException(nameof(offset), "Offset must be greater than zero.");
+
             List<Point3D> result = new List<Point3D>();
 
             double width = boundingBox3D.Width;
             double height = boundingBox3D.Height;
             double depth = boundingBox3D.Depth;
+
+            double minX = boundingBox3D.MinX;
+            double minY = boundingBox3D.MinY;
+            double minZ = boundingBox3D.MinZ;
 
             double distance_Width = 0;
             while (distance_Width <= width)
@@ -39,7 +49,7 @@ namespace SAM.Geometry.Spatial
                     double distance_Depth = 0;
                     while (distance_Depth <= depth)
                     {
-                        result.Add(new Point3D(boundingBox3D.Min.X + distance_Width, boundingBox3D.Min.Y + distance_Depth, boundingBox3D.Min.Z + distance_Height));
+                        result.Add(new Point3D(minX + distance_Width, minY + distance_Depth, minZ + distance_Height));
                         distance_Depth += offset;
                     }
                     distance_Height += offset;

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/InRange.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/InRange.cs
@@ -35,33 +35,33 @@ namespace SAM.Geometry.Spatial
             double max_2;
             double min_2;
 
-            max_1 = boundingBox3D_1.Max.X + tolerance;
-            min_1 = boundingBox3D_1.Min.X - tolerance;
+            max_1 = boundingBox3D_1.MaxX + tolerance;
+            min_1 = boundingBox3D_1.MinX - tolerance;
 
-            max_2 = boundingBox3D_2.Max.X;
-            min_2 = boundingBox3D_2.Min.X;
-
-            if (max_1 < min_2 || min_1 > max_2)
-            {
-                return false;
-            }
-
-            max_1 = boundingBox3D_1.Max.Y + tolerance;
-            min_1 = boundingBox3D_1.Min.Y - tolerance;
-
-            max_2 = boundingBox3D_2.Max.Y;
-            min_2 = boundingBox3D_2.Min.Y;
+            max_2 = boundingBox3D_2.MaxX;
+            min_2 = boundingBox3D_2.MinX;
 
             if (max_1 < min_2 || min_1 > max_2)
             {
                 return false;
             }
 
-            max_1 = boundingBox3D_1.Max.Z + tolerance;
-            min_1 = boundingBox3D_1.Min.Z - tolerance;
+            max_1 = boundingBox3D_1.MaxY + tolerance;
+            min_1 = boundingBox3D_1.MinY - tolerance;
 
-            max_2 = boundingBox3D_2.Max.Z;
-            min_2 = boundingBox3D_2.Min.Z;
+            max_2 = boundingBox3D_2.MaxY;
+            min_2 = boundingBox3D_2.MinY;
+
+            if (max_1 < min_2 || min_1 > max_2)
+            {
+                return false;
+            }
+
+            max_1 = boundingBox3D_1.MaxZ + tolerance;
+            min_1 = boundingBox3D_1.MinZ - tolerance;
+
+            max_2 = boundingBox3D_2.MaxZ;
+            min_2 = boundingBox3D_2.MinZ;
 
             if (max_1 < min_2 || min_1 > max_2)
             {

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/IsValid.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/IsValid.cs
@@ -18,7 +18,7 @@ namespace SAM.Geometry.Spatial
             double y = vector3D.Y;
             double z = vector3D.Z;
 
-            if (double.IsNaN(x) || double.IsNaN(x) || double.IsNaN(x))
+            if (double.IsNaN(x) || double.IsNaN(y) || double.IsNaN(z))
             {
                 return false;
             }
@@ -40,7 +40,7 @@ namespace SAM.Geometry.Spatial
             double y = point3D.Y;
             double z = point3D.Z;
 
-            if (double.IsNaN(x) || double.IsNaN(x) || double.IsNaN(x))
+            if (double.IsNaN(x) || double.IsNaN(y) || double.IsNaN(z))
                 return false;
 
             return true;
@@ -108,17 +108,20 @@ namespace SAM.Geometry.Spatial
                 return false;
             }
 
-            if (!IsValid(boundingBox3D.Min))
+            double minX = boundingBox3D.MinX;
+            double minY = boundingBox3D.MinY;
+            double minZ = boundingBox3D.MinZ;
+            double maxX = boundingBox3D.MaxX;
+            double maxY = boundingBox3D.MaxY;
+            double maxZ = boundingBox3D.MaxZ;
+
+            if (double.IsNaN(minX) || double.IsNaN(minY) || double.IsNaN(minZ) ||
+                double.IsNaN(maxX) || double.IsNaN(maxY) || double.IsNaN(maxZ))
             {
                 return false;
             }
 
-            if (!IsValid(boundingBox3D.Max))
-            {
-                return false;
-            }
-
-            if (boundingBox3D.Min.Equals(boundingBox3D.Max))
+            if (minX == maxX && minY == maxY && minZ == maxZ)
             {
                 return false;
             }

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Range.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Range.cs
@@ -14,7 +14,9 @@ namespace SAM.Geometry.Spatial
                 return null;
             }
 
-            return new Range<double>(boundingBox3D.Min[dimensionIndex], boundingBox3D.Max[dimensionIndex]);
+            double min = dimensionIndex == 0 ? boundingBox3D.MinX : (dimensionIndex == 1 ? boundingBox3D.MinY : boundingBox3D.MinZ);
+            double max = dimensionIndex == 0 ? boundingBox3D.MaxX : (dimensionIndex == 1 ? boundingBox3D.MaxY : boundingBox3D.MaxZ);
+            return new Range<double>(min, max);
         }
     }
 }

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Transform.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Transform.cs
@@ -302,7 +302,9 @@ namespace SAM.Geometry.Spatial
             if (boundingBox3D == null || matrix4D == null)
                 return null;
 
-            return new BoundingBox3D(boundingBox3D.Min.Transform(matrix4D), boundingBox3D.Max.Transform(matrix4D));
+            List<Point3D> corners = boundingBox3D.GetPoints();
+            List<Point3D> transformedCorners = corners.ConvertAll(pt => pt.Transform(matrix4D));
+            return new BoundingBox3D(transformedCorners);
         }
 
         public static Point3D Transform(this Point3D point3D, Matrix4D matrix4D)

--- a/SAM/SAM.Tests/AnalyticalPanelTests.cs
+++ b/SAM/SAM.Tests/AnalyticalPanelTests.cs
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using SAM.Analytical;
+using SAM.Core;
+using SAM.Geometry.Spatial;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+using AnalyticalCreate = SAM.Analytical.Create;
+
+namespace SAM.Tests
+{
+    public class AnalyticalPanelTests
+    {
+        private static Construction CreateTestConstruction(string name)
+        {
+            return new Construction(Guid.NewGuid(), name);
+        }
+
+        private static ApertureConstruction CreateTestApertureConstruction(string name)
+        {
+            return new ApertureConstruction(Guid.NewGuid(), name, ApertureType.Window);
+        }
+
+        private static Face3D CreateTestFace3D(double x = 0, double y = 0, double width = 10, double height = 10)
+        {
+            Point3D origin = new Point3D(x, y, 0);
+            Point3D p2 = new Point3D(x + width, y, 0);
+            Point3D p3 = new Point3D(x + width, y + height, 0);
+            Point3D p4 = new Point3D(x, y + height, 0);
+            return new Face3D(new Polygon3D(new Point3D[] { origin, p2, p3, p4 }));
+        }
+
+        private static Panel CreateTestPanel(Construction construction, PanelType panelType, double x = 0, double y = 0)
+        {
+            Face3D face3D = CreateTestFace3D(x, y);
+            return AnalyticalCreate.Panel(construction, panelType, face3D);
+        }
+
+        [Fact]
+        public void GetPanels_ByConstruction_ReturnsMatchingPanels()
+        {
+            Construction wallConstruction = CreateTestConstruction("External Wall");
+            Construction roofConstruction = CreateTestConstruction("Flat Roof");
+
+            Panel wall = CreateTestPanel(wallConstruction, PanelType.Wall);
+            Panel roof = CreateTestPanel(roofConstruction, PanelType.Roof);
+
+            AdjacencyCluster adjacencyCluster = new AdjacencyCluster();
+            adjacencyCluster.AddObject(wall);
+            adjacencyCluster.AddObject(roof);
+
+            List<Panel> wallPanels = adjacencyCluster.GetPanels(wallConstruction);
+            List<Panel> roofPanels = adjacencyCluster.GetPanels(roofConstruction);
+
+            Assert.Single(wallPanels);
+            Assert.Single(roofPanels);
+            Assert.Equal(wallConstruction.Guid, wallPanels[0].TypeGuid);
+            Assert.Equal(roofConstruction.Guid, roofPanels[0].TypeGuid);
+        }
+
+        [Fact]
+        public void GetPanels_ByConstruction_NoMatchReturnsEmpty()
+        {
+            Construction wallConstruction = CreateTestConstruction("External Wall");
+            Construction unknownConstruction = CreateTestConstruction("Unknown");
+
+            Panel wall = CreateTestPanel(wallConstruction, PanelType.Wall);
+
+            AdjacencyCluster adjacencyCluster = new AdjacencyCluster();
+            adjacencyCluster.AddObject(wall);
+
+            List<Panel> panels = adjacencyCluster.GetPanels(unknownConstruction);
+
+            Assert.NotNull(panels);
+            Assert.Empty(panels);
+        }
+
+        [Fact]
+        public void GetPanel_ByAperture_ReturnsParentPanel()
+        {
+            Construction wallConstruction = CreateTestConstruction("External Wall");
+            ApertureConstruction windowConstruction = CreateTestApertureConstruction("Window");
+
+            Panel wall = CreateTestPanel(wallConstruction, PanelType.Wall);
+
+            Face3D apertureFace = new Face3D(new Polygon3D(new Point3D[]
+            {
+                new Point3D(3, 3, 0),
+                new Point3D(5, 3, 0),
+                new Point3D(5, 5, 0),
+                new Point3D(3, 5, 0)
+            }));
+
+            Aperture window = AnalyticalCreate.Aperture(windowConstruction, apertureFace);
+            wall.AddAperture(window);
+
+            AdjacencyCluster adjacencyCluster = new AdjacencyCluster();
+            adjacencyCluster.AddObject(wall);
+
+            Panel foundPanel = adjacencyCluster.GetPanel(window);
+
+            Assert.NotNull(foundPanel);
+            Assert.Equal(wall.Guid, foundPanel.Guid);
+            Assert.True(foundPanel.HasAperture(window.Guid));
+        }
+
+        [Fact]
+        public void GetPanels_ByApertureConstruction_ReturnsMatchingPanels()
+        {
+            Construction wallConstruction = CreateTestConstruction("External Wall");
+            ApertureConstruction windowConstruction = CreateTestApertureConstruction("Window");
+            ApertureConstruction doorConstruction = CreateTestApertureConstruction("Door");
+
+            Panel panelWithWindow = CreateTestPanel(wallConstruction, PanelType.Wall);
+            Panel panelWithDoor = CreateTestPanel(wallConstruction, PanelType.Wall, x: 15, y: 0);
+
+            Face3D windowFace = new Face3D(new Polygon3D(new Point3D[]
+            {
+                new Point3D(3, 3, 0), new Point3D(5, 3, 0),
+                new Point3D(5, 5, 0), new Point3D(3, 5, 0)
+            }));
+            Aperture window = AnalyticalCreate.Aperture(windowConstruction, windowFace);
+            panelWithWindow.AddAperture(window);
+
+            Face3D doorFace = new Face3D(new Polygon3D(new Point3D[]
+            {
+                new Point3D(17, 0, 0), new Point3D(19, 0, 0),
+                new Point3D(19, 8, 0), new Point3D(17, 8, 0)
+            }));
+            Aperture door = AnalyticalCreate.Aperture(doorConstruction, doorFace);
+            panelWithDoor.AddAperture(door);
+
+            AdjacencyCluster adjacencyCluster = new AdjacencyCluster();
+            adjacencyCluster.AddObject(panelWithWindow);
+            adjacencyCluster.AddObject(panelWithDoor);
+
+            List<Panel> panelsWithWindows = adjacencyCluster.GetPanels(windowConstruction);
+            List<Panel> panelsWithDoors = adjacencyCluster.GetPanels(doorConstruction);
+
+            Assert.Single(panelsWithWindows);
+            Assert.Single(panelsWithDoors);
+            Assert.Equal(panelWithWindow.Guid, panelsWithWindows[0].Guid);
+            Assert.Equal(panelWithDoor.Guid, panelsWithDoors[0].Guid);
+        }
+
+        [Fact]
+        public void GetPanels_ByConstruction_FromPanelsAndCluster()
+        {
+            Construction wallConstruction = CreateTestConstruction("External Wall");
+            Construction roofConstruction = CreateTestConstruction("Flat Roof");
+
+            Panel wallInCluster = CreateTestPanel(wallConstruction, PanelType.Wall);
+            Panel roofInCluster = CreateTestPanel(roofConstruction, PanelType.Roof, x: 0, y: 15);
+            Panel wallDirect = CreateTestPanel(wallConstruction, PanelType.Wall, x: 15, y: 0);
+
+            AdjacencyCluster adjacencyCluster = new AdjacencyCluster();
+            adjacencyCluster.AddObject(wallInCluster);
+            adjacencyCluster.AddObject(roofInCluster);
+
+            List<Panel> allPanels = new List<Panel>();
+            allPanels.AddRange(adjacencyCluster.GetPanels());
+            allPanels.Add(wallDirect);
+
+            List<Panel> wallPanels = allPanels.FindAll(x => x.TypeGuid == wallConstruction.Guid);
+            List<Panel> roofPanels = allPanels.FindAll(x => x.TypeGuid == roofConstruction.Guid);
+
+            Assert.Equal(3, allPanels.Count);
+            Assert.Equal(2, wallPanels.Count);
+            Assert.Single(roofPanels);
+        }
+
+        [Fact]
+        public void FilterPanels_ByAperture_DirectListFindParent()
+        {
+            Construction wallConstruction = CreateTestConstruction("External Wall");
+            ApertureConstruction windowConstruction = CreateTestApertureConstruction("Window");
+
+            Panel wall = CreateTestPanel(wallConstruction, PanelType.Wall);
+
+            Face3D apertureFace = new Face3D(new Polygon3D(new Point3D[]
+            {
+                new Point3D(3, 3, 0), new Point3D(5, 3, 0),
+                new Point3D(5, 5, 0), new Point3D(3, 5, 0)
+            }));
+            Aperture window = AnalyticalCreate.Aperture(windowConstruction, apertureFace);
+            wall.AddAperture(window);
+
+            List<Panel> panels = new List<Panel> { wall };
+
+            Panel foundPanel = panels.Find(x => x.HasAperture(window.Guid));
+
+            Assert.NotNull(foundPanel);
+            Assert.Equal(wall.Guid, foundPanel.Guid);
+        }
+
+        [Fact]
+        public void CreatePanel_DeepClones_IndependentInstances()
+        {
+            Construction wallConstruction = CreateTestConstruction("External Wall");
+            Panel original = CreateTestPanel(wallConstruction, PanelType.Wall);
+
+            Panel clone = AnalyticalCreate.Panel(original);
+
+            Assert.NotNull(clone);
+            Assert.Equal(original.TypeGuid, clone.TypeGuid);
+            Assert.Equal(original.PanelType, clone.PanelType);
+            Assert.NotSame(original, clone);
+            Assert.NotNull(clone.Face3D);
+        }
+
+        [Fact]
+        public void GetPanels_PointInsideFace_ReturnsMatchingPanel()
+        {
+            Construction wallConstruction = CreateTestConstruction("External Wall");
+            Panel panel = CreateTestPanel(wallConstruction, PanelType.Wall, x: 0, y: 0);
+
+            AdjacencyCluster adjacencyCluster = new AdjacencyCluster();
+            adjacencyCluster.AddObject(panel);
+
+            Point3D pointInside = new Point3D(5, 5, 0);
+            Point3D pointOutside = new Point3D(15, 15, 0);
+
+            List<Panel> allPanels = adjacencyCluster.GetPanels();
+
+            bool foundInside = false;
+            bool foundOutside = false;
+
+            foreach (Panel p in allPanels)
+            {
+                Face3D face3D = p.Face3D;
+                if (face3D == null)
+                    continue;
+
+                if (face3D.Inside(pointInside, Tolerance.MacroDistance) || face3D.InRange(pointInside, Tolerance.MacroDistance))
+                    foundInside = true;
+
+                if (face3D.Inside(pointOutside, Tolerance.MacroDistance) || face3D.InRange(pointOutside, Tolerance.MacroDistance))
+                    foundOutside = true;
+            }
+
+            Assert.True(foundInside);
+            Assert.False(foundOutside);
+        }
+
+        [Fact]
+        public void GetPanels_Face3DInside_ReturnsMatchingPanel()
+        {
+            Construction wallConstruction = CreateTestConstruction("External Wall");
+            Panel largePanel = CreateTestPanel(wallConstruction, PanelType.Wall, x: 0, y: 0);
+
+            AdjacencyCluster adjacencyCluster = new AdjacencyCluster();
+            adjacencyCluster.AddObject(largePanel);
+
+            Face3D smallFaceInside = CreateTestFace3D(x: 2, y: 2, width: 4, height: 4);
+            Face3D faceOutside = CreateTestFace3D(x: 20, y: 20, width: 4, height: 4);
+
+            List<Panel> allPanels = adjacencyCluster.GetPanels();
+
+            Assert.False(allPanels[0].Face3D.Inside(faceOutside)); // assuming face outside is not inside panel
+        }
+    }
+}

--- a/SAM/SAM.Tests/AperturePanelMapTests.cs
+++ b/SAM/SAM.Tests/AperturePanelMapTests.cs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using SAM.Analytical;
+using SAM.Core;
+using SAM.Geometry.Planar;
+using SAM.Geometry.Spatial;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using AnalyticalCreate = SAM.Analytical.Create;
+
+namespace SAM.Tests
+{
+    /// <summary>
+    /// Correctness tests for the operation-local aperture-panel snapshot map
+    /// used in AnalyticalModel_ByOpeningProperties.
+    /// </summary>
+    public class ApertureSnapshotTests
+    {
+        private static readonly Construction wallCons = new Construction(Guid.NewGuid(), "Wall");
+        private static readonly ApertureConstruction windowCons = new ApertureConstruction(Guid.NewGuid(), "Window", ApertureType.Window);
+        private static Point3D P(double x, double y, double z) => new Point3D(x, y, z);
+
+        // ---- snapshot builder (matches production helper) ----
+
+        private static Dictionary<Guid, Panel> BuildMap(AdjacencyCluster cluster)
+        {
+            List<Panel> panels = cluster?.GetPanels();
+            var result = new Dictionary<Guid, Panel>();
+            if (panels == null) return result;
+
+            foreach (Panel panel in panels)
+            {
+                if (panel == null || !panel.HasApertures) continue;
+                List<Aperture> apertures = panel.Apertures;
+                if (apertures == null) continue;
+                foreach (Aperture ap in apertures)
+                {
+                    if (ap != null && !result.ContainsKey(ap.Guid))
+                        result.Add(ap.Guid, panel);
+                }
+            }
+            return result;
+        }
+
+        private static AdjacencyCluster BuildCluster(int panelCount, int apPerPanel)
+        {
+            var c = new AdjacencyCluster();
+            for (int i = 0; i < panelCount; i++)
+            {
+                var f = new Face3D(new Polygon3D(new[]
+                    { P(i * 12.0, 0, 0), P(i * 12.0 + 10, 0, 0), P(i * 12.0 + 10, 10, 0), P(i * 12.0, 10, 0) }));
+                Panel p = AnalyticalCreate.Panel(wallCons, PanelType.Wall, f);
+                for (int j = 0; j < apPerPanel; j++)
+                {
+                    double ax = i * 12.0 + 1 + j * 3.5, ay = 1 + j * 3.5;
+                    var af = new Face3D(new Polygon3D(new[]
+                        { P(ax, ay, 0), P(ax + 2, ay, 0), P(ax + 2, ay + 2, 0), P(ax, ay + 2, 0) }));
+                    p.AddAperture(AnalyticalCreate.Aperture(windowCons, af));
+                }
+                c.AddObject(p);
+            }
+            return c;
+        }
+
+        // ---- tests ----
+
+        [Fact]
+        public void NullApertureCollection_EmptyMap()
+        {
+            var c = new AdjacencyCluster();
+            c.AddObject(AnalyticalCreate.Panel(wallCons, PanelType.Wall,
+                new Face3D(new Polygon3D(new[] { P(0, 0, 0), P(10, 0, 0), P(10, 10, 0), P(0, 10, 0) }))));
+            Assert.Empty(BuildMap(c));
+        }
+
+        [Fact]
+        public void GhostAperture_NotFound()
+        {
+            var c = BuildCluster(10, 1);
+            var ghost = AnalyticalCreate.Aperture(windowCons, new Face3D(new Polygon3D(new[]
+                { P(999, 999, 0), P(1001, 999, 0), P(1001, 1001, 0), P(999, 1001, 0) })));
+            Assert.Null(c.GetPanel(ghost));
+            Assert.False(BuildMap(c).ContainsKey(ghost.Guid));
+        }
+
+        [Fact]
+        public void FirstMatchWins_AllAperturesMatch()
+        {
+            var c = BuildCluster(100, 1);
+            var map = BuildMap(c);
+            foreach (var ap in c.GetApertures())
+            {
+                Panel prod = c.GetPanel(ap);
+                Assert.True(map.TryGetValue(ap.Guid, out Panel sp));
+                Assert.Equal(prod.Guid, sp.Guid);
+            }
+        }
+
+        [Fact]
+        public void DupGuid_SingleApertureOnOnePanel()
+        {
+            var c = new AdjacencyCluster();
+            Panel p1 = AnalyticalCreate.Panel(wallCons, PanelType.Wall,
+                new Face3D(new Polygon3D(new[] { P(0, 0, 0), P(10, 0, 0), P(10, 10, 0), P(0, 10, 0) })));
+            Panel p2 = AnalyticalCreate.Panel(wallCons, PanelType.Wall,
+                new Face3D(new Polygon3D(new[] { P(20, 0, 0), P(30, 0, 0), P(30, 10, 0), P(20, 10, 0) })));
+            var ap = AnalyticalCreate.Aperture(windowCons,
+                new Face3D(new Polygon3D(new[] { P(2, 2, 0), P(4, 2, 0), P(4, 4, 0), P(2, 4, 0) })));
+            p1.AddAperture(ap); c.AddObject(p1); c.AddObject(p2);
+            Panel prod = c.GetPanel(ap);
+            var map = BuildMap(c);
+            Assert.True(map.TryGetValue(ap.Guid, out Panel sp));
+            Assert.Equal(prod.Guid, sp.Guid);
+        }
+
+        [Fact]
+        public void InOperation_MutationDoesNotInvalidate()
+        {
+            var c = new AdjacencyCluster();
+            var f1 = new Face3D(new Polygon3D(new[] { P(0, 0, 0), P(10, 0, 0), P(10, 10, 0), P(0, 10, 0) }));
+            var af = new Face3D(new Polygon3D(new[] { P(2, 2, 0), P(4, 2, 0), P(4, 4, 0), P(2, 4, 0) }));
+            Panel panel = AnalyticalCreate.Panel(wallCons, PanelType.Wall, f1);
+            Aperture ap = AnalyticalCreate.Aperture(windowCons, af);
+            panel.AddAperture(ap); c.AddObject(panel);
+            var map = BuildMap(c);
+            Assert.True(map.TryGetValue(ap.Guid, out Panel before));
+            Assert.Equal(panel.Guid, before.Guid);
+            // simulate AnalyticalModel_ByOpeningProperties mutations
+            panel.RemoveAperture(ap.Guid);
+            panel.AddAperture(AnalyticalCreate.Aperture(windowCons,
+                new Face3D(new Polygon3D(new[] { P(2, 2, 0), P(4, 2, 0), P(4, 4, 0), P(2, 4, 0) }))));
+            c.AddObject(panel);
+            Assert.True(map.TryGetValue(ap.Guid, out Panel after));
+            Assert.Equal(panel.Guid, after.Guid);
+        }
+
+        [Fact]
+        public void MultipleAperturesOnOnePanel_AllMatch()
+        {
+            var c = BuildCluster(5, 4);
+            var map = BuildMap(c);
+            foreach (var ap in c.GetApertures())
+            {
+                Panel prod = c.GetPanel(ap);
+                Assert.True(map.TryGetValue(ap.Guid, out Panel sp));
+                Assert.Equal(prod.Guid, sp.Guid);
+            }
+        }
+
+        [Fact]
+        public void MultipleAperturesOnSamePanel_PreservesEarlierUpdates()
+        {
+            // Simulate two apertures on one panel — after processing the
+            // first, the snapshot must be updated so the second iteration
+            // sees apertures added in the first iteration.
+
+            var c = new AdjacencyCluster();
+            var f1 = new Face3D(new Polygon3D(new[]
+                { P(0, 0, 0), P(10, 0, 0), P(10, 10, 0), P(0, 10, 0) }));
+            Panel panel = AnalyticalCreate.Panel(wallCons, PanelType.Wall, f1);
+            Aperture ap1 = AnalyticalCreate.Aperture(windowCons,
+                new Face3D(new Polygon3D(new[]
+                    { P(1, 1, 0), P(3, 1, 0), P(3, 3, 0), P(1, 3, 0) })));
+            Aperture ap2 = AnalyticalCreate.Aperture(windowCons,
+                new Face3D(new Polygon3D(new[]
+                    { P(5, 5, 0), P(7, 5, 0), P(7, 7, 0), P(5, 7, 0) })));
+            panel.AddAperture(ap1);
+            panel.AddAperture(ap2);
+            c.AddObject(panel);
+
+            var map = BuildMap(c);
+
+            // Iteration 1: process ap1
+            Assert.True(map.TryGetValue(ap1.Guid, out Panel p1));
+
+            // Clone panel, remove ap1, add newAp1 (as production does)
+            Panel cloned = AnalyticalCreate.Panel(p1.Guid, p1, p1.GetFace3D(), null);
+            // Manually set up the apertures to match production behaviour
+            cloned.RemoveAperture(ap1.Guid);
+            cloned.RemoveAperture(ap2.Guid);  // temporarily remove
+            Aperture newAp1 = AnalyticalCreate.Aperture(windowCons,
+                new Face3D(new Polygon3D(new[]
+                    { P(1, 1, 0), P(3, 1, 0), P(3, 3, 0), P(1, 3, 0) })));
+            cloned.AddAperture(newAp1);
+            cloned.AddAperture(ap2);  // re-add ap2
+            c.AddObject(cloned);
+
+            // Update snapshot (as production now does)
+            List<Aperture> aps = cloned.Apertures;
+            if (aps != null)
+                foreach (Aperture a in aps)
+                    if (a != null) map[a.Guid] = cloned;
+
+            // Iteration 2: lookup ap2 — must see cloned panel with newAp1
+            Assert.True(map.TryGetValue(ap2.Guid, out Panel p2));
+            Assert.True(p2.HasAperture(newAp1.Guid));
+            Assert.True(p2.HasAperture(ap2.Guid));
+            Assert.False(p2.HasAperture(ap1.Guid));
+        }
+
+        [Fact]
+        public void FullLoopEquivalence_AllConfigurations()
+        {
+            foreach (var (pc, apc) in new[] { (10, 0), (10, 1), (100, 2), (100, 4), (50, 1) })
+            {
+                var c = BuildCluster(pc, apc);
+                var aps = c.GetApertures();
+                var map = BuildMap(c);
+                int mismatches = 0;
+                for (int i = 0; i < aps.Count; i++)
+                {
+                    Panel prod = c.GetPanel(aps[i]);
+                    bool found = map.TryGetValue(aps[i].Guid, out Panel sp);
+                    if (prod == null && !found) continue;
+                    if (prod != null && found && prod.Guid == sp.Guid) continue;
+                    mismatches++;
+                }
+                Assert.Equal(0, mismatches);
+            }
+        }
+
+        [Fact]
+        public void DeepClonedInput_ApertureGuidsMatch()
+        {
+            var c1 = BuildCluster(100, 3);
+            var clones = c1.GetPanels().Select(p =>
+                AnalyticalCreate.Panel(p.Guid, p, p.GetFace3D(), p.Apertures)).ToList();
+            var c2 = new AdjacencyCluster();
+            clones.ForEach(p => c2.AddObject(p));
+            var map2 = BuildMap(c2);
+            foreach (var ap1 in c1.GetApertures())
+            {
+                Panel p1 = c1.GetPanel(ap1);
+                if (p1 == null) continue;
+                Assert.True(map2.TryGetValue(ap1.Guid, out _),
+                    $"Cloned aperture {ap1.Guid} not found");
+            }
+        }
+    }
+}

--- a/SAM/SAM.Tests/BoundingBox3DTests.cs
+++ b/SAM/SAM.Tests/BoundingBox3DTests.cs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using System;
+using System.Collections.Generic;
+using SAM.Geometry.Spatial;
+using SAM.Math;
+using Xunit;
+
+namespace SAM.Tests
+{
+    public class BoundingBox3DTests
+    {
+        [Fact]
+        public void Constructor_WithOffset_ShouldNotBeFlatZ()
+        {
+            Point3D center = new Point3D(10, 20, 30);
+            double offset = 5;
+            BoundingBox3D bbox = new BoundingBox3D(center, offset);
+
+            Assert.Equal(5, bbox.MinX);
+            Assert.Equal(15, bbox.MaxX);
+            Assert.Equal(15, bbox.MinY);
+            Assert.Equal(25, bbox.MaxY);
+            Assert.Equal(25, bbox.MinZ);
+            Assert.Equal(35, bbox.MaxZ);
+
+            Assert.Equal(10, bbox.Width);
+            Assert.Equal(10, bbox.Depth);
+            Assert.Equal(10, bbox.Height);
+        }
+
+        [Fact]
+        public void IsValid_WithNaNCoordinates_ShouldReturnFalse()
+        {
+            // Vector3D NaN checks
+            Assert.False(new Vector3D(double.NaN, 0, 0).IsValid());
+            Assert.False(new Vector3D(0, double.NaN, 0).IsValid());
+            Assert.False(new Vector3D(0, 0, double.NaN).IsValid());
+
+            // Point3D NaN checks
+            Assert.False(Query.IsValid(new Point3D(double.NaN, 0, 0)));
+            Assert.False(Query.IsValid(new Point3D(0, double.NaN, 0)));
+            Assert.False(Query.IsValid(new Point3D(0, 0, double.NaN)));
+
+            // BoundingBox3D NaN checks
+            BoundingBox3D validBox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 1, 1));
+            Assert.True(validBox.IsValid());
+
+            BoundingBox3D invalidBoxX = new BoundingBox3D(new Point3D(double.NaN, 0, 0), new Point3D(1, 1, 1));
+            Assert.False(invalidBoxX.IsValid());
+
+            BoundingBox3D invalidBoxY = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, double.NaN, 1));
+            Assert.False(invalidBoxY.IsValid());
+
+            BoundingBox3D invalidBoxZ = new BoundingBox3D(new Point3D(0, 0, double.NaN), new Point3D(1, 1, 1));
+            Assert.False(invalidBoxZ.IsValid());
+        }
+
+        [Fact]
+        public void GetSegments_ShouldReturnExactly12Segments()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 2, 3));
+            List<Segment3D> segments = bbox.GetSegments();
+
+            Assert.Equal(12, segments.Count);
+        }
+
+        [Fact]
+        public void GetPoints_ShouldReturnActual8Corners()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 2, 3));
+            List<Point3D> points = bbox.GetPoints();
+
+            Assert.Equal(8, points.Count);
+
+            // Verify all points are within [0,1], [0,2], [0,3] bounds
+            foreach (Point3D pt in points)
+            {
+                Assert.True(pt.X >= 0 && pt.X <= 1);
+                Assert.True(pt.Y >= 0 && pt.Y <= 2);
+                Assert.True(pt.Z >= 0 && pt.Z <= 3);
+            }
+
+            // Verify top corners specifically do not go to x=2, y=4 due to previous offset multiplication bug
+            Assert.Contains(points, pt => pt.X == 1 && pt.Y == 2 && pt.Z == 3); // Max corner
+            Assert.Contains(points, pt => pt.X == 0 && pt.Y == 0 && pt.Z == 0); // Min corner
+            Assert.Contains(points, pt => pt.X == 0 && pt.Y == 2 && pt.Z == 3);
+            Assert.Contains(points, pt => pt.X == 1 && pt.Y == 0 && pt.Z == 3);
+        }
+
+        [Fact]
+        public void Transform_WithRotation_ShouldResultInAxesAlignedAABB()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 1, 1));
+
+            // Rotate around Z axis by 45 degrees
+            double angle = System.Math.PI / 4;
+            double cos = System.Math.Cos(angle);
+            double sin = System.Math.Sin(angle);
+
+            // Matrix4D setup for 45 deg Z rotation
+            Matrix4D rotation = new Matrix4D(
+                cos, -sin, 0, 0,
+                sin, cos, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1
+            );
+
+            BoundingBox3D transformedBox = bbox.Transform(rotation);
+
+            // The original corners of (0,0,0) and (1,1,1) transform to:
+            // (0,0,0) -> (0,0,0)
+            // (1,0,0) -> (cos, sin, 0) ~ (0.707, 0.707, 0)
+            // (0,1,0) -> (-sin, cos, 0) ~ (-0.707, 0.707, 0)
+            // (1,1,0) -> (cos - sin, sin + cos, 0) ~ (0, 1.414, 0)
+            // Maximum coordinate in Y is sin + cos = 1.414. Minimum coordinate in X is -sin = -0.707.
+            // Under old implementation, it only transformed min(0,0,0) and max(1,1,1), getting bounds [-0.707, 0] in X which cuts off (1,0,0)!
+            // Under new correct implementation, transformed box bounds should contain all transformed corners.
+
+            Assert.True(transformedBox.MinX <= -0.7);
+            Assert.True(transformedBox.MaxX >= 0.7);
+            Assert.True(transformedBox.MinY >= 0.0);
+            Assert.True(transformedBox.MaxY >= 1.4);
+            Assert.Equal(0.0, transformedBox.MinZ);
+            Assert.Equal(1.0, transformedBox.MaxZ);
+        }
+
+        [Fact]
+        public void Point3Ds_WithInvalidOffset_ShouldThrowException()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 1, 1));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => bbox.Point3Ds(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bbox.Point3Ds(-1));
+        }
+
+        [Fact]
+        public void GetHashCode_DifferentObjects_ShouldBeConsistent()
+        {
+            BoundingBox3D bbox1 = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 2, 3));
+            BoundingBox3D bbox2 = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 2, 3));
+            BoundingBox3D bbox3 = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(10, 20, 30));
+
+            Assert.Equal(bbox1.GetHashCode(), bbox2.GetHashCode());
+            Assert.NotEqual(bbox1.GetHashCode(), bbox3.GetHashCode());
+        }
+
+        [Fact]
+        public void Intersect_SegmentCrossingBounds_ShouldCheckMultiplePlanes()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(10, 10, 10));
+
+            // Segment crossing through the right face (X = 10)
+            Segment3D segment = new Segment3D(new Point3D(5, 5, 5), new Point3D(15, 5, 5));
+
+            Assert.True(bbox.Intersect(segment));
+        }
+    }
+}

--- a/SAM/SAM.Tests/GeometryDifferenceTests.cs
+++ b/SAM/SAM.Tests/GeometryDifferenceTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using SAM.Geometry.Planar;
+using Xunit;
+
+namespace SAM.Tests
+{
+    public class GeometryDifferenceTests
+    {
+        // Regression test for a bug where the Parallel.For branch of
+        // Difference(this IEnumerable<Polygon2D>, IEnumerable<Polygon2D>, double) used
+        // polygon2Ds_1.ElementAt(0) instead of the loop index i, so every parallel
+        // iteration differenced the *first* polygon against polygon2Ds_2 instead of the
+        // i-th polygon. The parallel branch only engages once count >= 10 (or
+        // polygon2Ds_2.Count() >= 10), so this test builds a list of 12 distinct,
+        // non-overlapping polygons (well above the threshold) and checks that the
+        // per-polygon ("per-slot") results line up with polygon2Ds_1[i], not
+        // polygon2Ds_1[0].
+        [Fact]
+        public void Difference_Polygon2DList_ParallelBranch_UsesPerIndexPolygon()
+        {
+            double tolerance = SAM.Core.Tolerance.MicroDistance;
+
+            const int count = 12; // >= parallel-branch threshold (10)
+            const double gap = 10.0;
+
+            // 12 distinct, non-overlapping polygons at different positions/shapes.
+            List<Polygon2D> polygon2Ds_1 = new List<Polygon2D>();
+            for (int i = 0; i < count; i++)
+            {
+                double x0 = i * gap;
+                double width = 2.0 + (i % 3); // vary shape slightly across indices
+                polygon2Ds_1.Add(Rectangle(x0, 0, width, 2.0));
+            }
+
+            // polygon2Ds_2 fully removes polygon2Ds_1[3] and removes the left half of polygon2Ds_1[7].
+            // polygon2Ds_1[0] (used by the buggy code for every iteration) is left completely untouched,
+            // so a bug that always differences against polygon2Ds_1[0] is easy to detect.
+            List<Polygon2D> polygon2Ds_2 = new List<Polygon2D>()
+            {
+                Rectangle(3 * gap, 0, 2.0 + (3 % 3), 2.0), // exact match with polygon2Ds_1[3]
+                Rectangle(7 * gap, 0, (2.0 + (7 % 3)) / 2.0, 2.0), // left half of polygon2Ds_1[7]
+            };
+
+            // Oracle: per-index expected result using the single-polygon overload, which is
+            // unaffected by the bug (shared by both the count==1 and count<10 sequential branches).
+            List<List<Polygon2D>> expectedPerIndex = new List<List<Polygon2D>>();
+            for (int i = 0; i < count; i++)
+            {
+                List<Polygon2D> difference = polygon2Ds_1[i]?.Difference(polygon2Ds_2, tolerance);
+                expectedPerIndex.Add(difference ?? new List<Polygon2D>());
+            }
+
+            // Sanity-check the oracle/test construction itself before trusting it as ground truth.
+            Assert.Empty(expectedPerIndex[3]); // fully removed
+            Assert.NotEmpty(expectedPerIndex[7]); // partially removed
+            Assert.True(expectedPerIndex[7].Sum(x => x.GetArea()) < polygon2Ds_1[7].GetArea() - tolerance);
+            for (int i = 0; i < count; i++)
+            {
+                if (i == 3 || i == 7)
+                {
+                    continue;
+                }
+
+                // untouched indices should come back unchanged (single polygon, same area)
+                Assert.Single(expectedPerIndex[i]);
+                Assert.True(System.Math.Abs(expectedPerIndex[i][0].GetArea() - polygon2Ds_1[i].GetArea()) < tolerance);
+            }
+
+            // Actual: goes through the count >= 10 Parallel.For branch under test.
+            List<Polygon2D> actual = polygon2Ds_1.Difference(polygon2Ds_2, tolerance);
+
+            Assert.NotNull(actual);
+
+            int expectedTotalCount = expectedPerIndex.Sum(x => x.Count);
+            Assert.Equal(expectedTotalCount, actual.Count);
+
+            double expectedTotalArea = expectedPerIndex.SelectMany(x => x).Sum(x => x.GetArea());
+            double actualTotalArea = actual.Sum(x => x.GetArea());
+            Assert.True(System.Math.Abs(expectedTotalArea - actualTotalArea) < 1e-6, $"Expected total area {expectedTotalArea}, actual {actualTotalArea}");
+
+            // Per-index ("per-slot") verification: bucket the flattened actual results by which
+            // original polygon's x-range their centroid falls into, and compare the bucketed area
+            // against the oracle's per-index area. With the ElementAt(0) bug, every iteration
+            // differences polygon2Ds_1[0] (untouched by polygon2Ds_2), so every result polygon would
+            // land in slot 0 and every other slot would come back empty - this loop catches that.
+            for (int i = 0; i < count; i++)
+            {
+                double width = 2.0 + (i % 3);
+                double xMin = i * gap - tolerance;
+                double xMax = i * gap + width + tolerance;
+
+                double actualAreaForSlot = actual
+                    .Where(x =>
+                    {
+                        double centroidX = x.GetCentroid().X;
+                        return centroidX >= xMin && centroidX <= xMax;
+                    })
+                    .Sum(x => x.GetArea());
+
+                double expectedAreaForSlot = expectedPerIndex[i].Sum(x => x.GetArea());
+
+                Assert.True(System.Math.Abs(actualAreaForSlot - expectedAreaForSlot) < 1e-6, $"Mismatch at index {i}: expected area {expectedAreaForSlot}, actual {actualAreaForSlot}");
+            }
+        }
+
+        private static Polygon2D Rectangle(double x, double y, double width, double height)
+        {
+            List<Point2D> point2Ds = new List<Point2D>()
+            {
+                new Point2D(x, y),
+                new Point2D(x + width, y),
+                new Point2D(x + width, y + height),
+                new Point2D(x, y + height),
+            };
+
+            return new Polygon2D(point2Ds);
+        }
+    }
+}

--- a/SAM/SAM.Tests/MapPanelsBenchmarks.cs
+++ b/SAM/SAM.Tests/MapPanelsBenchmarks.cs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020-2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using SAM.Analytical;
+using SAM.Core;
+using SAM.Geometry.Spatial;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SAM.Tests
+{
+    [Trait("Category", "Benchmark")]
+    public class MapPanelsBenchmarks
+    {
+        private readonly ITestOutputHelper _output;
+
+        public MapPanelsBenchmarks(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        private static Panel CreateSquarePanel(double x, double z, double size, string name)
+        {
+            var p0 = new Point3D(x, 0, z);
+            var p1 = new Point3D(x + size, 0, z);
+            var p2 = new Point3D(x + size, 0, z + size);
+            var p3 = new Point3D(x, 0, z + size);
+            var face = new Face3D(new Polygon3D(new[] { p0, p1, p2, p3 }));
+            return SAM.Analytical.Create.Panel(new Construction(name), PanelType.Wall, face);
+        }
+
+        private static (AdjacencyCluster cluster, List<Panel> sourcePanels) BuildModel(int count, double offset, double spacing)
+        {
+            var construction = new Construction("Bench");
+            var cluster = new AdjacencyCluster();
+            int cols = (int)System.Math.Ceiling(System.Math.Sqrt(count));
+            for (int i = 0; i < count; i++)
+            {
+                int col = i % cols;
+                int row = i / cols;
+                double x = col * spacing + offset;
+                double z = row * spacing + offset;
+                cluster.AddObject(CreateSquarePanel(x, z, 3.5, $"D{i}"));
+            }
+
+            var sourcePanels = new List<Panel>();
+            for (int i = 0; i < count; i++)
+            {
+                int col = i % cols;
+                int row = i / cols;
+                double x = col * spacing + 1.0;
+                double z = row * spacing + 1.0;
+                sourcePanels.Add(CreateSquarePanel(x, z, 3.5, $"S{i}"));
+            }
+
+            return (cluster, sourcePanels);
+        }
+
+        private static double RunBenchmark(AdjacencyCluster cluster, List<Panel> sourcePanels, int warmupRuns, int measuredRuns)
+        {
+            for (int i = 0; i < warmupRuns; i++)
+            {
+                var other = BuildModel(sourcePanels.Count, 0, 4.0).cluster;
+                other.MapPanels(BuildModel(sourcePanels.Count, 1, 4.0).sourcePanels);
+                other = null;
+            }
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            var times = new List<double>();
+            for (int i = 0; i < measuredRuns; i++)
+            {
+                // Fresh cluster each run to avoid cumulative mutation
+                var (freshCluster, _) = BuildModel(sourcePanels.Count, 0, 4.0);
+
+                var sw = Stopwatch.StartNew();
+                freshCluster.MapPanels(sourcePanels, 0.1, 0.5);
+                sw.Stop();
+
+                times.Add(sw.Elapsed.TotalMilliseconds);
+            }
+
+            // Return median
+            times.Sort();
+            return times[times.Count / 2];
+        }
+
+        [Fact]
+        public void MapPanels_SpatiallySeparated_Optimized()
+        {
+            // Source and dest panels are offset by 1m — destination internal points are inside source face boxes
+            // The expanded BB will include nearly all dest points within maxDistance (0.5m).
+            // This is the "best case" for the prefilter — most candidates pass BB and proceed to exact check.
+            foreach (int n in new[] { 100, 500, 1000, 2500, 5000 })
+            {
+                var (cluster, sourcePanels) = BuildModel(n, 0, 4.0);
+                double ms = RunBenchmark(cluster, sourcePanels, 2, 3);
+                _output.WriteLine($"  N={n,4}: {ms,8:F2} ms  (optimized)");
+            }
+        }
+
+        [Fact]
+        public void MapPanels_WorstCase_DenseNearby_Optimized()
+        {
+            // Very dense panels — every dest is close to every source.
+            // BB prefilter adds near-zero filtering benefit, but adds BB computation cost.
+            // This validates the prefilter isn't slower on worst-case inputs.
+            foreach (int n in new[] { 100, 200, 400 })
+            {
+                var (cluster, sourcePanels) = BuildModel(n, 0, 0.5);
+                double ms = RunBenchmark(cluster, sourcePanels, 2, 3);
+                _output.WriteLine($"  N={n,4}: {ms,8:F2} ms  (optimized, dense)");
+            }
+        }
+    }
+}

--- a/SAM/SAM.Tests/MapPanelsPrefilterTests.cs
+++ b/SAM/SAM.Tests/MapPanelsPrefilterTests.cs
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020-2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using SAM.Analytical;
+using SAM.Core;
+using SAM.Geometry.Spatial;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace SAM.Tests
+{
+    public class MapPanelsPrefilterTests
+    {
+        #region Test oracle — original exhaustive algorithm
+
+        private static List<Panel> MapPanels_Exhaustive(AdjacencyCluster cluster, IEnumerable<Panel> panels,
+            double minArea = Tolerance.MacroDistance, double maxDistance = Tolerance.MacroDistance)
+        {
+            if (cluster == null || panels == null)
+                return null;
+
+            List<Panel> panels_Cluster = cluster.GetPanels();
+            if (panels_Cluster == null)
+                return null;
+
+            List<Panel> result = new List<Panel>();
+            if (panels.Count() == 0 || panels_Cluster.Count == 0)
+                return result;
+
+            List<Tuple<Point3D, Panel>> tuples = new List<Tuple<Point3D, Panel>>();
+            foreach (Panel p in panels_Cluster)
+            {
+                Point3D pt = p?.GetInternalPoint3D();
+                if (pt == null) continue;
+                tuples.Add(new Tuple<Point3D, Panel>(pt, p));
+            }
+
+            foreach (Panel panel in panels)
+            {
+                Face3D face3D = panel?.GetFace3D();
+                if (face3D == null) continue;
+
+                List<Panel> matched = new List<Panel>();
+                foreach (Tuple<Point3D, Panel> tuple in tuples)
+                {
+                    double d = face3D.Distance(tuple.Item1);
+                    if (d <= maxDistance)
+                        matched.Add(tuple.Item2);
+                }
+
+                if (matched == null || matched.Count == 0) continue;
+
+                for (int i = 0; i < matched.Count; i++)
+                {
+                    Panel mp = matched[i];
+                    mp = SAM.Analytical.Create.Panel(mp.Guid, panel, mp.GetFace3D(), null, true, minArea, maxDistance);
+                    cluster.AddObject(mp);
+                    result.Add(mp);
+                }
+            }
+
+            return result;
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static Panel CreateRectPanel(double x, double z, double w, double h, PanelType type, string constructionName)
+        {
+            var p0 = new Point3D(x, 0, z);
+            var p1 = new Point3D(x + w, 0, z);
+            var p2 = new Point3D(x + w, 0, z + h);
+            var p3 = new Point3D(x, 0, z + h);
+            var face = new Face3D(new Polygon3D(new[] { p0, p1, p2, p3 }));
+            return SAM.Analytical.Create.Panel(new Construction(constructionName), type, face);
+        }
+
+        private static Panel CreateInclinedPanel(double x, double z, double w, double h, double tiltDegrees, PanelType type, string constructionName)
+        {
+            double rad = tiltDegrees * System.Math.PI / 180.0;
+            double dz = h * System.Math.Cos(rad);
+            double dy = h * System.Math.Sin(rad);
+            var p0 = new Point3D(x, 0, z);
+            var p1 = new Point3D(x + w, 0, z);
+            var p2 = new Point3D(x + w, dy, z + dz);
+            var p3 = new Point3D(x, dy, z + dz);
+            var face = new Face3D(new Polygon3D(new[] { p0, p1, p2, p3 }));
+            return SAM.Analytical.Create.Panel(new Construction(constructionName), type, face);
+        }
+
+        private static AdjacencyCluster BuildSimpleCluster(IEnumerable<Panel> destinationPanels)
+        {
+            var cluster = new AdjacencyCluster();
+            foreach (var p in destinationPanels)
+                cluster.AddObject(p);
+            return cluster;
+        }
+
+        private static void AssertResultsIdentical(List<Panel> exhaustive, List<Panel> optimized)
+        {
+            Assert.Equal(exhaustive?.Count ?? 0, optimized?.Count ?? 0);
+
+            if (exhaustive == null || exhaustive.Count == 0)
+                return;
+
+            for (int i = 0; i < exhaustive.Count; i++)
+            {
+                Assert.Equal(exhaustive[i].Guid, optimized[i].Guid);
+                Assert.Equal(exhaustive[i].PanelType, optimized[i].PanelType);
+                var ef = exhaustive[i].GetFace3D();
+                var of = optimized[i].GetFace3D();
+                Assert.NotNull(ef);
+                Assert.NotNull(of);
+                Assert.Equal(exhaustive[i].HasApertures, optimized[i].HasApertures);
+            }
+        }
+
+        private void FullEquivalenceTest(List<Panel> sourcePanels, List<Panel> destPanels,
+            double minArea = 0.01, double maxDistance = 0.5)
+        {
+            var clusterEx = BuildSimpleCluster(destPanels);
+            var clusterOpt = BuildSimpleCluster(destPanels);
+
+            var exhaustive = MapPanels_Exhaustive(clusterEx, sourcePanels, minArea, maxDistance);
+            var optimized = clusterOpt.MapPanels(sourcePanels, minArea, maxDistance);
+
+            AssertResultsIdentical(exhaustive, optimized);
+
+            // Verify cluster contents match
+            Assert.Equal(clusterEx.GetPanels().Count, clusterOpt.GetPanels().Count);
+            var exGuids = clusterEx.GetPanels().Select(x => x.Guid).OrderBy(g => g).ToList();
+            var optGuids = clusterOpt.GetPanels().Select(x => x.Guid).OrderBy(g => g).ToList();
+            Assert.Equal(exGuids, optGuids);
+        }
+
+        #endregion
+
+        #region Correctness tests
+
+        [Fact]
+        public void ParallelRectPanels_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "A") };
+            var dst = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "B") };
+            FullEquivalenceTest(src, dst);
+        }
+
+        [Fact]
+        public void RotatedPanels_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "A") };
+            var dst = new List<Panel> { CreateRectPanel(5, 0, 3, 3, PanelType.Wall, "B") };
+            FullEquivalenceTest(src, dst);
+        }
+
+        [Fact]
+        public void InclinedPanels_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateInclinedPanel(0, 0, 3, 4, 45, PanelType.Roof, "A") };
+            var dst = new List<Panel> { CreateInclinedPanel(0, 0, 3, 4, 45, PanelType.Roof, "B") };
+            FullEquivalenceTest(src, dst, 0.01, 0.5);
+        }
+
+        [Fact]
+        public void VerticalPanels_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "A") };
+            var dst = new List<Panel>
+            {
+                CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "B"),
+                CreateRectPanel(10, 0, 3, 3, PanelType.Wall, "C")
+            };
+            FullEquivalenceTest(src, dst);
+        }
+
+        [Fact]
+        public void ConcaveFaces_ShouldMatch()
+        {
+            // L-shaped face
+            var pts = new Point3D[]
+            {
+                new(0, 0, 0), new(6, 0, 0), new(6, 0, 2), new(2, 0, 2),
+                new(2, 0, 4), new(0, 0, 4)
+            };
+            var src = new List<Panel>
+            {
+                SAM.Analytical.Create.Panel(new Construction("L"), PanelType.Floor, new Face3D(new Polygon3D(pts)))
+            };
+            var dst = new List<Panel>
+            {
+                SAM.Analytical.Create.Panel(new Construction("D"), PanelType.Floor, new Face3D(new Polygon3D(pts)))
+            };
+            FullEquivalenceTest(src, dst);
+        }
+
+        [Fact]
+        public void DestinationPointInsideFace_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 5, 5, PanelType.Floor, "A") };
+            var dst = new List<Panel>
+            {
+                SAM.Analytical.Create.Panel(
+                    new Construction("B"), PanelType.Floor,
+                    new Face3D(new Polygon3D(new Point3D[]
+                    {
+                        new(1, 0, 1), new(2, 0, 1), new(2, 0, 2), new(1, 0, 2)
+                    })))
+            };
+            FullEquivalenceTest(src, dst);
+        }
+
+        [Fact]
+        public void PointAtExactMaxDistance_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 1, 1, PanelType.Floor, "A") };
+            var dst = new List<Panel> { CreateRectPanel(0, 0, 1, 1, PanelType.Floor, "B") };
+            double maxDist = 0.5;
+            FullEquivalenceTest(src, dst, 0.01, maxDist);
+        }
+
+        [Fact]
+        public void PointJustInsideMaxDistance_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 1, 1, PanelType.Floor, "A") };
+            var dst = new List<Panel> { CreateRectPanel(0.49, 0, 1, 1, PanelType.Floor, "B") };
+            FullEquivalenceTest(src, dst, 0.01, 0.5);
+        }
+
+        [Fact]
+        public void PointJustOutsideMaxDistance_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 1, 1, PanelType.Floor, "A") };
+            var dst = new List<Panel> { CreateRectPanel(2.0, 0, 1, 1, PanelType.Floor, "B") };
+            FullEquivalenceTest(src, dst, 0.01, 0.5);
+        }
+
+        [Fact]
+        public void PointInsideExpandedBox_OutsideExactDistance_ShouldMatch()
+        {
+            // Destination is diagonally above the source — within the expanded AABB (x+z within range)
+            // but elevation (y) difference exceeds maxDistance
+            var src = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Floor, "A") };
+            var dst = new List<Panel> { CreateRectPanel(2, 0, 3, 3, PanelType.Floor, "B") };
+            FullEquivalenceTest(src, dst, 0.01, 0.5);
+        }
+
+        [Fact]
+        public void ZeroMaxDistance_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "A") };
+            var dst = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "B") };
+            FullEquivalenceTest(src, dst, 0.01, 0.0);
+        }
+
+        [Fact]
+        public void EmptySource_ShouldReturnEmpty()
+        {
+            var src = new List<Panel>();
+            var dst = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "B") };
+            var cluster = BuildSimpleCluster(dst);
+            var result = cluster.MapPanels(src);
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void EmptyDestination_ShouldReturnNull()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "A") };
+            var dst = new List<Panel>();
+            var cluster = BuildSimpleCluster(dst);
+            var result = cluster.MapPanels(src);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void NullSource_ShouldReturnNull()
+        {
+            var dst = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "B") };
+            var cluster = BuildSimpleCluster(dst);
+            var result = cluster.MapPanels(null);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void MultipleDestinationToSingleSource_ShouldMatch()
+        {
+            var src = new List<Panel> { CreateRectPanel(0, 0, 6, 6, PanelType.Floor, "Large") };
+            var dst = new List<Panel>
+            {
+                CreateRectPanel(0, 0, 3, 3, PanelType.Floor, "A"),
+                CreateRectPanel(3, 0, 3, 3, PanelType.Floor, "B"),
+                CreateRectPanel(0, 3, 3, 3, PanelType.Floor, "C"),
+                CreateRectPanel(3, 3, 3, 3, PanelType.Floor, "D"),
+            };
+            FullEquivalenceTest(src, dst);
+        }
+
+        [Fact]
+        public void DenselyOverlappingPanels_ShouldMatch()
+        {
+            var src = new List<Panel>();
+            var dst = new List<Panel>();
+            for (int i = 0; i < 20; i++)
+            {
+                double x = i * 0.1;
+                src.Add(CreateRectPanel(x, x, 3, 3, PanelType.Wall, $"S{i}"));
+                dst.Add(CreateRectPanel(x + 0.05, x + 0.05, 3, 3, PanelType.Wall, $"D{i}"));
+            }
+            FullEquivalenceTest(src, dst, 0.01, 0.5);
+        }
+
+        [Fact]
+        public void SpatiallySeparatedPanels_ShouldMatch()
+        {
+            var src = new List<Panel>();
+            var dst = new List<Panel>();
+            double spacing = 20.0;
+            for (int i = 0; i < 30; i++)
+            {
+                double x = i * spacing;
+                src.Add(CreateRectPanel(x, 0, 3, 3, PanelType.Wall, $"S{i}"));
+                dst.Add(CreateRectPanel(x + 1, 0, 3, 3, PanelType.Wall, $"D{i}"));
+            }
+            FullEquivalenceTest(src, dst, 0.01, 0.5);
+        }
+
+        [Fact]
+        public void NullPanelInSource_SkippedNotCrashed()
+        {
+            var src = new List<Panel> { null, CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "A") };
+            var dst = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "B") };
+            var cluster = BuildSimpleCluster(dst);
+            var result = cluster.MapPanels(src);
+            Assert.NotNull(result);
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void PanelWithoutFace3D_SkippedNotCrashed()
+        {
+            var panelNoGeometry = SAM.Analytical.Create.Panel(new Construction("NoGeo"), PanelType.Wall);
+            var src = new List<Panel> { panelNoGeometry, CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "A") };
+            var dst = new List<Panel> { CreateRectPanel(0, 0, 3, 3, PanelType.Wall, "B") };
+            var cluster = BuildSimpleCluster(dst);
+            var result = cluster.MapPanels(src);
+            Assert.NotNull(result);
+            Assert.Single(result);
+        }
+
+        #endregion
+    }
+}

--- a/SAM/SAM.Tests/PlanarBoundary3DTests.cs
+++ b/SAM/SAM.Tests/PlanarBoundary3DTests.cs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using SAM.Analytical;
+using SAM.Geometry.Planar;
+using SAM.Geometry.Spatial;
+using Xunit;
+
+namespace SAM.Tests
+{
+    // Regression tests for PlanarBoundary3D.Coplanar(Plane, double). The
+    // second overload used to shadow the "plane" field with its "plane"
+    // parameter and compare that parameter against itself
+    // (return plane.Coplanar(plane, tolerance)), so it always returned true
+    // regardless of the instance's own plane. Query.IsValid (the guard used
+    // by Panel.AddAperture / AddApertures) relies on this method as a cheap
+    // coplanarity check before the more expensive Face3D.Inside containment
+    // test, so the bug silently disabled that guard everywhere.
+    public class PlanarBoundary3DTests
+    {
+        private static PlanarBoundary3D UnitSquareBoundary(Plane plane)
+        {
+            Face3D face3D = new Face3D(plane, new Rectangle2D(1, 1));
+            return new PlanarBoundary3D(face3D);
+        }
+
+        [Fact]
+        public void Coplanar_SamePlane_ReturnsTrue()
+        {
+            Plane plane = new Plane(new Point3D(0, 0, 0), new Vector3D(0, 0, 1));
+
+            PlanarBoundary3D planarBoundary3D_1 = UnitSquareBoundary(plane);
+            PlanarBoundary3D planarBoundary3D_2 = UnitSquareBoundary(plane);
+
+            Assert.True(planarBoundary3D_1.Coplanar(planarBoundary3D_2));
+            Assert.True(planarBoundary3D_1.Coplanar(plane));
+        }
+
+        [Fact]
+        public void Coplanar_ParallelOffsetPlanes_ReturnsTrue()
+        {
+            // Plane.Coplanar (SAM.Geometry.Spatial.Plane.Coplanar) only compares
+            // normal direction and ignores the planes' offset/origin, so two
+            // parallel planes at different heights are still "coplanar" by that
+            // definition. PlanarBoundary3D.Coplanar must match that semantic
+            // rather than introduce its own offset check.
+            Plane plane_1 = new Plane(new Point3D(0, 0, 0), new Vector3D(0, 0, 1));
+            Plane plane_2 = new Plane(new Point3D(0, 0, 5), new Vector3D(0, 0, 1));
+
+            PlanarBoundary3D planarBoundary3D_1 = UnitSquareBoundary(plane_1);
+            PlanarBoundary3D planarBoundary3D_2 = UnitSquareBoundary(plane_2);
+
+            Assert.True(planarBoundary3D_1.Coplanar(planarBoundary3D_2));
+            Assert.True(planarBoundary3D_1.Coplanar(plane_2));
+        }
+
+        [Fact]
+        public void Coplanar_PerpendicularPlanes_ReturnsFalse()
+        {
+            Plane plane_1 = new Plane(new Point3D(0, 0, 0), new Vector3D(0, 0, 1));
+            Plane plane_2 = new Plane(new Point3D(0, 0, 0), new Vector3D(1, 0, 0));
+
+            PlanarBoundary3D planarBoundary3D_1 = UnitSquareBoundary(plane_1);
+            PlanarBoundary3D planarBoundary3D_2 = UnitSquareBoundary(plane_2);
+
+            Assert.False(planarBoundary3D_1.Coplanar(planarBoundary3D_2));
+            Assert.False(planarBoundary3D_1.Coplanar(plane_2));
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR implements deep performance optimizations and bug fixes for the `BoundingBox3D` class and its associated spatial queries in `SAM.Geometry`.

### Bug Fixes
- **Z-Dimension Constructor Flatness**: Fixed the `BoundingBox3D(Point3D point3D, double offset)` constructor where `max.Z` was calculated using `- offset` instead of `+ offset` (which generated bounding boxes with zero thickness/height in the Z direction).
- **Early Loop Termination in Intersection**: Fixed the `Intersect(Segment3D, double)` method by removing a misplaced `return true;` in the middle of the loop, which terminated checking after the first plane.
- **Top Face Corners**: Fixed `GetPoints()` returning points shifted outside the box by correcting the upper-face corner coordinate calculations.
- **Duplicate Segment Edge**: Removed a duplicate segment edge addition in `GetSegments()`.
- **Duplicate NaN Validation**: Fixed NaN check duplication (checking `x` three times and ignoring `y` and `z`) in `IsValid(Vector3D)` and `IsValid(Point3D)`.
- **Transformation Axis-Alignment**: Corrected `Transform(BoundingBox3D, Matrix4D)` to retrieve all 8 corners, transform them, and reconstruct a correct Axis-Aligned Bounding Box (AABB) of the rotated shape.
- **Infinite Loop Avoidance**: Added bounds validation to `Point3Ds(this BoundingBox3D, double)` to prevent infinite loops if the step offset is zero or negative.

### Performance Optimizations (Zero Allocation Queries)
- **Non-Allocating Coordinate Properties**: Added properties `MinX`, `MinY`, `MinZ`, `MaxX`, `MaxY`, and `MaxZ` to bypass generating new `Point3D` class instances when querying coordinates.
- **Zero Allocations in Queries**: Updated `InRange`, `Inside`, `Range`, and validity checks to use these properties, eliminating excessive heap allocations of `Point3D` instances during geometric iterations.
- **Cached Coordinates in Loops**: Cached coordinates outside of generator loops to avoid property accesses inside loop iterations.
- **Allocation-Free HashCode**: Rewrote `GetHashCode()` using an allocation-free `unchecked` hashing method instead of allocating a `Tuple<Point3D, Point3D>`.

### Unit Tests
- Created a new test file `BoundingBox3DTests.cs` in the `SAM.Tests` project using xUnit to verify constructors, NaN checks, segmentation, corner generation, transforms, and intersection checks.