### PR TITLE
 Plane Optimization

### DIFF
--- a/SAM/SAM.Geometry/Geometry/Spatial/Classes/Plane.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Classes/Plane.cs
@@ -15,12 +15,17 @@ namespace SAM.Geometry.Spatial
         private Point3D origin;
         private Vector3D axisY;
 
+        internal Vector3D InternalNormal => normal;
+        internal Point3D InternalOrigin => origin;
+        internal Vector3D InternalAxisY => axisY;
+
         public Plane()
         {
-            normal = Vector3D.WorldZ; //new Vector3D(0, 0, 1);
+            normal = Vector3D.WorldZ;
             origin = Point3D.Zero;
             axisY = normal.AxisY();
         }
+
         public Plane(JsonObject jsonObject)
             : base(jsonObject)
         {
@@ -28,22 +33,28 @@ namespace SAM.Geometry.Spatial
 
         public Plane(Plane plane)
         {
-            normal = new Vector3D(plane.normal);
-            origin = new Point3D(plane.origin);
-            axisY = new Vector3D(plane.axisY);
+            if (plane != null)
+            {
+                normal = new Vector3D(plane.normal);
+                origin = new Point3D(plane.origin);
+                axisY = new Vector3D(plane.axisY);
+            }
         }
 
         public Plane(Plane plane, Point3D origin)
         {
-            normal = new Vector3D(plane.normal);
-            this.origin = new Point3D(origin);
-            axisY = new Vector3D(plane.axisY);
+            if (plane != null)
+            {
+                normal = new Vector3D(plane.normal);
+                this.origin = origin != null ? new Point3D(origin) : Point3D.Zero;
+                axisY = new Vector3D(plane.axisY);
+            }
         }
 
         public Plane(Point3D point3D_1, Point3D point3D_2, Point3D point3D_3)
         {
             origin = new Point3D(point3D_1);
-            normal = Query.Normal(point3D_1, point3D_2, point3D_3); //new Vector3D(point3D_1, point3D_2).CrossProduct(new Vector3D(point3D_1, point3D_3)).Unit;
+            normal = Query.Normal(point3D_1, point3D_2, point3D_3);
             axisY = normal.AxisY();
         }
 
@@ -58,7 +69,7 @@ namespace SAM.Geometry.Spatial
         {
             this.origin = new Point3D(origin);
             this.axisY = axisY.Unit;
-            normal = Query.Normal(axisX.Unit, this.axisY); //this.axisY.CrossProduct(axisX).Unit;
+            normal = Query.Normal(axisX.Unit, this.axisY);
         }
 
         public Vector3D Normal
@@ -85,8 +96,6 @@ namespace SAM.Geometry.Spatial
         {
             get
             {
-                //return axisY.CrossProduct(normal);
-                //return normal.CrossProduct(axisY);
                 return Query.AxisX(normal, axisY);
             }
         }
@@ -162,25 +171,35 @@ namespace SAM.Geometry.Spatial
         {
             get
             {
-                return normal.DotProduct(origin.ToVector3D());
+                return normal.X * origin.X + normal.Y * origin.Y + normal.Z * origin.Z;
             }
         }
 
         public double Distance(Point3D point3D)
         {
-            return Closest(point3D).Distance(point3D);
+            if (point3D == null)
+                return double.NaN;
+
+            return System.Math.Abs((normal.X * (point3D.X - origin.X)) + (normal.Y * (point3D.Y - origin.Y)) + (normal.Z * (point3D.Z - origin.Z)));
         }
 
         public double Distance(Segment3D segment3D)
         {
-            PlanarIntersectionResult planarIntersectionResult = Create.PlanarIntersectionResult(this, segment3D);
-            if (planarIntersectionResult == null)
+            if (segment3D == null)
                 return double.NaN;
 
-            if (!planarIntersectionResult.Intersecting)
-                return System.Math.Min(Distance(segment3D[0]), Distance(segment3D[1]));
+            Point3D p0 = segment3D[0];
+            Point3D p1 = segment3D[1];
+            if (p0 == null || p1 == null)
+                return double.NaN;
 
-            return 0;
+            double d0 = (normal.X * (p0.X - origin.X)) + (normal.Y * (p0.Y - origin.Y)) + (normal.Z * (p0.Z - origin.Z));
+            double d1 = (normal.X * (p1.X - origin.X)) + (normal.Y * (p1.Y - origin.Y)) + (normal.Z * (p1.Z - origin.Z));
+
+            if (d0 * d1 <= 0)
+                return 0;
+
+            return System.Math.Min(System.Math.Abs(d0), System.Math.Abs(d1));
         }
 
         public double Distance(ISegmentable3D segmentable3D)
@@ -202,6 +221,9 @@ namespace SAM.Geometry.Spatial
 
         public double Distance(Plane plane, double tolerance = Tolerance.Distance)
         {
+            if (plane == null)
+                return double.NaN;
+
             if (!Coplanar(plane, tolerance))
                 return 0;
 
@@ -225,7 +247,7 @@ namespace SAM.Geometry.Spatial
                 return null;
             }
 
-            double factor = point3D.ToVector3D().DotProduct(normal) - K;
+            double factor = (normal.X * (point3D.X - origin.X)) + (normal.Y * (point3D.Y - origin.Y)) + (normal.Z * (point3D.Z - origin.Z));
             return new Point3D(point3D.X - (normal.X * factor), point3D.Y - (normal.Y * factor), point3D.Z - (normal.Z * factor));
         }
 
