### PR TITLE
fix/optimalization: Fix and Optimize BoundingBox3D Class and Spatial Queries

### DIFF
--- a/SAM/SAM.Geometry/Geometry/Spatial/Classes/BoundingBox3D.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Classes/BoundingBox3D.cs
@@ -13,6 +13,13 @@ namespace SAM.Geometry.Spatial
         private Point3D min;
         private Point3D max;
 
+        public double MinX => min?.X ?? double.NaN;
+        public double MinY => min?.Y ?? double.NaN;
+        public double MinZ => min?.Z ?? double.NaN;
+        public double MaxX => max?.X ?? double.NaN;
+        public double MaxY => max?.Y ?? double.NaN;
+        public double MaxZ => max?.Z ?? double.NaN;
+
         public BoundingBox3D(IEnumerable<Point3D> point3Ds)
         {
             double aX_Min = double.MaxValue;
@@ -59,7 +66,7 @@ namespace SAM.Geometry.Spatial
         public BoundingBox3D(Point3D point3D, double offset)
         {
             min = new Point3D(point3D.X - offset, point3D.Y - offset, point3D.Z - offset);
-            max = new Point3D(point3D.X + offset, point3D.Y + offset, point3D.Z - offset);
+            max = new Point3D(point3D.X + offset, point3D.Y + offset, point3D.Z + offset);
         }
 
         public BoundingBox3D(IEnumerable<Point3D> point3Ds, double offset)
@@ -107,14 +114,14 @@ namespace SAM.Geometry.Spatial
             foreach (BoundingBox3D boundingBox3D in boundingBox3Ds)
             {
                 if (min == null)
-                    min = new Point3D(boundingBox3D.Min);
+                    min = new Point3D(boundingBox3D.min);
                 else
-                    min = Query.Min(boundingBox3D.Min, min);
+                    min = Query.Min(boundingBox3D.min, min);
 
                 if (max == null)
-                    max = new Point3D(boundingBox3D.Max);
+                    max = new Point3D(boundingBox3D.max);
                 else
-                    max = Query.Max(boundingBox3D.Max, max);
+                    max = Query.Max(boundingBox3D.max, max);
             }
         }
         public BoundingBox3D(JsonObject jsonObject)
@@ -178,7 +185,6 @@ namespace SAM.Geometry.Spatial
                         }
                     }
                 }
-                return true;
             }
 
             return false;
@@ -337,7 +343,6 @@ namespace SAM.Geometry.Spatial
             result.Add(new Segment3D(new Point3D(min), new Point3D(min.X, min.Y, min.Z + z)));
             result.Add(new Segment3D(new Point3D(min.X + x, min.Y, min.Z), new Point3D(min.X + x, min.Y, min.Z + z)));
             result.Add(new Segment3D(new Point3D(min.X + x, min.Y + y, min.Z), new Point3D(min.X + x, min.Y + y, min.Z + z)));
-            result.Add(new Segment3D(new Point3D(min.X + x, min.Y + y, min.Z), new Point3D(min.X + x, min.Y + y, min.Z + z)));
             result.Add(new Segment3D(new Point3D(min.X, min.Y + y, min.Z), new Point3D(min.X, min.Y + y, min.Z + z)));
             return result;
         }
@@ -350,14 +355,14 @@ namespace SAM.Geometry.Spatial
 
             List<Point3D> point3Ds = new List<Point3D>();
             point3Ds.Add(new Point3D(min));
-            point3Ds.Add(new Point3D(min.X + x, min.Y, Min.Z));
-            point3Ds.Add(new Point3D(min.X + x, min.Y + y, Min.Z));
-            point3Ds.Add(new Point3D(min.X, min.Y + y, Min.Z));
+            point3Ds.Add(new Point3D(min.X + x, min.Y, min.Z));
+            point3Ds.Add(new Point3D(min.X + x, min.Y + y, min.Z));
+            point3Ds.Add(new Point3D(min.X, min.Y + y, min.Z));
 
+            point3Ds.Add(new Point3D(min.X, min.Y, max.Z));
+            point3Ds.Add(new Point3D(min.X + x, min.Y, max.Z));
             point3Ds.Add(new Point3D(max));
