### PR TITLE
fix: restore fail-fast return in 4 validation branches (reverses PR #39 return-to-continue)

### DIFF
--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByAperture.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByAperture.cs
@@ -316,7 +316,7 @@ namespace SAM.Analytical.Grasshopper
                         if (double.IsNaN(emissivity))
                         {
                             AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid emissivity for layer");
-                            continue;
+                            return;
                         }
 
                         hi = 3.6 + (4.1 * emissivity / 0.837);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByConstruction.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCalculateGlazingValueByConstruction.cs
@@ -327,7 +327,7 @@ namespace SAM.Analytical.Grasshopper
                         if (double.IsNaN(emissivity))
                         {
                             AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid emissivity for layer");
-                            continue;
+                            return;
                         }
 
                         hi = 3.6 + (4.1 * emissivity / 0.837);

--- a/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLayersByMaterials.cs
+++ b/Grasshopper/SAM.Analytical.Grasshopper/Component/SAMAnalyticalCreateConstructionLayersByMaterials.cs
@@ -106,14 +106,14 @@ namespace SAM.Analytical.Grasshopper
                     if (material == null)
                     {
                         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                        continue;
+                        return;
                     }
 
                     double thickness = material.GetValue<double>(Core.MaterialParameter.DefaultThickness);
                     if (double.IsNaN(thickness))
                     {
                         AddRuntimeMessage(GH_RuntimeMessageLevel.Error, "Invalid data");
-                        continue;
+                        return;
                     }
 
                     thicknesses.Add(thickness);


### PR DESCRIPTION
﻿## Summary

Restores `return` in 4 error-handling branches where PR #39 (`a31e996f`) had changed `return` to `continue`. That change was intentional and documented in #39 ("Week 1 extended (return-vs-continue)"), but it left these components in an incoherent error state; this PR deliberately reverses that decision and restores the original fail-fast behaviour the guards shipped with (`c0078611`).

## Actual defects fixed (base-branch behaviour with `continue`)

### `SAMAnalyticalCalculateGlazingValueByAperture` / `SAMAnalyticalCalculateGlazingValueByConstruction`

The aperture/construction is added to the result-object list **before** emissivity validation. When `_hi_` is unset and the innermost pane has no valid `InternalEmissivity`:

- the failed object remains in the `Apertures`/`Constructions` output list with **no corresponding result-tree branches** (object list and value trees misalign for downstream pairing);
- the component reports `GH_RuntimeMessageLevel.Error` yet still finishes with `successful = true`.

Note: no wrong or NaN glazing value is computed for the failed item - `Glazing.Compute` is skipped. The defect is inconsistent partial output plus a false success flag.

With `return`: Error is reported, no outputs are set, and `successful` stays `false` - consistent with the other Error guards in the same components (the remaining in-loop `continue`s are silent filters, e.g. non-transparent constructions, not errors).

### `SAMAnalyticalCreateConstructionLayersByMaterials` (x2)

When filling omitted thicknesses, a null material or `DefaultThickness = NaN` skipped via `continue` leaves fewer thicknesses than material names. `Create.ConstructionLayers` then returns `null` (count mismatch), so the base behaviour is: Error + null `constructionLayers` output + full `materials` passthrough. No corrupted layers and no array-index exception occur.

With `return`: the component stops at the Error and emits nothing, matching the two adjacent Error->`return` guards in the same method.

## History

- Guards originally introduced with `return` (`c0078611` et al.).
- PR #39 (`a31e996f`) changed all four to `continue` (documented, intentional).
- PR #40 did not touch these lines.
- This PR restores the pre-#39 behaviour.

## Scope

- 3 files, +4/-4. Rebased onto current `sow/2026-Q3` (clean, no conflicts).

## Validation

- `dotnet build SAM.sln -c Release`: succeeds, 0 errors, on both base (`50830b63`) and this branch.
- `SAM.Tests` fails to compile identically on both branches (`BoundingBox3DTests.cs` CS0104/CS1729, pre-existing from #46; fix in #49) - no new test failure is introduced and no test signal is available.

## Separate follow-up (not in this PR)

`SAMAnalyticalCalculateGlazingValueByConstruction.cs:366` adds `result.ShadingCoefficient` to `gValues` instead of `shadingCoefficients`, so `GValue` branches receive two values and the `ShadingCoefficient` output stays empty.