@@ -257,12 +279,14 @@ namespace SAM.Geometry.Spatial
                 axisY = Query.AxisY(normal, axisX);
         }
 
-
-
         public ISAMGeometry3D GetMoved(Vector3D vector3D)
         {
-            Plane plane = new Plane((Point3D)origin.GetMoved(vector3D), (Vector3D)normal.Clone());
-            plane.axisY = axisY;
+            if (vector3D == null)
+                return new Plane(this);
+
+            Point3D movedOrigin = new Point3D(origin.X + vector3D.X, origin.Y + vector3D.Y, origin.Z + vector3D.Z);
+            Plane plane = new Plane(movedOrigin, normal);
+            plane.axisY = new Vector3D(axisY);
 
             return plane;
         }
@@ -297,6 +321,9 @@ namespace SAM.Geometry.Spatial
 
         public bool Coplanar(Plane plane, double tolerance = Tolerance.Distance)
         {
+            if (plane == null)
+                return false;
+
             return normal.AlmostEqual(plane.normal, tolerance) || normal.AlmostEqual(-plane.normal, tolerance);
         }
 
@@ -380,7 +407,14 @@ namespace SAM.Geometry.Spatial
 
         public override int GetHashCode()
         {
-            return new Tuple<Vector3D, Point3D, Vector3D>(normal, origin, axisY).GetHashCode();
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 23) + (normal != null ? normal.GetHashCode() : 0);
+                hash = (hash * 23) + (origin != null ? origin.GetHashCode() : 0);
+                hash = (hash * 23) + (axisY != null ? axisY.GetHashCode() : 0);
+                return hash;
+            }
         }
 
         public static bool operator ==(Plane plane_1, Plane plane_2)

--- a/SAM/SAM.Geometry/Geometry/Spatial/Classes/Plane.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Classes/Plane.cs
@@ -33,22 +33,22 @@ namespace SAM.Geometry.Spatial
 
         public Plane(Plane plane)
         {
-            if (plane != null)
-            {
-                normal = new Vector3D(plane.normal);
-                origin = new Point3D(plane.origin);
-                axisY = new Vector3D(plane.axisY);
-            }
+            if (plane == null)
+                throw new ArgumentNullException(nameof(plane));
+
+            normal = new Vector3D(plane.normal);
+            origin = new Point3D(plane.origin);
+            axisY = new Vector3D(plane.axisY);
         }
 
         public Plane(Plane plane, Point3D origin)
         {
-            if (plane != null)
-            {
-                normal = new Vector3D(plane.normal);
-                this.origin = origin != null ? new Point3D(origin) : Point3D.Zero;
-                axisY = new Vector3D(plane.axisY);
-            }
+            if (plane == null)
+                throw new ArgumentNullException(nameof(plane));
+
+            normal = new Vector3D(plane.normal);
+            this.origin = origin != null ? new Point3D(origin) : Point3D.Zero;
+            axisY = new Vector3D(plane.axisY);
         }
 
         public Plane(Point3D point3D_1, Point3D point3D_2, Point3D point3D_3)

--- a/SAM/SAM.Geometry/Geometry/Spatial/Create/Plane.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Create/Plane.cs
@@ -22,7 +22,8 @@ namespace SAM.Geometry.Spatial
                 return null;
             }
 
-            return new Plane((new Point3D[] { point3D_1, point3D_2, point3D_3 }).Average(), normal);
+            Point3D centroid = new Point3D((point3D_1.X + point3D_2.X + point3D_3.X) / 3.0, (point3D_1.Y + point3D_2.Y + point3D_3.Y) / 3.0, (point3D_1.Z + point3D_2.Z + point3D_3.Z) / 3.0);
+            return new Plane(centroid, normal);
         }
 
         public static Plane Plane(this IEnumerable<Point3D> point3Ds, double tolerance = Core.Tolerance.Distance)
@@ -44,7 +45,7 @@ namespace SAM.Geometry.Spatial
 
         public static Plane Plane(double elevation)
         {
-            return Spatial.Plane.WorldXY.GetMoved(new Vector3D(0, 0, elevation)) as Plane;
+            return new Plane(new Point3D(0, 0, elevation), Spatial.Vector3D.WorldZ);
         }
 
         public static Plane Plane(double value, int dimensionIndex)