-            point3Ds.Add(new Point3D(max.X + x, max.Y, max.Z));
-            point3Ds.Add(new Point3D(max.X + x, max.Y + y, max.Z));
-            point3Ds.Add(new Point3D(max.X, max.Y + y, max.Z));
+            point3Ds.Add(new Point3D(min.X, min.Y + y, max.Z));
 
             return point3Ds;
         }
@@ -483,7 +488,13 @@ namespace SAM.Geometry.Spatial
 
         public override int GetHashCode()
         {
-            return new Tuple<Point3D, Point3D>(min, max).GetHashCode();
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 23 + (min?.GetHashCode() ?? 0);
+                hash = hash * 23 + (max?.GetHashCode() ?? 0);
+                return hash;
+            }
         }
 
         public static bool operator ==(BoundingBox3D boundingBox3D_1, BoundingBox3D boundingBox3D_2)

--- a/SAM/SAM.Geometry/Geometry/Spatial/Create/Point3Ds.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Create/Point3Ds.cs
@@ -24,11 +24,21 @@ namespace SAM.Geometry.Spatial
 
         public static List<Point3D> Point3Ds(this BoundingBox3D boundingBox3D, double offset)
         {
+            if (boundingBox3D == null)
+                return null;
+
+            if (offset <= 0)
+                throw new System.ArgumentOutOfRangeException(nameof(offset), "Offset must be greater than zero.");
+
             List<Point3D> result = new List<Point3D>();
 
             double width = boundingBox3D.Width;
             double height = boundingBox3D.Height;
             double depth = boundingBox3D.Depth;
+
+            double minX = boundingBox3D.MinX;
+            double minY = boundingBox3D.MinY;
+            double minZ = boundingBox3D.MinZ;
 
             double distance_Width = 0;
             while (distance_Width <= width)
@@ -39,7 +49,7 @@ namespace SAM.Geometry.Spatial
                     double distance_Depth = 0;
                     while (distance_Depth <= depth)
                     {
-                        result.Add(new Point3D(boundingBox3D.Min.X + distance_Width, boundingBox3D.Min.Y + distance_Depth, boundingBox3D.Min.Z + distance_Height));
+                        result.Add(new Point3D(minX + distance_Width, minY + distance_Depth, minZ + distance_Height));
                         distance_Depth += offset;
                     }
                     distance_Height += offset;

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/InRange.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/InRange.cs
@@ -35,33 +35,33 @@ namespace SAM.Geometry.Spatial
             double max_2;
             double min_2;
 
-            max_1 = boundingBox3D_1.Max.X + tolerance;
-            min_1 = boundingBox3D_1.Min.X - tolerance;
+            max_1 = boundingBox3D_1.MaxX + tolerance;
+            min_1 = boundingBox3D_1.MinX - tolerance;
 
-            max_2 = boundingBox3D_2.Max.X;
-            min_2 = boundingBox3D_2.Min.X;
-
-            if (max_1 < min_2 || min_1 > max_2)
-            {
-                return false;
-            }
-
-            max_1 = boundingBox3D_1.Max.Y + tolerance;
-            min_1 = boundingBox3D_1.Min.Y - tolerance;
-
-            max_2 = boundingBox3D_2.Max.Y;
-            min_2 = boundingBox3D_2.Min.Y;
+            max_2 = boundingBox3D_2.MaxX;
+            min_2 = boundingBox3D_2.MinX;
 
             if (max_1 < min_2 || min_1 > max_2)
             {
                 return false;
             }
 
-            max_1 = boundingBox3D_1.Max.Z + tolerance;
-            min_1 = boundingBox3D_1.Min.Z - tolerance;
+            max_1 = boundingBox3D_1.MaxY + tolerance;
+            min_1 = boundingBox3D_1.MinY - tolerance;
 
-            max_2 = boundingBox3D_2.Max.Z;
-            min_2 = boundingBox3D_2.Min.Z;
+            max_2 = boundingBox3D_2.MaxY;
+            min_2 = boundingBox3D_2.MinY;
+
+            if (max_1 < min_2 || min_1 > max_2)
+            {
+                return false;
+            }
+
+            max_1 = boundingBox3D_1.MaxZ + tolerance;
+            min_1 = boundingBox3D_1.MinZ - tolerance;
+
+            max_2 = boundingBox3D_2.MaxZ;
+            min_2 = boundingBox3D_2.MinZ;
 
             if (max_1 < min_2 || min_1 > max_2)
             {

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/IsValid.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/IsValid.cs
@@ -18,7 +18,7 @@ namespace SAM.Geometry.Spatial
             double y = vector3D.Y;
             double z = vector3D.Z;
 
-            if (double.IsNaN(x) || double.IsNaN(x) || double.IsNaN(x))
+            if (double.IsNaN(x) || double.IsNaN(y) || double.IsNaN(z))
             {
                 return false;
             }
@@ -40,7 +40,7 @@ namespace SAM.Geometry.Spatial
             double y = point3D.Y;
             double z = point3D.Z;
 
-            if (double.IsNaN(x) || double.IsNaN(x) || double.IsNaN(x))
+            if (double.IsNaN(x) || double.IsNaN(y) || double.IsNaN(z))
                 return false;
 
             return true;
@@ -108,17 +108,20 @@ namespace SAM.Geometry.Spatial
                 return false;
             }
 
-            if (!IsValid(boundingBox3D.Min))
+            double minX = boundingBox3D.MinX;
+            double minY = boundingBox3D.MinY;
+            double minZ = boundingBox3D.MinZ;
+            double maxX = boundingBox3D.MaxX;
+            double maxY = boundingBox3D.MaxY;
+            double maxZ = boundingBox3D.MaxZ;
+
+            if (double.IsNaN(minX) || double.IsNaN(minY) || double.IsNaN(minZ) ||
+                double.IsNaN(maxX) || double.IsNaN(maxY) || double.IsNaN(maxZ))
             {
                 return false;
             }
 
-            if (!IsValid(boundingBox3D.Max))
-            {
-                return false;
-            }
-
-            if (boundingBox3D.Min.Equals(boundingBox3D.Max))
+            if (minX == maxX && minY == maxY && minZ == maxZ)
             {
                 return false;
             }

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Range.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Range.cs
@@ -14,9 +14,17 @@ namespace SAM.Geometry.Spatial
                 return null;
             }
 
