### PR TITLE
fix: guard against null TraceFirst vector in fin/overhang panel creation

### DIFF
--- a/SAM/SAM.Analytical/Create/Panels.cs
+++ b/SAM/SAM.Analytical/Create/Panels.cs
@@ -433,8 +433,16 @@ namespace SAM.Analytical
                     }
 
                     Vector2D vector2D_Base = Geometry.Planar.Query.TraceFirst(centroid, direction_Base, rectangle2D);
+                    if(vector2D_Base is null)
+                    {
+                        continue;
+                    }
 
                     Vector2D vector2D_Auxiliary = direction_Auxiliary * (length_Auxiliary / 2);
+                    if(vector2D_Auxiliary is null)
+                    {
+                        continue;
+                    }
 
                     if (overhangDepth > 0)
                     {

--- a/SAM/SAM.Geometry/Geometry/Planar/Classes/Point2D.cs
+++ b/SAM/SAM.Geometry/Geometry/Planar/Classes/Point2D.cs
@@ -210,6 +210,11 @@ namespace SAM.Geometry.Planar
 
         public Point2D GetMoved(Vector2D vector2D)
         {
+            if(vector2D is null)
+            {
+                return null;
+            }
+
             return new Point2D(vector2D[0] + coordinates[0], vector2D[1] + coordinates[1]);
         }
 


### PR DESCRIPTION
## Summary
- `Point2D.GetMoved` indexed into a `Vector2D` without a null check.
- `Panels.cs` fin/overhang case creation called `Query.TraceFirst`, which can return null when the trace finds no intersection with the rectangle, and used the result without checking — throwing a `NullReferenceException`.
- Both now skip/return early instead of throwing.

## Test plan
- [x] CI build green