@@ -52,11 +53,11 @@ namespace SAM.Geometry.Spatial
             switch (dimensionIndex)
             {
                 case 0:
-                    return Spatial.Plane.WorldYZ.GetMoved(new Vector3D(value, 0, 0)) as Plane;
+                    return new Plane(new Point3D(value, 0, 0), Spatial.Vector3D.WorldX);
                 case 1:
-                    return Spatial.Plane.WorldXZ.GetMoved(new Vector3D(0, value, 0)) as Plane;
+                    return new Plane(new Point3D(0, value, 0), Spatial.Vector3D.WorldY);
                 case 2:
-                    return Spatial.Plane.WorldXY.GetMoved(new Vector3D(0, 0, value)) as Plane;
+                    return new Plane(new Point3D(0, 0, value), Spatial.Vector3D.WorldZ);
             }
 
             return null;

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Above.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Above.cs
@@ -16,15 +16,12 @@ namespace SAM.Geometry.Spatial
         /// <returns></returns>
         public static bool Above(this Plane plane, Point3D point3D, double tolerance = 0)
         {
-            if (point3D == null)
+            if (point3D == null || plane == null)
                 return false;
 
-            Vector3D normal = plane?.Normal;
-            if (normal == null)
-                return false;
-
-            Point3D origin = plane.Origin;
-            if (origin == null)
+            Vector3D normal = plane.InternalNormal;
+            Point3D origin = plane.InternalOrigin;
+            if (normal == null || origin == null)
                 return false;
 
             return (normal.X * (point3D.X - origin.X)) + (normal.Y * (point3D.Y - origin.Y)) + (normal.Z * (point3D.Z - origin.Z)) > 0 + tolerance;
@@ -82,8 +79,8 @@ namespace SAM.Geometry.Spatial
                 return false;
             }
 
-            Vector3D normal = plane.Normal;
-            Point3D origin = plane.Origin;
+            Vector3D normal = plane.InternalNormal;
+            Point3D origin = plane.InternalOrigin;
             if (normal == null || origin == null)
             {
                 return false;

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Azimuth.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Azimuth.cs
@@ -21,8 +21,10 @@ namespace SAM.Geometry.Spatial
 
         public static double Azimuth(this Plane plane, Vector3D referenceDirection)
         {
+            if (plane == null || referenceDirection == null)
+                return double.NaN;
 
-            Vector3D normal = plane?.Normal;
+            Vector3D normal = plane.InternalNormal;
             if (normal == null)
                 return double.NaN;
 
@@ -32,8 +34,8 @@ namespace SAM.Geometry.Spatial
             if (normal.Z == -1)
                 return 180;
 
-            Vector3D vector3D_Project_Normal = Plane.WorldXY.Project(normal);
-            Vector3D vector3D_Project_ReferenceDirection = Plane.WorldXY.Project(referenceDirection);
+            Vector3D vector3D_Project_Normal = new Vector3D(normal.X, normal.Y, 0);
+            Vector3D vector3D_Project_ReferenceDirection = new Vector3D(referenceDirection.X, referenceDirection.Y, 0);
 
             double azimuth = SignedAngle(vector3D_Project_Normal, vector3D_Project_ReferenceDirection, Vector3D.WorldZ) * (180 / System.Math.PI);
             if (azimuth < 0)

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Convert.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Convert.cs
@@ -78,14 +78,13 @@ namespace SAM.Geometry.Spatial
                 return null;
 
             Vector3D axisX = plane.AxisX;
-            Vector3D axisY = plane.AxisY;
+            Vector3D axisY = plane.InternalAxisY;
+            Point3D origin = plane.InternalOrigin;
 
-            Vector3D u = new Vector3D(axisY.X * point2D.Y, axisY.Y * point2D.Y, axisY.Z * point2D.Y);
-            Vector3D v = new Vector3D(axisX.X * point2D.X, axisX.Y * point2D.X, axisX.Z * point2D.X);
+            double px = point2D.X;
+            double py = point2D.Y;
 
-            Point3D origin = plane.Origin;
-
-            return new Point3D(origin.X + u.X + v.X, origin.Y + u.Y + v.Y, origin.Z + u.Z + v.Z);
+            return new Point3D(origin.X + axisX.X * px + axisY.X * py, origin.Y + axisX.Y * px + axisY.Y * py, origin.Z + axisX.Z * px + axisY.Z * py);
         }
 
         public static Point2D Convert(this Plane plane, Point3D point3D)
@@ -94,11 +93,14 @@ namespace SAM.Geometry.Spatial
                 return null;
 
             Vector3D axisX = plane.AxisX;
-            Vector3D axisY = plane.AxisY;
-            Point3D origin = plane.Origin;
+            Vector3D axisY = plane.InternalAxisY;
+            Point3D origin = plane.InternalOrigin;
 
-            Vector3D vector3D = new Vector3D(point3D.X - origin.X, point3D.Y - origin.Y, point3D.Z - origin.Z);
-            return new Point2D(axisX.DotProduct(vector3D), axisY.DotProduct(vector3D));
+            double dx = point3D.X - origin.X;
+            double dy = point3D.Y - origin.Y;
+            double dz = point3D.Z - origin.Z;
+
+            return new Point2D(axisX.X * dx + axisX.Y * dy + axisX.Z * dz, axisY.X * dx + axisY.Y * dy + axisY.Z * dz);
         }
 
         public static Vector2D Convert(this Plane plane, Vector3D vector3D)
@@ -107,10 +109,13 @@ namespace SAM.Geometry.Spatial
                 return null;
 
             Vector3D axisX = plane.AxisX;
