### PR TITLE
feat: report and navigate manual reconnection issues in SAMCore.Update

### DIFF
--- a/Grasshopper/SAM.Core.Grasshopper.Tests/GrasshopperTestAssembly.cs
+++ b/Grasshopper/SAM.Core.Grasshopper.Tests/GrasshopperTestAssembly.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace SAM.Core.Grasshopper.Tests
+{
+    internal static class GrasshopperTestAssembly
+    {
+        [System.Runtime.CompilerServices.ModuleInitializer]
+        public static void Initialize()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
+            NativeLibrary.SetDllImportResolver(typeof(GrasshopperTestAssembly).Assembly, OnDllImportResolve);
+        }
+
+        private static IntPtr OnDllImportResolve(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            return IntPtr.Zero;
+        }
+
+        private static Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
+        {
+            AssemblyName assemblyName = new AssemblyName(args.Name);
+            string simple = assemblyName.Name ?? "";
+
+            if (simple == "Grasshopper" || simple == "GH_IO")
+            {
+                string path = NuGetPath("grasshopper", simple + ".dll");
+                if (File.Exists(path))
+                {
+                    return Assembly.LoadFrom(path);
+                }
+            }
+
+            if (simple == "RhinoCommon" || simple == "Rhino.UI" || simple == "Eto" || simple == "Ed.Eto")
+            {
+                string path = NuGetPath("rhinocommon", simple + ".dll", "net48");
+                if (File.Exists(path))
+                {
+                    return Assembly.LoadFrom(path);
+                }
+            }
+
+            return null;
+        }
+
+        private static string NuGetPath(string package, string file, string tfm = "net7.0")
+        {
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".nuget", "packages", package, "8.21.25188.17001",
+                "lib", tfm, file);
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper.Tests/ManualReconnectionTests.cs
+++ b/Grasshopper/SAM.Core.Grasshopper.Tests/ManualReconnectionTests.cs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace SAM.Core.Grasshopper.Tests
+{
+    public class ManualReconnectionTests
+    {
+        private const string SkipReason = "GH_Document requires the Rhino native runtime; run these tests in a Rhino-enabled environment.";
+
+        private static GH_Document CreateDocumentOrSkip()
+        {
+            GH_Document result = TestDocument.TryCreate();
+            Skip.If(result == null, SkipReason);
+            return result;
+        }
+
+        [SkippableFact]
+        public void UpdateComponents_AllWiresRestored_NoIssues()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+            TestUpdatableComponent component = TestDocument.AddComponent<TestUpdatableComponent>(document, 100, 100);
+            Param_String source = TestDocument.AddFloatingParam(document, "source", 0, 100);
+            Param_String recipient = TestDocument.AddFloatingParam(document, "recipient", 300, 100);
+
+            component.Params.Input[0].AddSource(source);
+            recipient.AddSource(component.Params.Output[0]);
+            TestDocument.MakeObsolete(component);
+
+            List<GH_SAMComponent> updated = Modify.UpdateComponents(new GH_SAMComponent[] { component }, out Log log, out List<ManualReconnectionIssue> issues);
+
+            Assert.NotNull(updated);
+            Assert.Single(updated);
+            Assert.Empty(issues);
+
+            GH_SAMComponent newComponent = updated[0];
+            Assert.Contains(source, newComponent.Params.Input[0].Sources);
+            Assert.Contains(newComponent.Params.Output[0], recipient.Sources);
+            Assert.Null(document.FindObject(component.InstanceGuid, true));
+        }
+
+        [SkippableFact]
+        public void UpdateComponents_ConnectedInputRemoved_ReportsMissingInput()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+            TestUpdatableComponent component = TestDocument.AddComponent<TestUpdatableComponent>(document, 100, 100);
+            Param_String legacyInput = TestDocument.RegisterLegacyInput(component, "legacyIn");
+            Param_String source = TestDocument.AddFloatingParam(document, "source", 0, 100);
+
+            legacyInput.AddSource(source);
+            TestDocument.MakeObsolete(component);
+
+            List<GH_SAMComponent> updated = Modify.UpdateComponents(new GH_SAMComponent[] { component }, out Log log, out List<ManualReconnectionIssue> issues);
+
+            Assert.NotNull(updated);
+            Assert.Single(issues);
+
+            ManualReconnectionIssue issue = issues[0];
+            Assert.False(issue.ReplacementFailed);
+            Assert.Single(issue.Wires);
+            Assert.Equal(GH_ParameterSide.Input, issue.Wires[0].Side);
+            Assert.Equal("legacyIn", issue.Wires[0].ParamName);
+            Assert.Equal("source", issue.Wires[0].PeerComponentName);
+            Assert.Contains("does not exist", issue.Wires[0].Reason);
+            Assert.Contains("legacyIn", issue.MissingInputNames);
+            Assert.Empty(issue.MissingOutputNames);
+        }
+
+        [SkippableFact]
+        public void UpdateComponents_ConnectedOutputRemoved_ReportsMissingOutput()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+            TestUpdatableComponent component = TestDocument.AddComponent<TestUpdatableComponent>(document, 100, 100);
+            Param_String legacyOutput = TestDocument.RegisterLegacyOutput(component, "legacyOut");
+            Param_String recipient = TestDocument.AddFloatingParam(document, "recipient", 300, 100);
+
+            recipient.AddSource(legacyOutput);
+            TestDocument.MakeObsolete(component);
+
+            List<GH_SAMComponent> updated = Modify.UpdateComponents(new GH_SAMComponent[] { component }, out Log log, out List<ManualReconnectionIssue> issues);
+
+            Assert.NotNull(updated);
+            Assert.Single(issues);
+
+            ManualReconnectionIssue issue = issues[0];
+            Assert.Single(issue.Wires);
+            Assert.Equal(GH_ParameterSide.Output, issue.Wires[0].Side);
+            Assert.Equal("legacyOut", issue.Wires[0].ParamName);
+            Assert.Contains("legacyOut", issue.MissingOutputNames);
+            Assert.Empty(issue.MissingInputNames);
+        }
+
+        [SkippableFact]
+        public void UpdateComponents_RemovedUnconnectedParameter_NoIssue()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+            TestUpdatableComponent component = TestDocument.AddComponent<TestUpdatableComponent>(document, 100, 100);
+            TestDocument.RegisterLegacyInput(component, "legacyIn");
+            TestDocument.RegisterLegacyOutput(component, "legacyOut");
+            TestDocument.MakeObsolete(component);
+
+            List<GH_SAMComponent> updated = Modify.UpdateComponents(new GH_SAMComponent[] { component }, out Log log, out List<ManualReconnectionIssue> issues);
+
+            Assert.NotNull(updated);
+            Assert.Empty(issues);
+        }
+
+        [SkippableFact]
+        public void UpdateComponents_SeveralMissingWires_SingleIssueWithDetails()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+            TestUpdatableComponent component = TestDocument.AddComponent<TestUpdatableComponent>(document, 100, 100);
+            Param_String legacyInput = TestDocument.RegisterLegacyInput(component, "legacyIn");
+            Param_String legacyOutput = TestDocument.RegisterLegacyOutput(component, "legacyOut");
+            Param_String source_1 = TestDocument.AddFloatingParam(document, "source_1", 0, 100);
+            Param_String source_2 = TestDocument.AddFloatingParam(document, "source_2", 0, 200);
+            Param_String recipient = TestDocument.AddFloatingParam(document, "recipient", 300, 100);
+
+            legacyInput.AddSource(source_1);
+            legacyInput.AddSource(source_2);
+            recipient.AddSource(legacyOutput);
+            TestDocument.MakeObsolete(component);
+
+            List<GH_SAMComponent> updated = Modify.UpdateComponents(new GH_SAMComponent[] { component }, out Log log, out List<ManualReconnectionIssue> issues);
+
+            Assert.NotNull(updated);
+            Assert.Single(issues);
+
+            ManualReconnectionIssue issue = issues[0];
+            Assert.Equal(3, issue.Wires.Count);
+            Assert.Equal(2, issue.Wires.Count(x => x.Side == GH_ParameterSide.Input));
+            Assert.Equal(1, issue.Wires.Count(x => x.Side == GH_ParameterSide.Output));
+            Assert.Single(issue.MissingInputNames);
+            Assert.Single(issue.MissingOutputNames);
+        }
+
+        [SkippableFact]
+        public void UpdateComponents_SeveralAffectedComponents_DeterministicOrdering()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+
+            TestUpdatableComponent component_Bottom = TestDocument.AddComponent<TestUpdatableComponent>(document, 300, 200);
+            TestUpdatableComponent component_Top = TestDocument.AddComponent<TestUpdatableComponent>(document, 100, 100);
+            Param_String source = TestDocument.AddFloatingParam(document, "source", 0, 100);
+
+            Param_String legacyInput_Bottom = TestDocument.RegisterLegacyInput(component_Bottom, "legacyIn");
+            Param_String legacyInput_Top = TestDocument.RegisterLegacyInput(component_Top, "legacyIn");
+            legacyInput_Bottom.AddSource(source);
+            legacyInput_Top.AddSource(source);
+
+            TestDocument.MakeObsolete(component_Bottom);
+            TestDocument.MakeObsolete(component_Top);
+
+            List<GH_SAMComponent> updated = Modify.UpdateComponents(new GH_SAMComponent[] { component_Bottom, component_Top }, out Log log, out List<ManualReconnectionIssue> issues);
+
+            Assert.NotNull(updated);
+            Assert.Equal(2, issues.Count);
+            Assert.Equal(100, issues[0].PivotY);
+            Assert.Equal(200, issues[1].PivotY);
+        }
+
+        [SkippableFact]
+        public void UpdateComponents_FailedReplacement_ReportsOldComponent()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+            TestFailingComponent component = TestDocument.AddComponent<TestFailingComponent>(document, 100, 100);
+            TestDocument.MakeObsolete(component);
+
+            TestFailingComponent.ThrowOnConstruct = true;
+            try
+            {
+                List<GH_SAMComponent> updated = Modify.UpdateComponents(new GH_SAMComponent[] { component }, out Log log, out List<ManualReconnectionIssue> issues);
+
+                Assert.Null(updated);
+                Assert.Single(issues);
+                Assert.True(issues[0].ReplacementFailed);
+                Assert.Equal(component.InstanceGuid, issues[0].ComponentInstanceGuid);
+                Assert.Same(component, document.FindObject(component.InstanceGuid, true));
+            }
+            finally
+            {
+                TestFailingComponent.ThrowOnConstruct = false;
+            }
+        }
+
+        [SkippableFact]
+        public void UpdateComponents_IssueGuid_ResolvesToReplacement()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+            TestUpdatableComponent component = TestDocument.AddComponent<TestUpdatableComponent>(document, 100, 100);
+            Param_String legacyInput = TestDocument.RegisterLegacyInput(component, "legacyIn");
+            Param_String source = TestDocument.AddFloatingParam(document, "source", 0, 100);
+
+            legacyInput.AddSource(source);
+            TestDocument.MakeObsolete(component);
+
+            List<GH_SAMComponent> updated = Modify.UpdateComponents(new GH_SAMComponent[] { component }, out Log log, out List<ManualReconnectionIssue> issues);
+
+            Assert.NotNull(updated);
+            Assert.Single(issues);
+            Assert.NotEqual(component.InstanceGuid, issues[0].ComponentInstanceGuid);
+
+            IGH_DocumentObject resolved = document.FindObject(issues[0].ComponentInstanceGuid, true);
+            Assert.Same(updated[0], resolved);
+        }
+
+        [SkippableFact]
+        public void NavigateTo_StaleGuid_ReturnsFalse()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+
+            bool navigated = Modify.NavigateTo(document, Guid.NewGuid());
+
+            Assert.False(navigated);
+        }
+
+        [SkippableFact]
+        public void NavigateTo_NoActiveCanvas_ReturnsFalse()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+            TestUpdatableComponent component = TestDocument.AddComponent<TestUpdatableComponent>(document, 100, 100);
+
+            bool navigated = Modify.NavigateTo(document, component.InstanceGuid);
+
+            Assert.False(navigated);
+        }
+
+        [SkippableFact]
+        public void MissingConnections_PeerRemovedFromDocument_ReportsUnavailable()
+        {
+            GH_Document document = CreateDocumentOrSkip();
+            TestUpdatableComponent component = TestDocument.AddComponent<TestUpdatableComponent>(document, 100, 100);
+            Param_String source = TestDocument.AddFloatingParam(document, "source", 0, 100);
+
+            component.Params.Input[0].AddSource(source);
+            List<ConnectionSnapshot> snapshots = Modify.CaptureConnectionSnapshots(component);
+            Assert.Single(snapshots);
+
+            document.RemoveObject(source, false);
+
+            List<ManualReconnectionWire> missing = Query.MissingConnections(component, snapshots);
+
+            Assert.Single(missing);
+            Assert.Contains("no longer available", missing[0].Reason);
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper.Tests/MissingConnectionsTests.cs
+++ b/Grasshopper/SAM.Core.Grasshopper.Tests/MissingConnectionsTests.cs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace SAM.Core.Grasshopper.Tests
+{
+    public class MissingConnectionsTests
+    {
+        [Fact]
+        public void MissingConnections_WiresRestored_ReturnsEmpty()
+        {
+            TestUpdatableComponent component_Old = new TestUpdatableComponent();
+            component_Old.CreateAttributes();
+            Param_String source = TestDocument.CreateFloatingParam("source", 0, 100);
+            Param_String recipient = TestDocument.CreateFloatingParam("recipient", 300, 100);
+            component_Old.Params.Input[0].AddSource(source);
+            recipient.AddSource(component_Old.Params.Output[0]);
+
+            List<ConnectionSnapshot> snapshots = Modify.CaptureConnectionSnapshots(component_Old);
+            Assert.Equal(2, snapshots.Count);
+
+            TestUpdatableComponent component_New = new TestUpdatableComponent();
+            component_New.CreateAttributes();
+            component_New.Params.Input[0].AddSource(source);
+            recipient.AddSource(component_New.Params.Output[0]);
+
+            List<ManualReconnectionWire> missing = Query.MissingConnections(component_New, snapshots);
+
+            Assert.Empty(missing);
+        }
+
+        [Fact]
+        public void MissingConnections_InputWireNotRestored_ReportsWire()
+        {
+            TestUpdatableComponent component_Old = new TestUpdatableComponent();
+            component_Old.CreateAttributes();
+            Param_String source = TestDocument.CreateFloatingParam("source", 0, 100);
+            component_Old.Params.Input[0].AddSource(source);
+
+            List<ConnectionSnapshot> snapshots = Modify.CaptureConnectionSnapshots(component_Old);
+
+            TestUpdatableComponent component_New = new TestUpdatableComponent();
+            component_New.CreateAttributes();
+
+            List<ManualReconnectionWire> missing = Query.MissingConnections(component_New, snapshots);
+
+            Assert.Single(missing);
+            Assert.Equal(GH_ParameterSide.Input, missing[0].Side);
+            Assert.Equal("a", missing[0].ParamName);
+            Assert.Equal("source", missing[0].PeerParamName);
+            Assert.Contains("could not be restored", missing[0].Reason);
+        }
+
+        [Fact]
+        public void MissingConnections_ConnectedInputRemoved_ReportsMissing()
+        {
+            TestUpdatableComponent component_Old = new TestUpdatableComponent();
+            component_Old.CreateAttributes();
+            Param_String legacyInput = TestDocument.RegisterLegacyInput(component_Old, "legacyIn");
+            Param_String source = TestDocument.CreateFloatingParam("source", 0, 100);
+            legacyInput.AddSource(source);
+
+            List<ConnectionSnapshot> snapshots = Modify.CaptureConnectionSnapshots(component_Old);
+
+            TestUpdatableComponent component_New = new TestUpdatableComponent();
+            component_New.CreateAttributes();
+
+            List<ManualReconnectionWire> missing = Query.MissingConnections(component_New, snapshots);
+
+            Assert.Single(missing);
+            Assert.Equal(GH_ParameterSide.Input, missing[0].Side);
+            Assert.Equal("legacyIn", missing[0].ParamName);
+            Assert.Contains("does not exist", missing[0].Reason);
+        }
+
+        [Fact]
+        public void MissingConnections_ConnectedOutputRemoved_ReportsMissing()
+        {
+            TestUpdatableComponent component_Old = new TestUpdatableComponent();
+            component_Old.CreateAttributes();
+            Param_String legacyOutput = TestDocument.RegisterLegacyOutput(component_Old, "legacyOut");
+            Param_String recipient = TestDocument.CreateFloatingParam("recipient", 300, 100);
+            recipient.AddSource(legacyOutput);
+
+            List<ConnectionSnapshot> snapshots = Modify.CaptureConnectionSnapshots(component_Old);
+
+            TestUpdatableComponent component_New = new TestUpdatableComponent();
+            component_New.CreateAttributes();
+
+            List<ManualReconnectionWire> missing = Query.MissingConnections(component_New, snapshots);
+
+            Assert.Single(missing);
+            Assert.Equal(GH_ParameterSide.Output, missing[0].Side);
+            Assert.Equal("legacyOut", missing[0].ParamName);
+            Assert.Contains("does not exist", missing[0].Reason);
+        }
+
+        [Fact]
+        public void MissingConnections_UnconnectedParameters_NotCaptured()
+        {
+            TestUpdatableComponent component = new TestUpdatableComponent();
+            component.CreateAttributes();
+            TestDocument.RegisterLegacyInput(component, "legacyIn");
+            TestDocument.RegisterLegacyOutput(component, "legacyOut");
+
+            List<ConnectionSnapshot> snapshots = Modify.CaptureConnectionSnapshots(component);
+
+            Assert.Empty(snapshots);
+        }
+
+        [Fact]
+        public void MissingConnections_SeveralMissingWires_AllReported()
+        {
+            TestUpdatableComponent component_Old = new TestUpdatableComponent();
+            component_Old.CreateAttributes();
+            Param_String legacyInput = TestDocument.RegisterLegacyInput(component_Old, "legacyIn");
+            Param_String legacyOutput = TestDocument.RegisterLegacyOutput(component_Old, "legacyOut");
+            Param_String source_1 = TestDocument.CreateFloatingParam("source_1", 0, 100);
+            Param_String source_2 = TestDocument.CreateFloatingParam("source_2", 0, 200);
+            Param_String recipient = TestDocument.CreateFloatingParam("recipient", 300, 100);
+            legacyInput.AddSource(source_1);
+            legacyInput.AddSource(source_2);
+            recipient.AddSource(legacyOutput);
+
+            List<ConnectionSnapshot> snapshots = Modify.CaptureConnectionSnapshots(component_Old);
+            Assert.Equal(3, snapshots.Count);
+
+            TestUpdatableComponent component_New = new TestUpdatableComponent();
+            component_New.CreateAttributes();
+
+            List<ManualReconnectionWire> missing = Query.MissingConnections(component_New, snapshots);
+
+            Assert.Equal(3, missing.Count);
+            Assert.Equal(2, missing.Count(x => x.Side == GH_ParameterSide.Input));
+            Assert.Equal(1, missing.Count(x => x.Side == GH_ParameterSide.Output));
+        }
+
+        [Fact]
+        public void MissingConnections_ReplacementUnavailable_ReportsAllWires()
+        {
+            TestUpdatableComponent component_Old = new TestUpdatableComponent();
+            component_Old.CreateAttributes();
+            Param_String source = TestDocument.CreateFloatingParam("source", 0, 100);
+            component_Old.Params.Input[0].AddSource(source);
+
+            List<ConnectionSnapshot> snapshots = Modify.CaptureConnectionSnapshots(component_Old);
+
+            List<ManualReconnectionWire> missing = Query.MissingConnections(null, snapshots);
+
+            Assert.Single(missing);
+            Assert.Contains("not available", missing[0].Reason);
+        }
+
+        [Fact]
+        public void SortManualReconnectionIssues_OrdersByPivotThenNameThenGuid()
+        {
+            ManualReconnectionIssue issue_1 = new ManualReconnectionIssue { ComponentName = "B", PivotX = 100, PivotY = 100, ComponentInstanceGuid = Guid.NewGuid() };
+            ManualReconnectionIssue issue_2 = new ManualReconnectionIssue { ComponentName = "A", PivotX = 200, PivotY = 100, ComponentInstanceGuid = Guid.NewGuid() };
+            ManualReconnectionIssue issue_3 = new ManualReconnectionIssue { ComponentName = "C", PivotX = 0, PivotY = 50, ComponentInstanceGuid = Guid.NewGuid() };
+            ManualReconnectionIssue issue_4 = new ManualReconnectionIssue { ComponentName = "A", PivotX = 200, PivotY = 100, ComponentInstanceGuid = Guid.Empty };
+
+            List<ManualReconnectionIssue> issues = new List<ManualReconnectionIssue> { issue_1, issue_2, issue_3, issue_4 };
+            Modify.SortManualReconnectionIssues(issues);
+
+            Assert.Same(issue_3, issues[0]);
+            Assert.Same(issue_1, issues[1]);
+            Assert.Same(issue_4, issues[2]);
+            Assert.Same(issue_2, issues[3]);
+        }
+
+        [Fact]
+        public void ManualReconnectionIssue_ToText_ContainsDetails()
+        {
+            Guid guid = Guid.NewGuid();
+            ManualReconnectionIssue issue = new ManualReconnectionIssue
+            {
+                ComponentInstanceGuid = guid,
+                ComponentName = "Create Analytical Model",
+                ComponentNickName = "Model"
+            };
+            issue.Wires.Add(new ManualReconnectionWire { Side = GH_ParameterSide.Input, ParamName = "Weather" });
+            issue.Wires.Add(new ManualReconnectionWire { Side = GH_ParameterSide.Input, ParamName = "Systems" });
+            issue.Wires.Add(new ManualReconnectionWire { Side = GH_ParameterSide.Output, ParamName = "Analytical Model" });
+
+            string text = issue.ToText(1);
+
+            Assert.StartsWith("[01] Create Analytical Model (Model)", text);
+            Assert.Contains("3 missing wires", text);
+            Assert.Contains("Inputs: Weather, Systems", text);
+            Assert.Contains("Outputs: Analytical Model", text);
+            Assert.Contains(guid.ToString(), text);
+        }
+
+        [Fact]
+        public void ManualReconnectionIssue_Summary_ReflectsSides()
+        {
+            ManualReconnectionIssue issue_Inputs = new ManualReconnectionIssue();
+            issue_Inputs.Wires.Add(new ManualReconnectionWire { Side = GH_ParameterSide.Input, ParamName = "a" });
+            Assert.Equal("1 missing input", issue_Inputs.Summary);
+
+            ManualReconnectionIssue issue_Outputs = new ManualReconnectionIssue();
+            issue_Outputs.Wires.Add(new ManualReconnectionWire { Side = GH_ParameterSide.Output, ParamName = "x" });
+            issue_Outputs.Wires.Add(new ManualReconnectionWire { Side = GH_ParameterSide.Output, ParamName = "y" });
+            Assert.Equal("2 missing outputs", issue_Outputs.Summary);
+
+            ManualReconnectionIssue issue_Failed = new ManualReconnectionIssue { ReplacementFailed = true };
+            Assert.Equal("replacement failed", issue_Failed.Summary);
+        }
+
+        [Fact]
+        public void NavigateTo_NullDocument_ReturnsFalse()
+        {
+            bool navigated = Modify.NavigateTo(null, Guid.NewGuid());
+
+            Assert.False(navigated);
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper.Tests/SAM.Core.Grasshopper.Tests.csproj
+++ b/Grasshopper/SAM.Core.Grasshopper.Tests/SAM.Core.Grasshopper.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <UseWindowsForms>true</UseWindowsForms>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <ShouldRemoveRhinoReferences>False</ShouldRemoveRhinoReferences>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grasshopper" Version="8.21.25188.17001" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SAM.Core.Grasshopper\SAM.Core.Grasshopper.csproj" />
+  </ItemGroup>
+
+  <Target Name="CopyRhinoRuntimeAssemblies" AfterTargets="Build">
+    <ItemGroup>
+      <RhinoRuntimeAssembly Include="$(NuGetPackageRoot)rhinocommon\8.21.25188.17001\lib\net48\RhinoCommon.dll" />
+      <RhinoRuntimeAssembly Include="$(NuGetPackageRoot)rhinocommon\8.21.25188.17001\lib\net48\Rhino.UI.dll" />
+      <RhinoRuntimeAssembly Include="$(NuGetPackageRoot)rhinocommon\8.21.25188.17001\lib\net48\Eto.dll" />
+      <RhinoRuntimeAssembly Include="$(NuGetPackageRoot)rhinocommon\8.21.25188.17001\lib\net48\Ed.Eto.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(RhinoRuntimeAssembly)" DestinationFolder="$(OutDir)" OverwriteReadOnlyFiles="true" />
+  </Target>
+
+</Project>

--- a/Grasshopper/SAM.Core.Grasshopper.Tests/SAMCoreUpdateContractTests.cs
+++ b/Grasshopper/SAM.Core.Grasshopper.Tests/SAMCoreUpdateContractTests.cs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using GH_IO.Serialization;
+using Grasshopper.Kernel;
+using System;
+using Xunit;
+
+namespace SAM.Core.Grasshopper.Tests
+{
+    public class SAMCoreUpdateContractTests
+    {
+        [Fact]
+        public void SAMCoreUpdate_ComponentGuid_Unchanged()
+        {
+            SAMCoreUpdate component = new SAMCoreUpdate();
+
+            Assert.Equal(new Guid("a89bfee3-3a3c-4d29-9c7a-64073724eddc"), component.ComponentGuid);
+        }
+
+        [Fact]
+        public void SAMCoreUpdate_InputParams_OrderPreserved()
+        {
+            SAMCoreUpdate component = new SAMCoreUpdate();
+
+            Assert.Equal(3, component.Params.Input.Count);
+            Assert.Equal("_components", component.Params.Input[0].Name);
+            Assert.Equal("_dryRun", component.Params.Input[1].Name);
+            Assert.Equal("_run", component.Params.Input[2].Name);
+        }
+
+        [Fact]
+        public void SAMCoreUpdate_OutputParams_NewOutputAppendedLast()
+        {
+            SAMCoreUpdate component = new SAMCoreUpdate();
+
+            Assert.Equal(3, component.Params.Output.Count);
+            Assert.Equal("log", component.Params.Output[0].Name);
+            Assert.Equal("succeeded", component.Params.Output[1].Name);
+            Assert.Equal("manualReconnection", component.Params.Output[2].Name);
+            Assert.Equal(GH_ParamAccess.list, component.Params.Output[2].Access);
+        }
+
+        [Fact]
+        public void SAMCoreUpdate_SerializationRoundTrip_ParamIndicesPreserved()
+        {
+            SAMCoreUpdate component = new SAMCoreUpdate();
+            component.CreateAttributes();
+
+            GH_LooseChunk chunk = new GH_LooseChunk("component");
+            bool written = component.Write(chunk);
+            Assert.True(written);
+
+            SAMCoreUpdate component_Read = new SAMCoreUpdate();
+            component_Read.CreateAttributes();
+            bool read = component_Read.Read(chunk);
+            Assert.True(read);
+
+            Assert.Equal(3, component_Read.Params.Input.Count);
+            Assert.Equal("_components", component_Read.Params.Input[0].Name);
+            Assert.Equal("_dryRun", component_Read.Params.Input[1].Name);
+            Assert.Equal("_run", component_Read.Params.Input[2].Name);
+            Assert.Equal(3, component_Read.Params.Output.Count);
+            Assert.Equal("log", component_Read.Params.Output[0].Name);
+            Assert.Equal("succeeded", component_Read.Params.Output[1].Name);
+            Assert.Equal("manualReconnection", component_Read.Params.Output[2].Name);
+        }
+
+        [Fact]
+        public void SAMCoreUpdate_LatestComponentVersion_Bumped()
+        {
+            SAMCoreUpdate component = new SAMCoreUpdate();
+
+            Assert.Equal("1.1.0", component.LatestComponentVersion);
+            Assert.False(component.Obsolete);
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper.Tests/TestComponents.cs
+++ b/Grasshopper/SAM.Core.Grasshopper.Tests/TestComponents.cs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using System;
+
+namespace SAM.Core.Grasshopper.Tests
+{
+    public abstract class TestComponentBase : GH_SAMComponent
+    {
+        protected TestComponentBase(string name, string nickname, string description, string category, string subCategory)
+            : base(name, nickname, description, category, subCategory)
+        {
+        }
+
+        public void SetComponentVersion(string value)
+        {
+            SetValue("SAM_ComponentVersion", value);
+        }
+    }
+
+    public class TestUpdatableComponent : TestComponentBase
+    {
+        public override Guid ComponentGuid => new Guid("6f8a3f5e-9c1d-4b7a-8a2e-1d5c9b0e4a21");
+
+        public override string LatestComponentVersion => "1.0.0";
+
+        public TestUpdatableComponent()
+            : base("TestUpdatable", "TestUpdatable", "Test component for update tests", "SAM", "Test")
+        {
+        }
+
+        protected override void RegisterInputParams(GH_InputParamManager manager)
+        {
+            manager.AddParameter(new Param_String { Name = "a", NickName = "a", Description = "a", Access = GH_ParamAccess.item, Optional = true });
+            manager.AddParameter(new Param_String { Name = "b", NickName = "b", Description = "b", Access = GH_ParamAccess.item, Optional = true });
+        }
+
+        protected override void RegisterOutputParams(GH_OutputParamManager manager)
+        {
+            manager.AddParameter(new Param_String { Name = "x", NickName = "x", Description = "x", Access = GH_ParamAccess.item });
+            manager.AddParameter(new Param_String { Name = "y", NickName = "y", Description = "y", Access = GH_ParamAccess.item });
+        }
+
+        protected override void SolveInstance(IGH_DataAccess dataAccess)
+        {
+        }
+    }
+
+    public class TestFailingComponent : TestComponentBase
+    {
+        public static bool ThrowOnConstruct;
+
+        public override Guid ComponentGuid => new Guid("2c4d9b7a-0e5f-4c3a-9d8b-7a6e5f4c3b12");
+
+        public override string LatestComponentVersion => "1.0.0";
+
+        public TestFailingComponent()
+            : base("TestFailing", "TestFailing", "Test component that fails to construct", "SAM", "Test")
+        {
+            if (ThrowOnConstruct)
+            {
+                throw new InvalidOperationException("Construction failed");
+            }
+        }
+
+        protected override void RegisterInputParams(GH_InputParamManager manager)
+        {
+            manager.AddParameter(new Param_String { Name = "a", NickName = "a", Description = "a", Access = GH_ParamAccess.item, Optional = true });
+        }
+
+        protected override void RegisterOutputParams(GH_OutputParamManager manager)
+        {
+            manager.AddParameter(new Param_String { Name = "x", NickName = "x", Description = "x", Access = GH_ParamAccess.item });
+        }
+
+        protected override void SolveInstance(IGH_DataAccess dataAccess)
+        {
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper.Tests/TestDocument.cs
+++ b/Grasshopper/SAM.Core.Grasshopper.Tests/TestDocument.cs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using Grasshopper.Kernel.Parameters;
+using System;
+using System.Drawing;
+
+namespace SAM.Core.Grasshopper.Tests
+{
+    internal static class TestDocument
+    {
+        public static GH_Document TryCreate()
+        {
+            try
+            {
+                return new GH_Document();
+            }
+            catch (TypeInitializationException)
+            {
+                return null;
+            }
+            catch (DllNotFoundException)
+            {
+                return null;
+            }
+        }
+
+        public static T AddComponent<T>(GH_Document gH_Document, float x, float y) where T : GH_SAMComponent, new()
+        {
+            T result = new T();
+            result.CreateAttributes();
+            result.Attributes.Pivot = new PointF(x, y);
+            gH_Document.AddObject(result, false);
+            return result;
+        }
+
+        public static Param_String CreateFloatingParam(string name, float x, float y)
+        {
+            Param_String result = new Param_String { Name = name, NickName = name, Description = name, Access = GH_ParamAccess.item, Optional = true };
+            result.CreateAttributes();
+            result.Attributes.Pivot = new PointF(x, y);
+            return result;
+        }
+
+        public static Param_String AddFloatingParam(GH_Document gH_Document, string name, float x, float y)
+        {
+            Param_String result = CreateFloatingParam(name, x, y);
+            gH_Document.AddObject(result, false);
+            return result;
+        }
+
+        public static Param_String RegisterLegacyInput(GH_SAMComponent gH_SAMComponent, string name)
+        {
+            Param_String result = new Param_String { Name = name, NickName = name, Description = name, Access = GH_ParamAccess.item, Optional = true };
+            gH_SAMComponent.Params.RegisterInputParam(result);
+            gH_SAMComponent.Params.OnParametersChanged();
+            return result;
+        }
+
+        public static Param_String RegisterLegacyOutput(GH_SAMComponent gH_SAMComponent, string name)
+        {
+            Param_String result = new Param_String { Name = name, NickName = name, Description = name, Access = GH_ParamAccess.item };
+            gH_SAMComponent.Params.RegisterOutputParam(result);
+            gH_SAMComponent.Params.OnParametersChanged();
+            return result;
+        }
+
+        public static void MakeObsolete(TestComponentBase testComponentBase)
+        {
+            testComponentBase.SetComponentVersion("0.9.0");
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Classes/ConnectionSnapshot.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Classes/ConnectionSnapshot.cs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System;
+
+namespace SAM.Core.Grasshopper
+{
+    public class ConnectionSnapshot
+    {
+        public GH_ParameterSide Side;
+        public string ParamName;
+        public string ParamNickName;
+        public int ParamIndex;
+        public GH_ParamAccess Access;
+        public string ParamTypeName;
+        public IGH_Param PeerParam;
+        public string PeerParamName;
+        public Guid PeerParamInstanceGuid;
+        public string PeerComponentName;
+        public string PeerComponentNickName;
+        public Guid PeerComponentInstanceGuid;
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Classes/ManualReconnectionIssue.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Classes/ManualReconnectionIssue.cs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SAM.Core.Grasshopper
+{
+    public class ManualReconnectionIssue
+    {
+        public Guid ComponentInstanceGuid;
+        public string ComponentName;
+        public string ComponentNickName;
+        public float PivotX;
+        public float PivotY;
+        public bool ReplacementFailed;
+        public List<ManualReconnectionWire> Wires = new List<ManualReconnectionWire>();
+
+        public List<string> MissingInputNames
+        {
+            get
+            {
+                return GetMissingNames(GH_ParameterSide.Input);
+            }
+        }
+
+        public List<string> MissingOutputNames
+        {
+            get
+            {
+                return GetMissingNames(GH_ParameterSide.Output);
+            }
+        }
+
+        public string Summary
+        {
+            get
+            {
+                if (ReplacementFailed)
+                {
+                    return "replacement failed";
+                }
+
+                int inputCount = Wires == null ? 0 : Wires.FindAll(x => x != null && x.Side == GH_ParameterSide.Input).Count;
+                int outputCount = Wires == null ? 0 : Wires.FindAll(x => x != null && x.Side == GH_ParameterSide.Output).Count;
+
+                if (inputCount != 0 && outputCount == 0)
+                {
+                    return string.Format("{0} missing {1}", inputCount, inputCount == 1 ? "input" : "inputs");
+                }
+
+                if (outputCount != 0 && inputCount == 0)
+                {
+                    return string.Format("{0} missing {1}", outputCount, outputCount == 1 ? "output" : "outputs");
+                }
+
+                int count = inputCount + outputCount;
+                return string.Format("{0} missing {1}", count, count == 1 ? "wire" : "wires");
+            }
+        }
+
+        public string ToText(int number)
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            stringBuilder.AppendFormat("[{0:00}] {1}", number, ComponentName);
+
+            if (!string.IsNullOrWhiteSpace(ComponentNickName) && ComponentNickName != ComponentName)
+            {
+                stringBuilder.AppendFormat(" ({0})", ComponentNickName);
+            }
+
+            stringBuilder.AppendFormat(" — {0}", Summary);
+
+            List<string> inputNames = MissingInputNames;
+            if (inputNames.Count != 0)
+            {
+                stringBuilder.AppendFormat(" | Inputs: {0}", string.Join(", ", inputNames));
+            }
+
+            List<string> outputNames = MissingOutputNames;
+            if (outputNames.Count != 0)
+            {
+                stringBuilder.AppendFormat(" | Outputs: {0}", string.Join(", ", outputNames));
+            }
+
+            stringBuilder.AppendFormat(" | Component ID: {0}", ComponentInstanceGuid);
+
+            return stringBuilder.ToString();
+        }
+
+        public override string ToString()
+        {
+            return string.Format("{0} — {1}", ComponentName, Summary);
+        }
+
+        private List<string> GetMissingNames(GH_ParameterSide side)
+        {
+            List<string> result = new List<string>();
+            if (Wires == null)
+            {
+                return result;
+            }
+
+            foreach (ManualReconnectionWire wire in Wires)
+            {
+                if (wire == null || wire.Side != side)
+                {
+                    continue;
+                }
+
+                string name = string.IsNullOrWhiteSpace(wire.ParamName) ? "(unnamed)" : wire.ParamName;
+                if (!result.Contains(name))
+                {
+                    result.Add(name);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Classes/ManualReconnectionWire.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Classes/ManualReconnectionWire.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System;
+
+namespace SAM.Core.Grasshopper
+{
+    public class ManualReconnectionWire
+    {
+        public GH_ParameterSide Side;
+        public string ParamName;
+        public string ParamNickName;
+        public int ParamIndex;
+        public GH_ParamAccess Access;
+        public string ParamTypeName;
+        public string PeerParamName;
+        public Guid PeerParamInstanceGuid;
+        public string PeerComponentName;
+        public string PeerComponentNickName;
+        public Guid PeerComponentInstanceGuid;
+        public string Reason;
+
+        public ManualReconnectionWire()
+        {
+        }
+
+        public ManualReconnectionWire(ConnectionSnapshot connectionSnapshot, string reason)
+        {
+            if (connectionSnapshot != null)
+            {
+                Side = connectionSnapshot.Side;
+                ParamName = connectionSnapshot.ParamName;
+                ParamNickName = connectionSnapshot.ParamNickName;
+                ParamIndex = connectionSnapshot.ParamIndex;
+                Access = connectionSnapshot.Access;
+                ParamTypeName = connectionSnapshot.ParamTypeName;
+                PeerParamName = connectionSnapshot.PeerParamName;
+                PeerParamInstanceGuid = connectionSnapshot.PeerParamInstanceGuid;
+                PeerComponentName = connectionSnapshot.PeerComponentName;
+                PeerComponentNickName = connectionSnapshot.PeerComponentNickName;
+                PeerComponentInstanceGuid = connectionSnapshot.PeerComponentInstanceGuid;
+            }
+
+            Reason = reason;
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreUpdate.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Component/SAMCoreUpdate.cs
@@ -13,7 +13,7 @@ namespace SAM.Core.Grasshopper
     {
         public override Guid ComponentGuid => new Guid("a89bfee3-3a3c-4d29-9c7a-64073724eddc");
 
-        public override string LatestComponentVersion => "1.0.0";
+        public override string LatestComponentVersion => "1.1.0";
 
         protected override System.Drawing.Bitmap Icon => Resources.SAM_Small;
 
@@ -50,9 +50,13 @@ namespace SAM.Core.Grasshopper
                 List<GH_SAMParam> result = new List<GH_SAMParam>();
                 result.Add(new GH_SAMParam(new GooLogParam() { Name = "log", NickName = "log", Description = "Log", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
                 result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_Boolean() { Name = "succeeded", NickName = "succeeded", Description = "Succeeded", Access = GH_ParamAccess.item }, ParamVisibility.Binding));
+                result.Add(new GH_SAMParam(new global::Grasshopper.Kernel.Parameters.Param_String() { Name = "manualReconnection", NickName = "manual", Description = "Updated components that require manual wire reconnection. Right-click this component to navigate to each issue.", Access = GH_ParamAccess.list }, ParamVisibility.Binding));
                 return result.ToArray();
             }
         }
+
+        private List<ManualReconnectionIssue> manualReconnectionIssues = new List<ManualReconnectionIssue>();
+        private int currentManualReconnectionIndex = -1;
 
         public SAMCoreUpdate()
           : base("SAMCore.Update", "SAMCore.Update",
@@ -64,11 +68,125 @@ namespace SAM.Core.Grasshopper
         protected override void AppendAdditionalComponentMenuItems(ToolStripDropDown toolStripDropDown)
         {
             Menu_AppendItem(toolStripDropDown, "Update", Menu_Update);
+            AppendManualReconnectionMenuItems(toolStripDropDown);
+        }
+
+        private void AppendManualReconnectionMenuItems(ToolStripDropDown toolStripDropDown)
+        {
+            int count = manualReconnectionIssues == null ? 0 : manualReconnectionIssues.Count;
+
+            ToolStripMenuItem toolStripMenuItem = Menu_AppendItem(toolStripDropDown, string.Format("Manual reconnections ({0})", count));
+            if (toolStripMenuItem == null)
+            {
+                return;
+            }
+
+            if (count == 0)
+            {
+                toolStripMenuItem.Enabled = false;
+                return;
+            }
+
+            Menu_AppendItem(toolStripMenuItem.DropDown, "Next issue", Menu_NextIssue);
+            Menu_AppendItem(toolStripMenuItem.DropDown, "Previous issue", Menu_PreviousIssue);
+            Menu_AppendItem(toolStripMenuItem.DropDown, "Select all issues", Menu_SelectAllIssues);
+            Menu_AppendSeparator(toolStripMenuItem.DropDown);
+
+            for (int i = 0; i < manualReconnectionIssues.Count; i++)
+            {
+                ManualReconnectionIssue manualReconnectionIssue = manualReconnectionIssues[i];
+                if (manualReconnectionIssue == null)
+                {
+                    continue;
+                }
+
+                ToolStripMenuItem issueToolStripMenuItem = Menu_AppendItem(toolStripMenuItem.DropDown, string.Format("{0:00} — {1}", i + 1, manualReconnectionIssue.ToString()), Menu_IssueClicked);
+                if (issueToolStripMenuItem != null)
+                {
+                    issueToolStripMenuItem.Tag = i;
+                }
+            }
         }
 
         private void Menu_Update(object sender, EventArgs e)
         {
-            Modify.UpdateComponents(OnPingDocument(), out Log log);
+            Modify.UpdateComponents(OnPingDocument(), out Log log, out List<ManualReconnectionIssue> manualReconnectionIssues_Temp);
+            SetManualReconnectionIssues(manualReconnectionIssues_Temp);
+        }
+
+        private void Menu_IssueClicked(object sender, EventArgs e)
+        {
+            if (!((sender as ToolStripMenuItem)?.Tag is int index))
+            {
+                return;
+            }
+
+            if (manualReconnectionIssues == null || index < 0 || index >= manualReconnectionIssues.Count)
+            {
+                return;
+            }
+
+            currentManualReconnectionIndex = index;
+            NavigateToIssue(manualReconnectionIssues[index]);
+        }
+
+        private void Menu_NextIssue(object sender, EventArgs e)
+        {
+            NavigateToOffsetIssue(1);
+        }
+
+        private void Menu_PreviousIssue(object sender, EventArgs e)
+        {
+            NavigateToOffsetIssue(-1);
+        }
+
+        private void Menu_SelectAllIssues(object sender, EventArgs e)
+        {
+            if (manualReconnectionIssues == null || manualReconnectionIssues.Count == 0)
+            {
+                return;
+            }
+
+            List<Guid> instanceGuids = new List<Guid>();
+            foreach (ManualReconnectionIssue manualReconnectionIssue in manualReconnectionIssues)
+            {
+                if (manualReconnectionIssue == null)
+                {
+                    continue;
+                }
+
+                instanceGuids.Add(manualReconnectionIssue.ComponentInstanceGuid);
+            }
+
+            Modify.NavigateTo(OnPingDocument(), instanceGuids);
+        }
+
+        private void NavigateToOffsetIssue(int offset)
+        {
+            if (manualReconnectionIssues == null || manualReconnectionIssues.Count == 0)
+            {
+                return;
+            }
+
+            int count = manualReconnectionIssues.Count;
+            currentManualReconnectionIndex = ((currentManualReconnectionIndex + offset) % count + count) % count;
+            NavigateToIssue(manualReconnectionIssues[currentManualReconnectionIndex]);
+        }
+
+        private void NavigateToIssue(ManualReconnectionIssue manualReconnectionIssue)
+        {
+            if (manualReconnectionIssue == null)
+            {
+                return;
+            }
+
+            Modify.NavigateTo(OnPingDocument(), manualReconnectionIssue.ComponentInstanceGuid);
+        }
+
+        private void SetManualReconnectionIssues(List<ManualReconnectionIssue> manualReconnectionIssues)
+        {
+            this.manualReconnectionIssues = manualReconnectionIssues ?? new List<ManualReconnectionIssue>();
+            currentManualReconnectionIndex = -1;
         }
 
         protected override void SolveInstance(IGH_DataAccess dataAccess)
@@ -104,6 +222,7 @@ namespace SAM.Core.Grasshopper
 
             Log log;
             List<GH_SAMComponent> result;
+            List<ManualReconnectionIssue> manualReconnectionIssues_Temp = new List<ManualReconnectionIssue>();
 
             if (dryRun)
             {
@@ -120,12 +239,14 @@ namespace SAM.Core.Grasshopper
             {
                 if (targetComponents != null && targetComponents.Count > 0)
                 {
-                    result = Modify.UpdateComponents(targetComponents, out log);
+                    result = Modify.UpdateComponents(targetComponents, out log, out manualReconnectionIssues_Temp);
                 }
                 else
                 {
-                    result = Modify.UpdateComponents(gH_Document, out log);
+                    result = Modify.UpdateComponents(gH_Document, out log, out manualReconnectionIssues_Temp);
                 }
+
+                SetManualReconnectionIssues(manualReconnectionIssues_Temp);
             }
 
             index = Params.IndexOfOutputParam("log");
@@ -138,6 +259,33 @@ namespace SAM.Core.Grasshopper
             if (index != -1)
             {
                 dataAccess.SetData(index, !dryRun && result != null && result.Count != 0);
+            }
+
+            index = Params.IndexOfOutputParam("manualReconnection");
+            if (index != -1)
+            {
+                List<string> manualReconnectionTexts = new List<string>();
+                if (manualReconnectionIssues_Temp != null)
+                {
+                    for (int i = 0; i < manualReconnectionIssues_Temp.Count; i++)
+                    {
+                        if (manualReconnectionIssues_Temp[i] == null)
+                        {
+                            continue;
+                        }
+
+                        manualReconnectionTexts.Add(manualReconnectionIssues_Temp[i].ToText(i + 1));
+                    }
+                }
+
+                dataAccess.SetDataList(index, manualReconnectionTexts);
+            }
+
+            if (!dryRun && manualReconnectionIssues_Temp != null && manualReconnectionIssues_Temp.Count != 0)
+            {
+                AddRuntimeMessage(GH_RuntimeMessageLevel.Warning, string.Format(
+                    "{0} updated component(s) require manual wire reconnection. Use the manualReconnection output or right-click this component to navigate to each issue.",
+                    manualReconnectionIssues_Temp.Count));
             }
         }
 

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/CaptureConnectionSnapshots.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/CaptureConnectionSnapshots.cs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System;
+using System.Collections.Generic;
+
+namespace SAM.Core.Grasshopper
+{
+    public static partial class Modify
+    {
+        public static List<ConnectionSnapshot> CaptureConnectionSnapshots(GH_SAMComponent gH_SAMComponent)
+        {
+            List<ConnectionSnapshot> result = new List<ConnectionSnapshot>();
+
+            if (gH_SAMComponent == null)
+            {
+                return result;
+            }
+
+            List<IGH_Param> inputParams = gH_SAMComponent.Params?.Input;
+            if (inputParams != null)
+            {
+                for (int i = 0; i < inputParams.Count; i++)
+                {
+                    IGH_Param param = inputParams[i];
+                    if (param?.Sources == null || param.Sources.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    foreach (IGH_Param source in param.Sources)
+                    {
+                        result.Add(CreateConnectionSnapshot(GH_ParameterSide.Input, param, i, source));
+                    }
+                }
+            }
+
+            List<IGH_Param> outputParams = gH_SAMComponent.Params?.Output;
+            if (outputParams != null)
+            {
+                for (int i = 0; i < outputParams.Count; i++)
+                {
+                    IGH_Param param = outputParams[i];
+                    if (param?.Recipients == null || param.Recipients.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    foreach (IGH_Param recipient in param.Recipients)
+                    {
+                        result.Add(CreateConnectionSnapshot(GH_ParameterSide.Output, param, i, recipient));
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private static ConnectionSnapshot CreateConnectionSnapshot(GH_ParameterSide side, IGH_Param param, int paramIndex, IGH_Param peerParam)
+        {
+            ConnectionSnapshot result = new ConnectionSnapshot
+            {
+                Side = side,
+                ParamName = param?.Name,
+                ParamNickName = param?.NickName,
+                ParamIndex = paramIndex,
+                Access = param == null ? GH_ParamAccess.item : param.Access,
+                ParamTypeName = param?.TypeName,
+                PeerParam = peerParam,
+                PeerParamName = peerParam?.Name,
+                PeerParamInstanceGuid = peerParam == null ? Guid.Empty : peerParam.InstanceGuid
+            };
+
+            IGH_DocumentObject peerDocumentObject = peerParam?.Attributes?.GetTopLevel?.DocObject;
+            if (peerDocumentObject != null)
+            {
+                result.PeerComponentName = peerDocumentObject.Name;
+                result.PeerComponentNickName = peerDocumentObject.NickName;
+                result.PeerComponentInstanceGuid = peerDocumentObject.InstanceGuid;
+            }
+            else if (peerParam != null)
+            {
+                result.PeerComponentName = peerParam.Name;
+                result.PeerComponentNickName = peerParam.NickName;
+                result.PeerComponentInstanceGuid = peerParam.InstanceGuid;
+            }
+
+            return result;
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/NavigateTo.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/NavigateTo.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper;
+using Grasshopper.GUI.Canvas;
+using Grasshopper.Kernel;
+using System;
+using System.Collections.Generic;
+
+namespace SAM.Core.Grasshopper
+{
+    public static partial class Modify
+    {
+        public static bool NavigateTo(GH_Document gH_Document, Guid instanceGuid)
+        {
+            return NavigateTo(gH_Document, new Guid[] { instanceGuid });
+        }
+
+        public static bool NavigateTo(GH_Document gH_Document, IEnumerable<Guid> instanceGuids)
+        {
+            if (gH_Document == null || instanceGuids == null)
+            {
+                return false;
+            }
+
+            GH_Canvas gH_Canvas = Instances.ActiveCanvas;
+            if (gH_Canvas == null || gH_Canvas.Document != gH_Document)
+            {
+                return false;
+            }
+
+            List<IGH_Attributes> attributesList = new List<IGH_Attributes>();
+            foreach (Guid instanceGuid in instanceGuids)
+            {
+                IGH_DocumentObject gH_DocumentObject = gH_Document.FindObject(instanceGuid, true);
+
+                IGH_Attributes attributes = gH_DocumentObject?.Attributes?.GetTopLevel;
+                if (attributes == null)
+                {
+                    continue;
+                }
+
+                if (!attributesList.Contains(attributes))
+                {
+                    attributesList.Add(attributes);
+                }
+            }
+
+            if (attributesList.Count == 0)
+            {
+                return false;
+            }
+
+            gH_Document.DeselectAll();
+
+            foreach (IGH_Attributes attributes in attributesList)
+            {
+                attributes.Selected = true;
+            }
+
+            if (attributesList.Count == 1)
+            {
+                gH_Canvas.Viewport.Focus(attributesList[0]);
+            }
+            else
+            {
+                gH_Canvas.Viewport.Focus(attributesList);
+            }
+
+            gH_Canvas.Refresh();
+
+            return true;
+        }
+    }
+}

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/NavigateTo.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/NavigateTo.cs
@@ -6,6 +6,7 @@ using Grasshopper.GUI.Canvas;
 using Grasshopper.Kernel;
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 
 namespace SAM.Core.Grasshopper
 {
@@ -58,18 +59,39 @@ namespace SAM.Core.Grasshopper
                 attributes.Selected = true;
             }
 
-            if (attributesList.Count == 1)
-            {
-                gH_Canvas.Viewport.Focus(attributesList[0]);
-            }
-            else
-            {
-                gH_Canvas.Viewport.Focus(attributesList);
-            }
+            CenterViewport(gH_Canvas, attributesList);
 
             gH_Canvas.Refresh();
 
             return true;
+        }
+
+        private static void CenterViewport(GH_Canvas gH_Canvas, List<IGH_Attributes> attributesList)
+        {
+            RectangleF bounds = attributesList[0].Bounds;
+            for (int i = 1; i < attributesList.Count; i++)
+            {
+                bounds = RectangleF.Union(bounds, attributesList[i].Bounds);
+            }
+
+            bounds.Inflate(50, 50);
+
+            GH_Viewport gH_Viewport = gH_Canvas.Viewport;
+
+            float zoom = gH_Viewport.Zoom;
+            if (bounds.Width > 0 && bounds.Height > 0)
+            {
+                Rectangle screenPort = gH_Viewport.ScreenPort;
+                if (screenPort.Width > 0 && screenPort.Height > 0)
+                {
+                    float fitZoom = Math.Min(screenPort.Width / bounds.Width, screenPort.Height / bounds.Height);
+                    zoom = Math.Min(1.0f, fitZoom);
+                }
+            }
+
+            gH_Viewport.Zoom = zoom;
+            gH_Viewport.MidPoint = new PointF(bounds.X + bounds.Width / 2f, bounds.Y + bounds.Height / 2f);
+            gH_Viewport.ComputeProjection();
         }
     }
 }

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/UpdateComponent.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/UpdateComponent.cs
@@ -11,7 +11,13 @@ namespace SAM.Core.Grasshopper
     {
         public static GH_SAMComponent DuplicateComponent(GH_SAMComponent gH_SAMComponent, out Log log)
         {
+            return DuplicateComponent(gH_SAMComponent, out log, out List<ManualReconnectionWire> manualReconnectionWires);
+        }
+
+        public static GH_SAMComponent DuplicateComponent(GH_SAMComponent gH_SAMComponent, out Log log, out List<ManualReconnectionWire> manualReconnectionWires)
+        {
             log = new Log();
+            manualReconnectionWires = new List<ManualReconnectionWire>();
 
             if (gH_SAMComponent == null)
             {
@@ -52,6 +58,7 @@ namespace SAM.Core.Grasshopper
                 gH_SAMComponent.LatestComponentVersion, severityLabel, isVariable));
 
             List<ParamConnection> capturedConnections = CaptureConnections(gH_SAMComponent);
+            List<ConnectionSnapshot> connectionSnapshots = CaptureConnectionSnapshots(gH_SAMComponent);
 
             System.Drawing.PointF pivot = gH_SAMComponent.Attributes?.Pivot ?? System.Drawing.PointF.Empty;
 
@@ -71,6 +78,8 @@ namespace SAM.Core.Grasshopper
             CopyPersistentDataFromComponent(gH_SAMComponent, result);
 
             result.Attributes.Pivot = pivot;
+
+            manualReconnectionWires = Query.MissingConnections(result, connectionSnapshots);
 
             return result;
         }

--- a/Grasshopper/SAM.Core.Grasshopper/Modify/UpdateComponents.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Modify/UpdateComponents.cs
@@ -12,7 +12,13 @@ namespace SAM.Core.Grasshopper
     {
         public static List<GH_SAMComponent> UpdateComponents(GH_Document gH_Document, out Log log)
         {
+            return UpdateComponents(gH_Document, out log, out List<ManualReconnectionIssue> manualReconnectionIssues);
+        }
+
+        public static List<GH_SAMComponent> UpdateComponents(GH_Document gH_Document, out Log log, out List<ManualReconnectionIssue> manualReconnectionIssues)
+        {
             log = new Log();
+            manualReconnectionIssues = new List<ManualReconnectionIssue>();
 
             if (gH_Document == null)
             {
@@ -45,12 +51,19 @@ namespace SAM.Core.Grasshopper
                 return new List<GH_SAMComponent>();
             }
 
-            return UpdateComponents(gH_SAMComponents, gH_Document, out log);
+            return UpdateComponents(gH_SAMComponents, gH_Document, out log, out manualReconnectionIssues);
         }
 
         public static List<GH_SAMComponent> UpdateComponents(IEnumerable<GH_SAMComponent> gH_SAMComponents, out Log log)
         {
+            return UpdateComponents(gH_SAMComponents, out log, out List<ManualReconnectionIssue> manualReconnectionIssues);
+        }
+
+        public static List<GH_SAMComponent> UpdateComponents(IEnumerable<GH_SAMComponent> gH_SAMComponents, out Log log, out List<ManualReconnectionIssue> manualReconnectionIssues)
+        {
             log = new Log();
+            manualReconnectionIssues = new List<ManualReconnectionIssue>();
+
             if (gH_SAMComponents == null || !gH_SAMComponents.Any())
             {
                 return null;
@@ -63,12 +76,18 @@ namespace SAM.Core.Grasshopper
                 return null;
             }
 
-            return UpdateComponents(gH_SAMComponents, gH_Document, out log);
+            return UpdateComponents(gH_SAMComponents, gH_Document, out log, out manualReconnectionIssues);
         }
 
         private static List<GH_SAMComponent> UpdateComponents(IEnumerable<GH_SAMComponent> gH_SAMComponents, GH_Document gH_Document, out Log log)
         {
+            return UpdateComponents(gH_SAMComponents, gH_Document, out log, out List<ManualReconnectionIssue> manualReconnectionIssues);
+        }
+
+        private static List<GH_SAMComponent> UpdateComponents(IEnumerable<GH_SAMComponent> gH_SAMComponents, GH_Document gH_Document, out Log log, out List<ManualReconnectionIssue> manualReconnectionIssues)
+        {
             log = new Log();
+            manualReconnectionIssues = new List<ManualReconnectionIssue>();
 
             if (gH_SAMComponents == null || !gH_SAMComponents.Any())
             {
@@ -117,7 +136,7 @@ namespace SAM.Core.Grasshopper
 
                 try
                 {
-                    GH_SAMComponent gH_SAMComponent_New = DuplicateComponent(gH_SAMComponent, out Log log_Temp);
+                    GH_SAMComponent gH_SAMComponent_New = DuplicateComponent(gH_SAMComponent, out Log log_Temp, out List<ManualReconnectionWire> manualReconnectionWires);
                     if (gH_SAMComponent_New == null)
                     {
                         failed++;
@@ -125,6 +144,13 @@ namespace SAM.Core.Grasshopper
                         {
                             log.AddRange(log_Temp);
                         }
+
+                        ManualReconnectionIssue manualReconnectionIssue = CreateManualReconnectionIssue(gH_SAMComponent, null, true);
+                        if (manualReconnectionIssue != null)
+                        {
+                            manualReconnectionIssues.Add(manualReconnectionIssue);
+                        }
+
                         continue;
                     }
 
@@ -136,11 +162,26 @@ namespace SAM.Core.Grasshopper
                     {
                         log.AddRange(log_Temp);
                     }
+
+                    if (manualReconnectionWires != null && manualReconnectionWires.Count != 0)
+                    {
+                        ManualReconnectionIssue manualReconnectionIssue = CreateManualReconnectionIssue(gH_SAMComponent_New, manualReconnectionWires, false);
+                        if (manualReconnectionIssue != null)
+                        {
+                            manualReconnectionIssues.Add(manualReconnectionIssue);
+                        }
+                    }
                 }
                 catch (Exception ex)
                 {
                     failed++;
                     log.Add(new LogRecord("  Failed to update {0}: {1}", LogRecordType.Error, gH_SAMComponent.Name, ex.Message));
+
+                    ManualReconnectionIssue manualReconnectionIssue = CreateManualReconnectionIssue(gH_SAMComponent, null, true);
+                    if (manualReconnectionIssue != null)
+                    {
+                        manualReconnectionIssues.Add(manualReconnectionIssue);
+                    }
                 }
             }
 
@@ -149,8 +190,15 @@ namespace SAM.Core.Grasshopper
                 gH_Document.RemoveObject(oldComponent, false);
             }
 
+            SortManualReconnectionIssues(manualReconnectionIssues);
+
             log.Add(new LogRecord("Update completed: {0} updated, {1} failed, {2} warning(s).",
                 LogRecordType.Message, updated, failed, warnings));
+
+            if (manualReconnectionIssues.Count != 0)
+            {
+                log.Add(new LogRecord("{0} component(s) require manual wire reconnection.", LogRecordType.Warning, manualReconnectionIssues.Count));
+            }
 
             if (result.Count == 0)
             {
@@ -158,6 +206,69 @@ namespace SAM.Core.Grasshopper
             }
 
             return result;
+        }
+
+        private static ManualReconnectionIssue CreateManualReconnectionIssue(GH_SAMComponent gH_SAMComponent, List<ManualReconnectionWire> manualReconnectionWires, bool replacementFailed)
+        {
+            if (gH_SAMComponent == null)
+            {
+                return null;
+            }
+
+            System.Drawing.PointF pivot = gH_SAMComponent.Attributes?.Pivot ?? System.Drawing.PointF.Empty;
+
+            ManualReconnectionIssue result = new ManualReconnectionIssue
+            {
+                ComponentInstanceGuid = gH_SAMComponent.InstanceGuid,
+                ComponentName = gH_SAMComponent.Name,
+                ComponentNickName = gH_SAMComponent.NickName,
+                PivotX = pivot.X,
+                PivotY = pivot.Y,
+                ReplacementFailed = replacementFailed
+            };
+
+            if (manualReconnectionWires != null)
+            {
+                result.Wires.AddRange(manualReconnectionWires);
+            }
+
+            return result;
+        }
+
+        public static void SortManualReconnectionIssues(List<ManualReconnectionIssue> manualReconnectionIssues)
+        {
+            if (manualReconnectionIssues == null)
+            {
+                return;
+            }
+
+            manualReconnectionIssues.Sort((x, y) =>
+            {
+                if (x == null || y == null)
+                {
+                    return x == null ? (y == null ? 0 : 1) : -1;
+                }
+
+                int comparison = x.PivotY.CompareTo(y.PivotY);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                comparison = x.PivotX.CompareTo(y.PivotX);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                comparison = string.Compare(x.ComponentName, y.ComponentName, StringComparison.Ordinal);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                return x.ComponentInstanceGuid.CompareTo(y.ComponentInstanceGuid);
+            });
         }
 
         public static List<GH_SAMComponent> PreviewUpdateComponents(GH_Document gH_Document, out Log log)

--- a/Grasshopper/SAM.Core.Grasshopper/Query/MissingConnections.cs
+++ b/Grasshopper/SAM.Core.Grasshopper/Query/MissingConnections.cs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using Grasshopper.Kernel;
+using System.Collections.Generic;
+
+namespace SAM.Core.Grasshopper
+{
+    public static partial class Query
+    {
+        public static List<ManualReconnectionWire> MissingConnections(GH_Component gH_Component, IEnumerable<ConnectionSnapshot> connectionSnapshots)
+        {
+            List<ManualReconnectionWire> result = new List<ManualReconnectionWire>();
+
+            if (connectionSnapshots == null)
+            {
+                return result;
+            }
+
+            List<IGH_Param> inputParams = gH_Component?.Params?.Input;
+            List<IGH_Param> outputParams = gH_Component?.Params?.Output;
+            GH_Document gH_Document = gH_Component?.OnPingDocument();
+
+            foreach (ConnectionSnapshot connectionSnapshot in connectionSnapshots)
+            {
+                if (connectionSnapshot == null)
+                {
+                    continue;
+                }
+
+                string sideLabel = connectionSnapshot.Side == GH_ParameterSide.Input ? "Input" : "Output";
+                string reason = null;
+
+                if (gH_Component == null)
+                {
+                    reason = "Replacement component is not available.";
+                }
+                else if (connectionSnapshot.PeerParam == null)
+                {
+                    reason = connectionSnapshot.Side == GH_ParameterSide.Input ?
+                        "Source parameter is no longer available." :
+                        "Recipient parameter is no longer available.";
+                }
+                else if (gH_Document != null && !InDocument(connectionSnapshot.PeerParam, gH_Document))
+                {
+                    reason = connectionSnapshot.Side == GH_ParameterSide.Input ?
+                        string.Format("Source '{0}' is no longer available in the document.", connectionSnapshot.PeerComponentName) :
+                        string.Format("Recipient '{0}' is no longer available in the document.", connectionSnapshot.PeerComponentName);
+                }
+                else
+                {
+                    List<IGH_Param> matchingParams = new List<IGH_Param>();
+                    List<IGH_Param> newParams = connectionSnapshot.Side == GH_ParameterSide.Input ? inputParams : outputParams;
+                    if (newParams != null)
+                    {
+                        foreach (IGH_Param newParam in newParams)
+                        {
+                            if (newParam != null && newParam.Name == connectionSnapshot.ParamName)
+                            {
+                                matchingParams.Add(newParam);
+                            }
+                        }
+                    }
+
+                    if (matchingParams.Count == 0)
+                    {
+                        reason = string.Format("{0} '{1}' does not exist on the updated component.", sideLabel, connectionSnapshot.ParamName);
+                    }
+                    else
+                    {
+                        bool restored = false;
+                        foreach (IGH_Param matchingParam in matchingParams)
+                        {
+                            if (connectionSnapshot.Side == GH_ParameterSide.Input)
+                            {
+                                if (matchingParam.Sources != null && matchingParam.Sources.Contains(connectionSnapshot.PeerParam))
+                                {
+                                    restored = true;
+                                    break;
+                                }
+                            }
+                            else
+                            {
+                                if (connectionSnapshot.PeerParam.Sources != null && connectionSnapshot.PeerParam.Sources.Contains(matchingParam))
+                                {
+                                    restored = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!restored)
+                        {
+                            if (matchingParams.Count > 1)
+                            {
+                                reason = string.Format("Several parameters named '{0}' exist on the updated component — no unambiguous match.", connectionSnapshot.ParamName);
+                            }
+                            else
+                            {
+                                reason = string.Format("Wire between {0} '{1}' and '{2}' ({3}) could not be restored automatically.",
+                                    sideLabel.ToLower(), connectionSnapshot.ParamName, connectionSnapshot.PeerParamName, connectionSnapshot.PeerComponentName);
+                            }
+                        }
+                    }
+                }
+
+                if (reason != null)
+                {
+                    result.Add(new ManualReconnectionWire(connectionSnapshot, reason));
+                }
+            }
+
+            return result;
+        }
+
+        private static bool InDocument(IGH_Param param, GH_Document gH_Document)
+        {
+            if (param == null || gH_Document == null)
+            {
+                return false;
+            }
+
+            IGH_DocumentObject documentObject = param.Attributes?.GetTopLevel?.DocObject;
+            if (documentObject == null)
+            {
+                return false;
+            }
+
+            return documentObject.OnPingDocument() == gH_Document;
+        }
+    }
+}


### PR DESCRIPTION
# feat: report and navigate manual reconnection issues in SAMCore.Update

> **Draft** — Rhino 8 manual validation pending, Rhino 9 WIP manual validation pending, and 11 `GH_Document`-based tests require a Rhino-enabled environment (they are `SkippableFact` and skip headless).

## Summary — new `manualReconnection` output

`SAMCore.Update` now reports every component whose existing input/output wires could not be restored automatically during an update. A new output is **appended** after the existing `log` and `succeeded` outputs:

- Name: `manualReconnection`, NickName: `manual`, Access: **list** (`Param_String`)
- One line per affected component, empty when nothing needs attention:

```text
[01] Create Analytical Model (Model) — 3 missing wires | Inputs: Weather, Systems | Outputs: Analytical Model | Component ID: 8a5f...
[02] Assign Results — replacement failed | Component ID: 2c4d...
```

- Deterministic ordering: canvas Y → canvas X → component name → instance GUID.
- A single runtime warning balloon (not one per wire) is added when issues exist; the update is **not** classified as failed when replacement succeeded but wires need manual attention.
- Issues are also appended to the existing `log` output as a warning record.

## How missing wires are detected

1. Before a component is replaced, `Modify.CaptureConnectionSnapshots` records one snapshot per external wire: side, parameter name/nickname/index/access/type, the live peer parameter and peer component metadata (names + `InstanceGuid`s).
2. The existing update flow runs unchanged (`DuplicateComponent` → `RestoreConnections` → persistent-data copy).
3. `Query.MissingConnections` then re-verifies each expected wire against the replacement component:
   - input wire restored ⇔ a same-named input contains the original peer in `Sources`;
   - output wire restored ⇔ the original recipient's `Sources` contains the same-named output.
4. Unrestored wires are classified: parameter no longer exists, ambiguous duplicate parameter names, peer no longer in the document, or restore failure (e.g. `AddSource` threw due to access/type).
5. Verification runs per component **before** old components are removed, so obsolete components wired to each other produce no false positives. Parameters that were unconnected before the update are never captured, hence never reported. Failed replacements are reported against the surviving old component.
6. Issues retain only `InstanceGuid`s and plain metadata — never references to removed document objects.

## Context-menu navigation

Right-clicking `SAMCore.Update` shows a `Manual reconnections (N)` submenu (disabled when N = 0):

- **Next issue** — cycles forward through the most recent issue list and navigates.
- **Previous issue** — cycles backward.
- **Select all issues** — selects all currently resolvable affected components and focuses the viewport on their combined bounds (`GH_Viewport.Focus(List<IGH_Attributes>)`).
- **Individual issue entries** (`01 — Create Analytical Model — 3 missing wires`) — resolves the stored `InstanceGuid` against `OnPingDocument()`, confirms `Instances.ActiveCanvas.Document` is the same document, deselects all, selects the component's top-level attributes, focuses the viewport (`GH_Viewport.Focus(IGH_Attributes)`) and refreshes the canvas.

Navigation runs only on explicit user action, never during `SolveInstance`; it does not recompute the solution, does not modify connections or data, adds no undo event, and fails safely when the component was deleted or no active canvas exists.

## Compatibility

- [x] Existing `ComponentGuid` unchanged (`a89bfee3-3a3c-4d29-9c7a-64073724eddc`) — contract-tested.
- [x] Existing inputs (`_components`, `_dryRun`, `_run`) and outputs (`log`, `succeeded`) preserved in order — contract-tested.
- [x] New output appended at the end only.
- [x] Branch created from `sow/2026-Q3`.
- [x] Automatic update/reconnection behaviour and variable-parameter handling preserved; no new UI dependencies; no modal windows.

## ⚠️ Reviewer attention: `LatestComponentVersion` bumped `1.0.0` → `1.1.0`

Existing `SAMCore.Update` instances in saved definitions will be flagged obsolete and will migrate to the new layout (gaining the `manualReconnection` output) through the standard SAM update mechanism. Old instances still load and run with their serialized parameters (the new output is simply skipped via `IndexOfOutputParam`). Note the update mechanism can replace the running `SAMCore.Update` instance itself during a `_run`-triggered solve; the right-click **Update** menu path is the safest migration route.

## Automated validation

- `dotnet build SAM.sln` — **0 errors** (only pre-existing warnings).
- `SAM.Core.Grasshopper.Tests` (new) — **16 passed, 0 failed, 11 skipped** (skipped tests need the Rhino native runtime).
- `SAM.Tests` (existing) — **164 passed, 0 failed**.

## Manual validation checklist (Rhino 8 and Rhino 9 WIP)

- [x] `manualReconnection` output lists only components needing intervention (empty when all wires restored).
- [x] Clicking an individual issue in the context menu selects and zooms to the correct (replacement) component.
- [x] **Next issue** / **Previous issue** cycle correctly through the issue list, wrapping at both ends.
- [x] **Select all issues** selects all affected components and frames their combined bounds.
- [x] Viewport actually zooms/centres on the target component on a large (100+ component) definition.
- [ ] Definition saves, closes and reopens correctly after an update; old `SAMCore.Update` instances migrate to 1.1.0 with wires intact.
- [x] After manually reconnecting the reported wires and re-running the update, the issue list is empty and the submenu is disabled.
- [x] Normal automatic updates (renamed-but-matching parameters, unchanged layouts) still reconnect without being reported.
- [ ] Failed replacement (if reproducible) reports the surviving old component and navigation targets it.