-            double min = dimensionIndex == 0 ? boundingBox3D.MinX : (dimensionIndex == 1 ? boundingBox3D.MinY : boundingBox3D.MinZ);
-            double max = dimensionIndex == 0 ? boundingBox3D.MaxX : (dimensionIndex == 1 ? boundingBox3D.MaxY : boundingBox3D.MaxZ);
-            return new Range<double>(min, max);
+            switch (dimensionIndex)
+            {
+                case 0:
+                    return new Range<double>(boundingBox3D.MinX, boundingBox3D.MaxX);
+                case 1:
+                    return new Range<double>(boundingBox3D.MinY, boundingBox3D.MaxY);
+                case 2:
+                    return new Range<double>(boundingBox3D.MinZ, boundingBox3D.MaxZ);
+                default:
+                    throw new System.IndexOutOfRangeException($"Index was outside the bounds of the 3D bounding box (index: {dimensionIndex}).");
+            }
         }
     }
 }

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Range.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Range.cs
@@ -14,7 +14,9 @@ namespace SAM.Geometry.Spatial
                 return null;
             }
 
-            return new Range<double>(boundingBox3D.Min[dimensionIndex], boundingBox3D.Max[dimensionIndex]);
+            double min = dimensionIndex == 0 ? boundingBox3D.MinX : (dimensionIndex == 1 ? boundingBox3D.MinY : boundingBox3D.MinZ);
+            double max = dimensionIndex == 0 ? boundingBox3D.MaxX : (dimensionIndex == 1 ? boundingBox3D.MaxY : boundingBox3D.MaxZ);
+            return new Range<double>(min, max);
         }
     }
 }

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Transform.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Transform.cs
@@ -302,7 +302,9 @@ namespace SAM.Geometry.Spatial
             if (boundingBox3D == null || matrix4D == null)
                 return null;
 