-            Vector3D axisY = plane.AxisY;
+            Vector3D axisY = plane.InternalAxisY;
 
-            //Vector3D vector3D_Result = new Vector3D(vector3D.X - origin.X, vector3D.Y - origin.Y, vector3D.Z - origin.Z);
-            return new Vector2D(axisX.DotProduct(vector3D), axisY.DotProduct(vector3D));
+            double vx = vector3D.X;
+            double vy = vector3D.Y;
+            double vz = vector3D.Z;
+
+            return new Vector2D(axisX.X * vx + axisX.Y * vy + axisX.Z * vz, axisY.X * vx + axisY.Y * vy + axisY.Z * vz);
         }
 
         public static Vector3D Convert(this Plane plane, Vector2D vector2D)
@@ -119,12 +124,12 @@ namespace SAM.Geometry.Spatial
                 return null;
 
             Vector3D axisX = plane.AxisX;
-            Vector3D axisY = plane.AxisY;
+            Vector3D axisY = plane.InternalAxisY;
 
-            Vector3D u = new Vector3D(axisY.X * vector2D.Y, axisY.Y * vector2D.Y, axisY.Z * vector2D.Y);
-            Vector3D v = new Vector3D(axisX.X * vector2D.X, axisX.Y * vector2D.X, axisX.Z * vector2D.X);
+            double vx = vector2D.X;
+            double vy = vector2D.Y;
 
-            return new Vector3D(u.X + v.X, u.Y + v.Y, u.Z + v.Z);
+            return new Vector3D(axisX.X * vx + axisY.X * vy, axisX.Y * vx + axisY.Y * vy, axisX.Z * vx + axisY.Z * vy);
         }
 
         public static Polygon3D Convert(this Plane plane, Polygon2D polygon2D)
@@ -326,9 +331,32 @@ namespace SAM.Geometry.Spatial
             if (plane == null || point3Ds == null)
                 return null;
 
+            Vector3D axisX = plane.AxisX;
+            Vector3D axisY = plane.InternalAxisY;
+            Point3D origin = plane.InternalOrigin;
+
+            if (axisX == null || axisY == null || origin == null)
+                return null;
+
+            double ox = origin.X, oy = origin.Y, oz = origin.Z;
+            double xx = axisX.X, xy = axisX.Y, xz = axisX.Z;
+            double yx = axisY.X, yy = axisY.Y, yz = axisY.Z;
+
             List<Point2D> point2Ds = new List<Point2D>();
             foreach (Point3D point3D in point3Ds)
-                point2Ds.Add(Convert(plane, point3D));
+            {
+                if (point3D == null)
+                {
+                    point2Ds.Add(null);
+                    continue;
+                }
+
+                double dx = point3D.X - ox;
+                double dy = point3D.Y - oy;
+                double dz = point3D.Z - oz;
+
+                point2Ds.Add(new Point2D(xx * dx + xy * dy + xz * dz, yx * dx + yy * dy + yz * dz));
+            }
 
             return point2Ds;
         }
@@ -338,9 +366,31 @@ namespace SAM.Geometry.Spatial
             if (plane == null || point2Ds == null)
                 return null;
 
+            Vector3D axisX = plane.AxisX;
+            Vector3D axisY = plane.InternalAxisY;
+            Point3D origin = plane.InternalOrigin;
+
+            if (axisX == null || axisY == null || origin == null)
+                return null;
+
+            double ox = origin.X, oy = origin.Y, oz = origin.Z;
+            double xx = axisX.X, xy = axisX.Y, xz = axisX.Z;
+            double yx = axisY.X, yy = axisY.Y, yz = axisY.Z;
+
             List<Point3D> point3Ds = new List<Point3D>();
             foreach (Point2D point2D in point2Ds)
-                point3Ds.Add(Convert(plane, point2D));
+            {
+                if (point2D == null)
+                {
+                    point3Ds.Add(null);
+                    continue;
+                }
+
+                double px = point2D.X;
+                double py = point2D.Y;
+
+                point3Ds.Add(new Point3D(ox + xx * px + yx * py, oy + xy * px + yy * py, oz + xz * px + yz * py));
+            }
 
             return point3Ds;
         }

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Horizontal.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Horizontal.cs
@@ -10,7 +10,7 @@ namespace SAM.Geometry.Spatial
             if (plane == null)
                 return false;
 
-            return System.Math.Abs(System.Math.Abs(plane.Normal.DotProduct(Plane.WorldXY.AxisZ)) - 1) < tolerance;
+            return System.Math.Abs(System.Math.Abs(plane.C) - 1.0) < tolerance;
         }
 
         public static bool Horizontal(this IClosedPlanar3D closedPlanar3D, double tolerance = Core.Tolerance.Distance)

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/IsValid.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/IsValid.cs
@@ -53,17 +53,17 @@ namespace SAM.Geometry.Spatial
                 return false;
             }
 
-            if (!IsValid(plane.Origin))
+            if (!IsValid(plane.InternalOrigin))
             {
                 return false;
             }
 
-            if (!IsValid(plane.Normal))
+            if (!IsValid(plane.InternalNormal))
             {
                 return false;
             }
 
