### PR TITLE
fix: restore SAM.Tests compilation and fix BoundingBox3D segment-face intersection

### DIFF
--- a/SAM/SAM.Geometry/Geometry/Spatial/Classes/BoundingBox3D.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Classes/BoundingBox3D.cs
@@ -171,7 +171,11 @@ namespace SAM.Geometry.Spatial
                     ISAMGeometry3D geometry3D = planarIntersectionResult.Geometry3D;
                     if (geometry3D is Point3D)
                     {
-                        if (On((Point3D)geometry3D, tolerance))
+                        // The intersection point lies on the (infinite) face plane; it is on the
+                        // box surface when it is also within the inclusive box bounds. On(...)
+                        // cannot be used here as it only tests the 12 box edges, missing
+                        // segments crossing through a face interior.
+                        if (Inside((Point3D)geometry3D, true, tolerance))
                         {
                             return true;
                         }
@@ -179,7 +183,7 @@ namespace SAM.Geometry.Spatial
                     else if (geometry3D is Segment3D)
                     {
                         Segment3D segment3D_Temp = (Segment3D)geometry3D;
-                        if (On(point3D_1, tolerance) || On(point3D_2, tolerance))
+                        if (Inside(segment3D_Temp[0], true, tolerance) || Inside(segment3D_Temp[1], true, tolerance))
                         {
                             return true;
                         }

--- a/SAM/SAM.Tests/BoundingBox3DTests.cs
+++ b/SAM/SAM.Tests/BoundingBox3DTests.cs
@@ -40,9 +40,9 @@ namespace SAM.Tests
             Assert.False(new Vector3D(0, 0, double.NaN).IsValid());
 
             // Point3D NaN checks
-            Assert.False(Query.IsValid(new Point3D(double.NaN, 0, 0)));
-            Assert.False(Query.IsValid(new Point3D(0, double.NaN, 0)));
-            Assert.False(Query.IsValid(new Point3D(0, 0, double.NaN)));
+            Assert.False(new Point3D(double.NaN, 0, 0).IsValid());
+            Assert.False(new Point3D(0, double.NaN, 0).IsValid());
+            Assert.False(new Point3D(0, 0, double.NaN).IsValid());
 
             // BoundingBox3D NaN checks
             BoundingBox3D validBox = new BoundingBox3D(new Point3D(0, 0, 0), new Point3D(1, 1, 1));
@@ -101,12 +101,13 @@ namespace SAM.Tests
             double sin = System.Math.Sin(angle);
 
             // Matrix4D setup for 45 deg Z rotation
-            Matrix4D rotation = new Matrix4D(
-                cos, -sin, 0, 0,
-                sin, cos, 0, 0,
-                0, 0, 1, 0,
-                0, 0, 0, 1
-            );
+            Matrix4D rotation = new Matrix4D();
+            rotation[0, 0] = cos;
+            rotation[0, 1] = -sin;
+            rotation[1, 0] = sin;
+            rotation[1, 1] = cos;
+            rotation[2, 2] = 1;
+            rotation[3, 3] = 1;
 
             BoundingBox3D transformedBox = bbox.Transform(rotation);
 


### PR DESCRIPTION
## Summary

PR #46 added `BoundingBox3DTests.cs`, but the test project does not compile since then (SAM.Tests is not part of SAM.sln, so this was not caught). This PR restores compilation and fixes the genuine product bug the previously-unrunnable tests exposed.

## Compile fixes (`SAM.Tests/BoundingBox3DTests.cs`)

- CS0104: `Query.IsValid(...)` was ambiguous between `SAM.Core.Query` and `SAM.Math.Query`; replaced with the instance method `Point3D.IsValid()` (mirrors the adjacent `Vector3D` assertions).
- CS1729: `Matrix4D` has no 16-argument constructor; the 45-degree Z-rotation matrix is now built with the parameterless constructor and the `[row, column]` indexer.

## Product fix (`BoundingBox3D.Intersect(Segment3D)`)

Once compiling, `Intersect_SegmentBothEndpointsOutsideCrossingBox_ShouldReturnTrue` failed: a segment fully crossing the box (both endpoints outside) returned `false`.

Cause: the face-plane loop validated intersection points with `On(point3D)`, which resolves to the `ISegmentable3D` overload and therefore only tests the 12 box edges. A crossing point in a face interior (e.g. (0, 5, 5) on face X = 0 of box [0,10]^3) was rejected.

Fix: validate candidates with the inclusive bounds test `Inside(point3D, acceptOnEdge: true, tolerance)`; the point already lies on the face plane, so inclusive box membership is the correct surface test. The colinear-segment branch now tests the actual intersection-segment endpoints instead of the original segment endpoints with the same edge-only `On(...)`.

## Validation

- `dotnet build SAM.sln -c Release`: 0 errors.
- `dotnet test SAM/SAM.Tests`: 164 passed, 0 failed, 0 skipped (previously: did not compile; after compile-only fix: 1 failed).
- Unaffected: `Intersect_SegmentCrossingBounds_ShouldCheckMultiplePlanes` (early exit path) and `Intersect_SegmentBboxOverlapsButSegmentMisses_ShouldReturnFalse` (still correctly false).

## Follow-up suggestion (not in this PR)

Add SAM.Tests to SAM.sln or CI so test-compilation breaks are caught automatically.