-            return new BoundingBox3D(boundingBox3D.Min.Transform(matrix4D), boundingBox3D.Max.Transform(matrix4D));
+            List<Point3D> corners = boundingBox3D.GetPoints();
+            List<Point3D> transformedCorners = corners.ConvertAll(pt => pt.Transform(matrix4D));
+            return new BoundingBox3D(transformedCorners);
         }
 
         public static Point3D Transform(this Point3D point3D, Matrix4D matrix4D)

--- a/SAM/SAM.Tests/BoundingBox3DTests.cs
+++ b/SAM/SAM.Tests/BoundingBox3DTests.cs
@@ -156,5 +156,51 @@ namespace SAM.Tests
 
             Assert.True(bbox.Intersect(segment));
         }
+
+        [Fact]
+        public void Intersect_SegmentBothEndpointsOutsideCrossingBox_ShouldReturnTrue()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(10, 10, 10));
+
+            // Segment from (-5, 5, 5) to (15, 5, 5) completely crosses the box
+            Segment3D segment = new Segment3D(new Point3D(-5, 5, 5), new Point3D(15, 5, 5));
+
+            Assert.True(bbox.Intersect(segment));
+        }
+
+        [Fact]
+        public void Intersect_SegmentBboxOverlapsButSegmentMisses_ShouldReturnFalse()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(10, 10, 10));
+
+            // Segment from (12, 9, 5) to (9, 12, 5) has bbox [9,12]x[9,12]x[5,5], which overlaps the box,
+            // but the segment itself misses it entirely (closest point is (10, 11, 5) which has Y > 10).
+            Segment3D segment = new Segment3D(new Point3D(12, 9, 5), new Point3D(9, 12, 5));
+
+            Assert.False(bbox.Intersect(segment));
+        }
+
+        [Fact]
+        public void Range_WithValidAndInvalidIndices_ShouldBehaveCorrectly()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(1, 2, 3), new Point3D(10, 20, 30));
+
+            // Valid indices
+            Range<double> rangeX = bbox.Range(0);
+            Assert.Equal(1, rangeX.Min);
+            Assert.Equal(10, rangeX.Max);
+
+            Range<double> rangeY = bbox.Range(1);
+            Assert.Equal(2, rangeY.Min);
+            Assert.Equal(20, rangeY.Max);
+
+            Range<double> rangeZ = bbox.Range(2);
+            Assert.Equal(3, rangeZ.Min);
+            Assert.Equal(30, rangeZ.Max);
+
+            // Invalid indices
+            Assert.Throws<IndexOutOfRangeException>(() => bbox.Range(-1));
+            Assert.Throws<IndexOutOfRangeException>(() => bbox.Range(3));
+        }
     }
 }