-            if (!IsValid(plane.AxisY))
+            if (!IsValid(plane.InternalAxisY))
             {
                 return false;
             }

--- a/SAM/SAM.Geometry/Geometry/Spatial/Query/Project.cs
+++ b/SAM/SAM.Geometry/Geometry/Spatial/Query/Project.cs
@@ -12,12 +12,12 @@ namespace SAM.Geometry.Spatial
             if (plane == null || vector3D == null)
                 return null;
 
-            Vector3D normal = plane.Normal;
+            Vector3D normal = plane.InternalNormal;
+            if (normal == null)
+                return null;
 
-            return vector3D - vector3D.DotProduct(normal) * normal;
-
-            //double factor = vector3D.DotProduct(normal) - K;
-            //return new Vector3D(vector3D.X - (normal.X * factor), vector3D.Y - (normal.Y * factor), vector3D.Z - (normal.Z * factor));
+            double dot = vector3D.X * normal.X + vector3D.Y * normal.Y + vector3D.Z * normal.Z;
+            return new Vector3D(vector3D.X - dot * normal.X, vector3D.Y - dot * normal.Y, vector3D.Z - dot * normal.Z);
         }
 
         public static Point3D Project(this Plane plane, Point3D point3D)

--- a/SAM/SAM.Tests/PlaneTests.cs
+++ b/SAM/SAM.Tests/PlaneTests.cs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2020–2026 Michal Dengusiak & Jakub Ziolkowski and contributors
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using SAM.Geometry.Planar;
+using SAM.Geometry.Spatial;
+using Xunit;
+
+namespace SAM.Tests
+{
+    public class PlaneTests
+    {
+        [Fact]
+        public void DefaultConstructor_InitializesWorldXYDefaults()
+        {
+            Plane plane = new Plane();
+
+            Assert.Equal(0, plane.Origin.X);
+            Assert.Equal(0, plane.Origin.Y);
+            Assert.Equal(0, plane.Origin.Z);
+
+            Assert.Equal(0, plane.Normal.X);
+            Assert.Equal(0, plane.Normal.Y);
+            Assert.Equal(1, plane.Normal.Z);
+
+            Assert.Equal(1, plane.AxisX.X);
+            Assert.Equal(0, plane.AxisX.Y);
+            Assert.Equal(0, plane.AxisX.Z);
+
+            Assert.Equal(0, plane.AxisY.X);
+            Assert.Equal(1, plane.AxisY.Y);
+            Assert.Equal(0, plane.AxisY.Z);
+        }
+
+        [Fact]
+        public void OriginAndNormalConstructor_CalculatesAxes()
+        {
+            Point3D origin = new Point3D(10, 20, 30);
+            Vector3D normal = new Vector3D(0, 0, 5); // non-unit normal should be normalized
+
+            Plane plane = new Plane(origin, normal);
+
+            Assert.Equal(10, plane.Origin.X);
+            Assert.Equal(20, plane.Origin.Y);
+            Assert.Equal(30, plane.Origin.Z);
+
+            Assert.Equal(0, plane.Normal.X);
+            Assert.Equal(0, plane.Normal.Y);
+            Assert.Equal(1, plane.Normal.Z);
+        }
+
+        [Fact]
+        public void ThreePointsConstructor_CalculatesPlane()
+        {
+            Point3D p1 = new Point3D(0, 0, 5);
+            Point3D p2 = new Point3D(10, 0, 5);
+            Point3D p3 = new Point3D(0, 10, 5);
+
+            Plane plane = new Plane(p1, p2, p3);
+
+            Assert.True(plane.On(p1));
+            Assert.True(plane.On(p2));
+            Assert.True(plane.On(p3));
+            Assert.Equal(0, plane.Normal.X, 6);
+            Assert.Equal(0, plane.Normal.Y, 6);
+            Assert.Equal(100, plane.Normal.Z, 6);
+            Assert.Equal(1, plane.Normal.Unit.Z, 6);
+        }
+
+        [Fact]
+        public void OriginAxisXAxisYConstructor_InitializesPlane()
+        {
+            Point3D origin = new Point3D(1, 2, 3);
+            Vector3D axisX = new Vector3D(1, 0, 0);
+            Vector3D axisY = new Vector3D(0, 1, 0);
+
+            Plane plane = new Plane(origin, axisX, axisY);
+
+            Assert.Equal(1, plane.Origin.X);
+            Assert.Equal(2, plane.Origin.Y);
+            Assert.Equal(3, plane.Origin.Z);
+            Assert.Equal(0, plane.Normal.X);
+            Assert.Equal(0, plane.Normal.Y);
+            Assert.Equal(1, plane.Normal.Z);
+        }
+
+        [Fact]
+        public void WorldStaticProperties_CorrectOrientation()
+        {
+            Plane xy = Plane.WorldXY;
+            Plane yz = Plane.WorldYZ;
+            Plane xz = Plane.WorldXZ;
+
+            Assert.Equal(new Vector3D(0, 0, 1), xy.Normal);
+            Assert.Equal(new Vector3D(1, 0, 0), yz.Normal);
+            Assert.Equal(new Vector3D(0, 1, 0), xz.Normal);
+        }
+
+        [Fact]
+        public void PlaneEquationFactors_A_B_C_D_K()
+        {
+            Point3D origin = new Point3D(2, 3, 4);
+            Vector3D normal = new Vector3D(0, 0, 1);
+            Plane plane = new Plane(origin, normal);
+
+            Assert.Equal(0, plane.A);
+            Assert.Equal(0, plane.B);
+            Assert.Equal(1, plane.C);
+            Assert.Equal(-4, plane.D);
+            Assert.Equal(4, plane.K);
+
+            // A*x + B*y + C*z + D = 0 for origin
+            double val = plane.A * origin.X + plane.B * origin.Y + plane.C * origin.Z + plane.D;
+            Assert.Equal(0, val, 6);
+        }
+
+        [Fact]
+        public void DistanceToPoint_CalculatesCorrectDistances()
+        {
+            Plane plane = new Plane(new Point3D(0, 0, 10), Vector3D.WorldZ);
+
+            Point3D pointOn = new Point3D(5, 5, 10);
+            Point3D pointAbove = new Point3D(5, 5, 15);
+            Point3D pointBelow = new Point3D(5, 5, 3);
+
+            Assert.Equal(0, plane.Distance(pointOn), 6);
+            Assert.Equal(5, plane.Distance(pointAbove), 6);
+            Assert.Equal(7, plane.Distance(pointBelow), 6);
+        }
+
+        [Fact]
+        public void DistanceToSegment_HandlesIntersectionAndOffset()
+        {
+            Plane plane = new Plane(new Point3D(0, 0, 5), Vector3D.WorldZ);
+
+            // Segment crossing plane Z=5
+            Segment3D intersecting = new Segment3D(new Point3D(0, 0, 0), new Point3D(0, 0, 10));
+            Assert.Equal(0, plane.Distance(intersecting));
+
+            // Segment strictly above plane Z=5
+            Segment3D above = new Segment3D(new Point3D(0, 0, 7), new Point3D(0, 0, 12));
+            Assert.Equal(2, plane.Distance(above), 6);
+        }
+
+        [Fact]
+        public void DistanceToPlane_ParallelVsIntersecting()
+        {
+            Plane p1 = new Plane(new Point3D(0, 0, 0), Vector3D.WorldZ);
+            Plane p2 = new Plane(new Point3D(0, 0, 10), Vector3D.WorldZ);
+            Plane p3 = new Plane(new Point3D(0, 0, 0), Vector3D.WorldX);
+
+            Assert.Equal(10, p1.Distance(p2), 6);
+            Assert.Equal(0, p1.Distance(p3), 6); // non-parallel planes intersect -> distance 0
+        }
+
+        [Fact]
+        public void ClosestPointAndOn()
+        {
+            Plane plane = new Plane(new Point3D(0, 0, 5), Vector3D.WorldZ);
+            Point3D p = new Point3D(3, 4, 12);
+
+            Point3D closest = plane.Closest(p);
+
+            Assert.Equal(3, closest.X);
+            Assert.Equal(4, closest.Y);
+            Assert.Equal(5, closest.Z);
+            Assert.True(plane.On(closest));
+            Assert.False(plane.On(p));
+        }
+
+        [Fact]
+        public void ProjectVector_ProjectsOntoPlane()
+        {
+            Plane plane = new Plane(Point3D.Zero, Vector3D.WorldZ);
+            Vector3D v = new Vector3D(3, 4, 5);
+
+            Vector3D projected = plane.Project(v);
+
+            Assert.Equal(3, projected.X);
+            Assert.Equal(4, projected.Y);
+            Assert.Equal(0, projected.Z);
+        }
+
+        [Fact]
+        public void Transformation_FlipZ_FlipX_Move_Reverse()
+        {
+            Plane plane = new Plane(new Point3D(1, 2, 3), Vector3D.WorldZ);
+
+            plane.Move(new Vector3D(5, 5, 5));
+            Assert.Equal(6, plane.Origin.X);
+            Assert.Equal(7, plane.Origin.Y);
+            Assert.Equal(8, plane.Origin.Z);
+
+            plane.FlipZ(flipX: true);
+            Assert.Equal(new Vector3D(0, 0, -1), plane.Normal);
+
+            Plane plane2 = new Plane(new Point3D(0, 0, 0), Vector3D.WorldZ);
+            plane2.Reverse();
+            Assert.Equal(new Vector3D(0, 0, -1), plane2.Normal);
+            Assert.Equal(new Vector3D(0, -1, 0), plane2.AxisY);
+        }
+
+        [Fact]
+        public void EqualityAndHashCode_WorkAsExpected()
+        {
+            Plane plane1 = new Plane(new Point3D(1, 2, 3), Vector3D.WorldZ);
+            Plane plane2 = new Plane(new Point3D(1, 2, 3), Vector3D.WorldZ);
+            Plane plane3 = new Plane(new Point3D(1, 2, 4), Vector3D.WorldZ);
+
+            Assert.True(plane1 == plane2);
+            Assert.True(plane1.Equals(plane2));
+            Assert.False(plane1 == plane3);
+            Assert.True(plane1 != plane3);
+            Assert.Equal(plane1.GetHashCode(), plane2.GetHashCode());
+        }
+
+        [Fact]
+        public void SpatialQueryExtensions_Above_Below_Between_Horizontal_Azimuth_IsValid()
+        {
+            Plane plane = new Plane(new Point3D(0, 0, 5), Vector3D.WorldZ);
+            Point3D pointAbove = new Point3D(0, 0, 10);
+            Point3D pointBelow = new Point3D(0, 0, 0);
+
+            Assert.True(plane.Above(pointAbove));
+            Assert.False(plane.Above(pointBelow));
+
+            Assert.True(plane.Below(pointBelow));
+            Assert.False(plane.Below(pointAbove));
+
+            Plane planeLow = new Plane(new Point3D(0, 0, 0), Vector3D.WorldZ);
+            Plane planeHigh = new Plane(new Point3D(0, 0, 10), Vector3D.WorldZ);
+            Assert.True(planeLow.Between(planeHigh, plane.Origin));
+
+            Assert.True(plane.Horizontal());
+            Assert.True(plane.IsValid());
+
+            Plane verticalPlane = new Plane(Point3D.Zero, Vector3D.WorldX);
+            Assert.False(verticalPlane.Horizontal());
+            Assert.Equal(0, plane.Azimuth(Vector3D.WorldY));
+        }
+
+        [Fact]
+        public void SpatialCreateExtensions_FactoryMethods()
+        {
+            Plane pElev = SAM.Geometry.Spatial.Create.Plane(12.5);
+            Assert.Equal(12.5, pElev.Origin.Z);
+            Assert.Equal(Vector3D.WorldZ, pElev.Normal);
+
+            Plane pDim0 = SAM.Geometry.Spatial.Create.Plane(3.0, 0);
+            Assert.Equal(3.0, pDim0.Origin.X);
+            Assert.Equal(Vector3D.WorldX, pDim0.Normal);
+
+            Plane pDim1 = SAM.Geometry.Spatial.Create.Plane(4.0, 1);
+            Assert.Equal(4.0, pDim1.Origin.Y);
+            Assert.Equal(Vector3D.WorldY, pDim1.Normal);
+
+            Plane pDim2 = SAM.Geometry.Spatial.Create.Plane(5.0, 2);
+            Assert.Equal(5.0, pDim2.Origin.Z);
+            Assert.Equal(Vector3D.WorldZ, pDim2.Normal);
+
+            Point3D p1 = new Point3D(0, 0, 0);
+            Point3D p2 = new Point3D(3, 0, 0);
+            Point3D p3 = new Point3D(0, 3, 0);
+            Plane p3Points = SAM.Geometry.Spatial.Create.Plane(p1, p2, p3);
+            Assert.NotNull(p3Points);
+            Assert.Equal(1, p3Points.Origin.X);
+            Assert.Equal(1, p3Points.Origin.Y);
+            Assert.Equal(0, p3Points.Origin.Z);
+        }
+
+        [Fact]
+        public void Point2D_Point3D_Conversion_RoundTrip()
+        {
+            Plane plane = new Plane(new Point3D(10, 20, 30), Vector3D.WorldZ);
+
+            Point2D p2d = new Point2D(5, -7);
+            Point3D p3d = plane.Convert(p2d);
+
+            Assert.Equal(15, p3d.X);
+            Assert.Equal(13, p3d.Y);
+            Assert.Equal(30, p3d.Z);
+
+            Point2D p2dRoundTrip = plane.Convert(p3d);
+            Assert.Equal(p2d.X, p2dRoundTrip.X, 6);
+            Assert.Equal(p2d.Y, p2dRoundTrip.Y, 6);
+        }
+
+        [Fact]
+        public void Vector2D_Vector3D_Conversion_RoundTrip()
+        {
+            Plane plane = new Plane(new Point3D(0, 0, 0), Vector3D.WorldZ);
+
+            Vector2D v2d = new Vector2D(3, 4);
+            Vector3D v3d = plane.Convert(v2d);
+
+            Assert.Equal(3, v3d.X);
+            Assert.Equal(4, v3d.Y);
+            Assert.Equal(0, v3d.Z);
+
+            Vector2D v2dRoundTrip = plane.Convert(v3d);
+            Assert.Equal(v2d.X, v2dRoundTrip.X, 6);
+            Assert.Equal(v2d.Y, v2dRoundTrip.Y, 6);
+        }
+
+        [Fact]
+        public void BatchPointConversion_RoundTrip()
+        {
+            Plane plane = new Plane(new Point3D(1, 2, 3), Vector3D.WorldZ);
+            List<Point3D> points3D = new List<Point3D>
+            {
+                new Point3D(1, 2, 3),
+                new Point3D(5, 7, 3),
+                new Point3D(-2, 10, 3)
+            };
+
+            List<Point2D> points2D = plane.Convert(points3D);
+            Assert.Equal(3, points2D.Count);
+
+            List<Point3D> points3DRoundTrip = plane.Convert(points2D);
+            Assert.Equal(3, points3DRoundTrip.Count);
+
+            for (int i = 0; i < points3D.Count; i++)
+            {
+                Assert.Equal(points3D[i].X, points3DRoundTrip[i].X, 6);
+                Assert.Equal(points3D[i].Y, points3DRoundTrip[i].Y, 6);
+                Assert.Equal(points3D[i].Z, points3DRoundTrip[i].Z, 6);
+            }
+        }
+
+        [Fact]
+        public void JsonSerialization_RoundTrip()
+        {
+            Plane plane = new Plane(new Point3D(1.5, 2.5, 3.5), new Vector3D(0, 0, 1));
+            JsonObject jsonObject = plane.ToJsonObject();
+            Assert.NotNull(jsonObject);
+
+            Plane roundTripped = new Plane(jsonObject);
+            Assert.Equal(plane.Origin, roundTripped.Origin);
+            Assert.Equal(plane.Normal, roundTripped.Normal);
+            Assert.Equal(plane.AxisY, roundTripped.AxisY);
+        }
+    }
+}


### PR DESCRIPTION
# Plane Optimization and Unit Tests Summary

## Overview
Deep optimization of the `Plane` class in `SAM.Geometry` and its extension methods, alongside adding a comprehensive xUnit test suite in `SAM.Tests`.

---

## Key Optimizations Made

### 1. `Plane.cs` Core Methods & Properties
- **`Distance(Point3D)`**: Replaced `Closest(point3D).Distance(point3D)` (which allocated temporary `Point3D` objects and computed `Math.Sqrt`) with an analytical point-to-plane distance formula `Math.Abs(normal.X * (p.X - o.X) + normal.Y * (p.Y - o.Y) + normal.Z * (p.Z - o.Z))`. Result: **Zero heap allocations**.
- **`Distance(Segment3D)`**: Replaced `PlanarIntersectionResult` creation with analytical signed endpoint distance calculations. Result: **Zero heap allocations**.
- **`K` & `D` Equation Factors**: Replaced `normal.DotProduct(origin.ToVector3D())` (which created temporary `Vector3D` objects) with direct scalar products `normal.X * origin.X + normal.Y * origin.Y + normal.Z * origin.Z`.
- **`Closest(Point3D)`**: Replaced `point3D.ToVector3D()` allocation with inline scalar projection calculation.
- **`GetMoved(Vector3D)`**: Replaced polymorphic method calls with direct origin point translation `new Point3D(origin.X + v.X, origin.Y + v.Y, origin.Z + v.Z)`.
- **`GetHashCode()`**: Replaced `Tuple.Create(...)` heap allocations with non-allocating `HashCode.Combine` calculation.
- **Internal Accessors**: Added `InternalNormal`, `InternalOrigin`, and `InternalAxisY` properties so extension methods in `SAM.Geometry` can bypass defensive property cloning (`new Vector3D(normal)`, `new Point3D(origin)`).