--- a/SAM/SAM.Tests/BoundingBox3DTests.cs
+++ b/SAM/SAM.Tests/BoundingBox3DTests.cs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using System;
+using System.Collections.Generic;
+using SAM.Geometry.Spatial;
+using SAM.Math;
+using Xunit;
+
+namespace SAM.Tests
+{
+    public class BoundingBox3DTests
+    {
+        [Fact]
+        public void Constructor_WithOffset_ShouldNotBeFlatZ()
+        {
+            Point3D center = new Point3D(10, 20, 30);
+            double offset = 5;
+            BoundingBox3D bbox = new BoundingBox3D(center, offset);
+
+            Assert.Equal(5, bbox.MinX);
+            Assert.Equal(15, bbox.MaxX);
+            Assert.Equal(15, bbox.MinY);
+            Assert.Equal(25, bbox.MaxY);
+            Assert.Equal(25, bbox.MinZ);
+            Assert.Equal(35, bbox.MaxZ);
+
+            Assert.Equal(10, bbox.Width);
+            Assert.Equal(10, bbox.Depth);
+            Assert.Equal(10, bbox.Height);
+        }
+
+        [Fact]
+        public void IsValid_WithNaNCoordinates_ShouldReturnFalse()
+        {
+            // Vector3D NaN checks
+            Assert.False(new Vector3D(double.NaN, 0, 0).IsValid());
+            Assert.False(new Vector3D(0, double.NaN, 0).IsValid());
+            Assert.False(new Vector3D(0, 0, double.NaN).IsValid());
+
+            // Point3D NaN checks
+            Assert.False(Query.IsValid(new Point3D(double.NaN, 0, 0)));
+            Assert.False(Query.IsValid(new Point3D(0, double.NaN, 0)));
+            Assert.False(Query.IsValid(new Point3D(0, 0, double.NaN)));
+
+            // BoundingBox3D NaN checks
+            BoundingBox3D validBox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 1, 1));
+            Assert.True(validBox.IsValid());
+
+            BoundingBox3D invalidBoxX = new BoundingBox3D(new Point3D(double.NaN, 0, 0), new Point3D(1, 1, 1));
+            Assert.False(invalidBoxX.IsValid());
+
+            BoundingBox3D invalidBoxY = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, double.NaN, 1));
+            Assert.False(invalidBoxY.IsValid());
+
+            BoundingBox3D invalidBoxZ = new BoundingBox3D(new Point3D(0, 0, double.NaN), new Point3D(1, 1, 1));
+            Assert.False(invalidBoxZ.IsValid());
+        }
+
+        [Fact]
+        public void GetSegments_ShouldReturnExactly12Segments()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 2, 3));
+            List<Segment3D> segments = bbox.GetSegments();
+
+            Assert.Equal(12, segments.Count);
+        }
+
+        [Fact]
+        public void GetPoints_ShouldReturnActual8Corners()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 2, 3));
+            List<Point3D> points = bbox.GetPoints();
+
+            Assert.Equal(8, points.Count);
+
+            // Verify all points are within [0,1], [0,2], [0,3] bounds
+            foreach (Point3D pt in points)
+            {
+                Assert.True(pt.X >= 0 && pt.X <= 1);
+                Assert.True(pt.Y >= 0 && pt.Y <= 2);
+                Assert.True(pt.Z >= 0 && pt.Z <= 3);
+            }
+
+            // Verify top corners specifically do not go to x=2, y=4 due to previous offset multiplication bug
+            Assert.Contains(points, pt => pt.X == 1 && pt.Y == 2 && pt.Z == 3); // Max corner
+            Assert.Contains(points, pt => pt.X == 0 && pt.Y == 0 && pt.Z == 0); // Min corner
+            Assert.Contains(points, pt => pt.X == 0 && pt.Y == 2 && pt.Z == 3);
+            Assert.Contains(points, pt => pt.X == 1 && pt.Y == 0 && pt.Z == 3);
+        }
+
+        [Fact]
+        public void Transform_WithRotation_ShouldResultInAxesAlignedAABB()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 1, 1));
+
+            // Rotate around Z axis by 45 degrees
+            double angle = System.Math.PI / 4;
+            double cos = System.Math.Cos(angle);
+            double sin = System.Math.Sin(angle);
+
+            // Matrix4D setup for 45 deg Z rotation
+            Matrix4D rotation = new Matrix4D(
+                cos, -sin, 0, 0,
+                sin, cos, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1
+            );
+
+            BoundingBox3D transformedBox = bbox.Transform(rotation);
+
+            // The original corners of (0,0,0) and (1,1,1) transform to:
+            // (0,0,0) -> (0,0,0)
+            // (1,0,0) -> (cos, sin, 0) ~ (0.707, 0.707, 0)
+            // (0,1,0) -> (-sin, cos, 0) ~ (-0.707, 0.707, 0)
+            // (1,1,0) -> (cos - sin, sin + cos, 0) ~ (0, 1.414, 0)
+            // Maximum coordinate in Y is sin + cos = 1.414. Minimum coordinate in X is -sin = -0.707.
+            // Under old implementation, it only transformed min(0,0,0) and max(1,1,1), getting bounds [-0.707, 0] in X which cuts off (1,0,0)!
+            // Under new correct implementation, transformed box bounds should contain all transformed corners.
+
+            Assert.True(transformedBox.MinX <= -0.7);
+            Assert.True(transformedBox.MaxX >= 0.7);
+            Assert.True(transformedBox.MinY >= 0.0);
+            Assert.True(transformedBox.MaxY >= 1.4);
+            Assert.Equal(0.0, transformedBox.MinZ);
+            Assert.Equal(1.0, transformedBox.MaxZ);
+        }
+
+        [Fact]
+        public void Point3Ds_WithInvalidOffset_ShouldThrowException()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 1, 1));
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => bbox.Point3Ds(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => bbox.Point3Ds(-1));
+        }
+
+        [Fact]
+        public void GetHashCode_DifferentObjects_ShouldBeConsistent()
+        {
+            BoundingBox3D bbox1 = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 2, 3));
+            BoundingBox3D bbox2 = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 2, 3));
+            BoundingBox3D bbox3 = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(10, 20, 30));
+
+            Assert.Equal(bbox1.GetHashCode(), bbox2.GetHashCode());
+            Assert.NotEqual(bbox1.GetHashCode(), bbox3.GetHashCode());
+        }
+
+        [Fact]
+        public void Intersect_SegmentCrossingBounds_ShouldCheckMultiplePlanes()
+        {
+            BoundingBox3D bbox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(10, 10, 10));
+
+            // Segment crossing through the right face (X = 10)
+            Segment3D segment = new Segment3D(new Point3D(5, 5, 5), new Point3D(15, 5, 5));
+
+            Assert.True(bbox.Intersect(segment));
+        }
+    }
+}

--- a/SAM/SAM.Tests/BoundingBox3DTests.cs
+++ b/SAM/SAM.Tests/BoundingBox3DTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using SAM.Geometry.Spatial;
 using SAM.Math;
 using Xunit;
+using SAM.Core;
 
 namespace SAM.Tests
 {


### PR DESCRIPTION
## Description

This PR implements deep performance optimizations and bug fixes for the `BoundingBox3D` class and its associated spatial queries in `SAM.Geometry`.

### Bug Fixes
- **Z-Dimension Constructor Flatness**: Fixed the `BoundingBox3D(Point3D point3D, double offset)` constructor where `max.Z` was calculated using `- offset` instead of `+ offset` (which generated bounding boxes with zero thickness/height in the Z direction).
- **Early Loop Termination in Intersection**: Fixed the `Intersect(Segment3D, double)` method by removing a misplaced `return true;` in the middle of the loop, which terminated checking after the first plane.
- **Top Face Corners**: Fixed `GetPoints()` returning points shifted outside the box by correcting the upper-face corner coordinate calculations.
- **Duplicate Segment Edge**: Removed a duplicate segment edge addition in `GetSegments()`.
- **Duplicate NaN Validation**: Fixed NaN check duplication (checking `x` three times and ignoring `y` and `z`) in `IsValid(Vector3D)` and `IsValid(Point3D)`.
- **Transformation Axis-Alignment**: Corrected `Transform(BoundingBox3D, Matrix4D)` to retrieve all 8 corners, transform them, and reconstruct a correct Axis-Aligned Bounding Box (AABB) of the rotated shape.
- **Infinite Loop Avoidance**: Added bounds validation to `Point3Ds(this BoundingBox3D, double)` to prevent infinite loops if the step offset is zero or negative.

### Performance Optimizations (Zero Allocation Queries)
- **Non-Allocating Coordinate Properties**: Added properties `MinX`, `MinY`, `MinZ`, `MaxX`, `MaxY`, and `MaxZ` to bypass generating new `Point3D` class instances when querying coordinates.
- **Zero Allocations in Queries**: Updated `InRange`, `Inside`, `Range`, and validity checks to use these properties, eliminating excessive heap allocations of `Point3D` instances during geometric iterations.
- **Cached Coordinates in Loops**: Cached coordinates outside of generator loops to avoid property accesses inside loop iterations.
- **Allocation-Free HashCode**: Rewrote `GetHashCode()` using an allocation-free `unchecked` hashing method instead of allocating a `Tuple<Point3D, Point3D>`.

### Unit Tests
- Created a new test file `BoundingBox3DTests.cs` in the `SAM.Tests` project using xUnit to verify constructors, NaN checks, segmentation, corner generation, transforms, and intersection checks.