### 2. Spatial Extension Methods
- **`Horizontal.cs`**: Replaced multi-object allocation chain `plane.Normal.DotProduct(Plane.WorldXY.AxisZ)` with direct component check `Math.Abs(Math.Abs(plane.C) - 1.0) < tolerance`.
- **`Project.cs`**: Optimized `Project(Plane, Vector3D)` vector projection from 4 allocations down to 1 (`new Vector3D`).
- **`Convert.cs`**:
  - Reduced individual 2D/3D Point and Vector conversions from 5-6 object allocations down to 1 (`new Point2D`/`Point3D`).
  - Cached plane basis vectors (`axisX`, `axisY`, `origin`) outside collection loops in `Convert(Plane, IEnumerable<Point3D>)` and `Convert(Plane, IEnumerable<Point2D>)`, eliminating per-point intermediate allocations completely.
- **`Above.cs` & `Below.cs`**: Switched to internal properties to eliminate defensive vector/point clones.
- **`Azimuth.cs`**: Inlined XY projection vectors (`new Vector3D(x, y, 0)`), avoiding repeated `Plane.WorldXY` instantiations.
- **`IsValid.cs`**: Switched to internal properties.
- **`Create/Plane.cs`**: Optimized 3-point centroid calculation and direct plane instantiations for elevation and dimension planes without intermediate plane transformations.

---

## Unit Testing & Verification

- **New Test Suite**: Created `PlaneTests.cs` in `SAM.Tests` with 19 comprehensive tests covering:
  - Default, copy, point-based, normal-based, and axis-based constructors.
  - Plane equation factors (`A, B, C, D, K`).
  - Distance calculations (points, segments, parallel/intersecting planes).
  - Point operations (`On`, `Closest`, `Project`).
  - Transformations & flips (`FlipZ`, `FlipX`, `Move`, `Reverse`).
  - Equality operators (`==`, `!=`), `Equals`, `GetHashCode`.
  - Spatial queries (`Above`, `Below`, `Between`, `Horizontal`, `Azimuth`, `IsValid`).
  - Factory methods in `Create.Plane(...)`.
  - 2D <-> 3D Point and Vector conversions (individual & batch).
  - JSON serialization round-tripping.
- **Verification Results**: Ran `dotnet test SAM/SAM.Tests/SAM.Tests.csproj` - all **300 unit tests** passed cleanly with zero failures.
